### PR TITLE
Basic listing of courses in the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -194,6 +194,9 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("admin.registration.new", "/admin/registration")
     config.add_route("admin.registration.suggest_urls", "/admin/registration/urls")
 
+    config.add_route("admin.courses", "/admin/courses")
+    config.add_route("admin.course", "/admin/course/{id_}")
+
     config.add_route("admin.email", "/admin/email")
     config.add_route(
         "admin.email.preview.instructor_email_digest",

--- a/lms/services/grouping/factory.py
+++ b/lms/services/grouping/factory.py
@@ -4,6 +4,8 @@ from lms.services.grouping.service import GroupingService
 def service_factory(_context, request):
     return GroupingService(
         db=request.db,
-        application_instance=request.lti_user.application_instance,
+        application_instance=(
+            request.lti_user.application_instance if request.lti_user else None
+        ),
         plugin=request.product.plugin.grouping,
     )

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -71,7 +71,7 @@ class OrganizationService:
         # SQLAlchemy, and should be fast to access.
         hierarchy = (
             self._db_session.query(Organization).filter(
-                Organization.id.in_(self._get_hierarchy_ids(id_, include_parents=True))
+                Organization.id.in_(self.get_hierarchy_ids(id_, include_parents=True))
             )
             # Order by parent id, this will cause the root (if any) to be last.
             # The default ascending order puts NULL's last
@@ -246,7 +246,7 @@ class OrganizationService:
     ):
         # Organizations that are children of the current one.
         # It includes the current org ID.
-        organization_children = self._get_hierarchy_ids(
+        organization_children = self.get_hierarchy_ids(
             organization.id, include_parents=False
         )
         # All the groups that can hold annotations (courses and segments) from this org
@@ -340,7 +340,7 @@ class OrganizationService:
             )
 
         # Get a list including our self and all are children etc.
-        if parent.id in self._get_hierarchy_ids(organization.id, include_parents=False):
+        if parent.id in self.get_hierarchy_ids(organization.id, include_parents=False):
             raise InvalidOrganizationParent(
                 f"Cannot use '{parent_public_id}' as a parent as it a "
                 "child of this organization"
@@ -349,7 +349,7 @@ class OrganizationService:
         organization.parent = parent
         organization.parent_id = parent.id
 
-    def _get_hierarchy_ids(self, id_, include_parents=False) -> list[int]:
+    def get_hierarchy_ids(self, id_, include_parents=False) -> list[int]:
         """
         Get an organization and it's children's ids order not guaranteed.
 

--- a/lms/templates/admin/base.html.jinja2
+++ b/lms/templates/admin/base.html.jinja2
@@ -72,6 +72,8 @@
                            href="{{ request.route_url("admin.registrations") }}">LTI Registrations</a>
                         <a class="navbar-item"
                            href="{{ request.route_url("admin.organizations") }}">Organizations</a>
+                        <a class="navbar-item"
+                           href="{{ request.route_url("admin.courses") }}">Courses</a>
                         <a class="navbar-item" href="{{ request.route_url("admin.email") }}">Email</a>
                         <div class="navbar-end">
                             <div class="navbar-item">

--- a/lms/templates/admin/course/search.html.jinja2
+++ b/lms/templates/admin/course/search.html.jinja2
@@ -1,0 +1,53 @@
+{% import "lms:templates/admin/macros.html.jinja2" as macros %}
+{% extends "lms:templates/admin/base.html.jinja2" %}
+{% block header %}Courses{% endblock %}
+{% block content %}
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Find courses</legend>
+        <form method="POST" action="{{ request.route_url("admin.courses") }}">
+        <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+        {{ macros.form_text_field(request, "ID", "id") }}
+        {{ macros.form_text_field(request, "Context ID", "context_id") }}
+        {{ macros.form_text_field(request, "H ID", "h_id") }}
+        {{ macros.form_text_field(request, "Organization ID", "org_public_id") }}
+        {{ macros.form_text_field(request, "Name", "name") }}
+        {% call macros.field_body(label="") %}
+        <input type="submit" class="button is-info" value="Search" />
+        {% endcall %}
+        </form>
+    </fieldset>
+    {% if courses is defined %}
+        <fieldset class="box mt-6">
+            {% if courses %}
+                <legend class="label has-text-centered">Results</legend>
+                <div class="container">
+                    <div class="table-container">
+                        <table class="table is-fullwidth">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    <th>Context ID</th>
+                                    <th>Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for course in courses %}
+                                    <tr>
+                                        <td>
+                                            <a class="button"
+                                               href="{{ request.route_url('admin.course', id_=course.id) }}">View</a>
+                                        </td>
+                                        <td>{{ course.lms_id }}</td>
+                                        <td>{{ course.name }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% else %}
+                <legend class="label has-text-centered">No results found</legend>
+            {% endif %}
+        </fieldset>
+    {% endif %}
+{% endblock %}

--- a/lms/templates/admin/course/show.html.jinja2
+++ b/lms/templates/admin/course/show.html.jinja2
@@ -1,0 +1,23 @@
+{% import "lms:templates/admin/macros.html.jinja2" as macros %}
+{% extends "lms:templates/admin/base.html.jinja2" %}
+{% block header %}Course: {{ course.lms_name }}{% endblock %}
+{% block content %}
+<div>
+    <fieldset>
+        <legend class="label has-text-centered">Course</legend>
+            {{ macros.disabled_text_field("ID", course.id) }}
+            {{ macros.disabled_text_field("Name", course.name) }}
+            {{ macros.disabled_text_field("H ID", course.authority_provided_id) }}
+            {{ macros.created_updated_fields(course) }}
+    </fieldset>
+    <fieldset class="box mt-6">
+      <legend class="label has-text-centered">Application Instance</legend>
+      {{ macros.instance_preview(request, course.application_instance) }}
+    </fieldset>
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Organization</legend>
+        {{ macros.organization_preview(request, course.application_instance.organization) }}
+    </fieldset>
+
+</div>
+{% endblock %}

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -1,0 +1,88 @@
+from marshmallow import validate
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.view import view_config, view_defaults
+from webargs import fields
+
+from lms.models import Course
+from lms.models.public_id import InvalidPublicId
+from lms.security import Permissions
+from lms.services import OrganizationService
+from lms.validation._base import PyramidRequestSchema
+from lms.views.admin import flash_validation
+from lms.views.admin._schemas import EmptyStringInt
+
+
+class SearchCourseSchema(PyramidRequestSchema):
+    location = "form"
+
+    # Max value for postgres `integer` type
+    id = EmptyStringInt(required=False, validate=validate.Range(max=2147483647))
+    name = fields.Str(required=False)
+    context_id = fields.Str(required=False)
+    h_id = fields.Str(required=False)
+    org_public_id = fields.Str(required=False)
+
+
+@view_defaults(request_method="GET", permission=Permissions.ADMIN)
+class AdminCourseViews:
+    def __init__(self, request) -> None:
+        self.request = request
+        self.course_service = request.find_service(name="course")
+        self.organization_service: OrganizationService = request.find_service(
+            OrganizationService
+        )
+
+    @view_config(
+        route_name="admin.courses",
+        request_method="GET",
+        renderer="lms:templates/admin/course/search.html.jinja2",
+        permission=Permissions.STAFF,
+    )
+    def courses(self):  # pragma: no cover
+        return {}
+
+    @view_config(
+        route_name="admin.course",
+        request_method="GET",
+        renderer="lms:templates/admin/course/show.html.jinja2",
+        permission=Permissions.STAFF,
+    )
+    def show(self):
+        course_id = self.request.matchdict["id_"]
+        course = self._get_course_or_404(course_id)
+
+        return {"course": course}
+
+    @view_config(
+        route_name="admin.courses",
+        request_method="POST",
+        renderer="lms:templates/admin/course/search.html.jinja2",
+        permission=Permissions.STAFF,
+    )
+    def search(self):
+        if flash_validation(self.request, SearchCourseSchema):
+            return {}
+
+        organization = None
+        if org_public_id := self.request.params.get("org_public_id", "").strip():
+            try:
+                organization = self.organization_service.get_by_public_id(org_public_id)
+            except InvalidPublicId as err:
+                self.request.session.flash(str(err), "errors")
+                return {}
+
+        courses = self.course_service.search(
+            id_=self.request.params.get("id", "").strip(),
+            name=self.request.params.get("name", "").strip(),
+            context_id=self.request.params.get("context_id", "").strip(),
+            h_id=self.request.params.get("h_id", "").strip(),
+            organization=organization,
+        )
+
+        return {"courses": courses}
+
+    def _get_course_or_404(self, id_) -> Course:
+        if course := self.course_service.search(id_=id_):
+            return course[0]
+
+        raise HTTPNotFound()

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -1,0 +1,88 @@
+from unittest.mock import sentinel
+
+import pytest
+from pyramid.httpexceptions import HTTPNotFound
+
+from lms.models.public_id import InvalidPublicId
+from lms.views.admin.course import AdminCourseViews
+
+
+@pytest.mark.usefixtures("course_service", "organization_service")
+class TestAdminCouseViews:
+    def test_show(self, pyramid_request, course_service, views):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+
+        response = views.show()
+
+        course_service.search.assert_called_once_with(id_=sentinel.id_)
+
+        assert response == {
+            "course": course_service.search.return_value[0],
+        }
+
+    def test_show_not_found(self, pyramid_request, course_service, views):
+        pyramid_request.matchdict["id_"] = sentinel.id_
+        course_service.search.return_value = []
+
+        with pytest.raises(HTTPNotFound):
+            views.show()
+
+    def test_search(self, pyramid_request, course_service, views):
+        pyramid_request.params["context_id"] = " PUBLIC_ID "
+        pyramid_request.params["name"] = " NAME "
+        pyramid_request.params["id"] = " 100 "
+        pyramid_request.params["h_id"] = " H_ID "
+
+        result = views.search()
+
+        course_service.search.assert_called_once_with(
+            id_="100",
+            name="NAME",
+            context_id="PUBLIC_ID",
+            h_id="H_ID",
+            organization=None,
+        )
+        assert result == {"courses": course_service.search.return_value}
+
+    def test_search_by_public_id(
+        self, pyramid_request, views, organization_service, course_service
+    ):
+        pyramid_request.params["org_public_id"] = " PUBLIC_ID "
+        organization_service.get_by_public_id.return_value = sentinel.org
+
+        views.search()
+
+        course_service.search.assert_called_once_with(
+            id_="",
+            name="",
+            context_id="DUMMY-CONTEXT-ID",
+            h_id="",
+            organization=sentinel.org,
+        )
+
+    def test_search_invalid_public_id(
+        self, pyramid_request, views, organization_service
+    ):
+        pyramid_request.params["org_public_id"] = " PUBLIC_ID "
+        organization_service.get_by_public_id.side_effect = InvalidPublicId
+
+        views.search()
+
+        assert pyramid_request.session.peek_flash("errors")
+
+    def test_search_invalid(self, pyramid_request, views):
+        pyramid_request.params["id"] = "not a number"
+
+        assert not views.search()
+        assert pyramid_request.session.peek_flash
+
+    def test_blank_search(self, views, course_service):
+        views.search()
+
+        course_service.search.assert_called_once_with(
+            id_="", name="", context_id="DUMMY-CONTEXT-ID", h_id="", organization=None
+        )
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return AdminCourseViews(pyramid_request)


### PR DESCRIPTION
Extracted from the PoC, just the courses part.

I reckon this useful regardless of any usage for the analysis project.

Lately I've been writing the query to search by organization by hand a few times, this will immediately help with that.


# Testing 

- Go ahead to http://localhost:8001/admin/courses and click around.