### PR TITLE
Moodle course copy fixes

### DIFF
--- a/lms/product/moodle/__init__.py
+++ b/lms/product/moodle/__init__.py
@@ -1,5 +1,6 @@
 from lms.product.moodle._plugin.course_copy import MoodleCourseCopyPlugin
 from lms.product.moodle._plugin.grouping import MoodleGroupingPlugin
+from lms.product.moodle._plugin.misc import MoodleMiscPlugin
 from lms.product.moodle.product import Moodle
 
 
@@ -11,3 +12,4 @@ def includeme(config):  # pragma: nocover
     config.register_service_factory(
         MoodleCourseCopyPlugin.factory, iface=MoodleCourseCopyPlugin
     )
+    config.register_service_factory(MoodleMiscPlugin.factory, iface=MoodleMiscPlugin)

--- a/lms/product/moodle/__init__.py
+++ b/lms/product/moodle/__init__.py
@@ -1,3 +1,4 @@
+from lms.product.moodle._plugin.course_copy import MoodleCourseCopyPlugin
 from lms.product.moodle._plugin.grouping import MoodleGroupingPlugin
 from lms.product.moodle.product import Moodle
 
@@ -6,4 +7,7 @@ def includeme(config):  # pragma: nocover
     """Register all of our plugins."""
     config.register_service_factory(
         MoodleGroupingPlugin.factory, iface=MoodleGroupingPlugin
+    )
+    config.register_service_factory(
+        MoodleCourseCopyPlugin.factory, iface=MoodleCourseCopyPlugin
     )

--- a/lms/product/moodle/_plugin/course_copy.py
+++ b/lms/product/moodle/_plugin/course_copy.py
@@ -8,10 +8,17 @@ class MoodleCourseCopyPlugin:
     def __init__(
         self,
         api: MoodleAPIClient,
+        files_helper: CourseCopyFilesHelper,
         groups_helper: CourseCopyGroupsHelper,
     ):
         self._api = api
         self._groups_helper = groups_helper
+        self._files_helper = files_helper
+
+    def find_matching_file_in_course(self, original_file_id, new_course_id):
+        return self._files_helper.find_matching_file_in_course(
+            self._api.list_files, self.file_type, original_file_id, new_course_id
+        )
 
     def find_matching_group_set_in_course(self, course, group_set_id):
         return self._groups_helper.find_matching_group_set_in_course(
@@ -22,5 +29,6 @@ class MoodleCourseCopyPlugin:
     def factory(cls, _context, request):
         return cls(
             request.find_service(MoodleAPIClient),
+            files_helper=request.find_service(CourseCopyFilesHelper),
             groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/product/moodle/_plugin/course_copy.py
+++ b/lms/product/moodle/_plugin/course_copy.py
@@ -1,0 +1,26 @@
+from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyGroupsHelper
+from lms.services.moodle import MoodleAPIClient
+
+
+class MoodleCourseCopyPlugin:
+    file_type = "moodle_file"
+
+    def __init__(
+        self,
+        api: MoodleAPIClient,
+        groups_helper: CourseCopyGroupsHelper,
+    ):
+        self._api = api
+        self._groups_helper = groups_helper
+
+    def find_matching_group_set_in_course(self, course, group_set_id):
+        return self._groups_helper.find_matching_group_set_in_course(
+            course, group_set_id
+        )
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(
+            request.find_service(MoodleAPIClient),
+            groups_helper=request.find_service(CourseCopyGroupsHelper),
+        )

--- a/lms/product/moodle/_plugin/course_copy.py
+++ b/lms/product/moodle/_plugin/course_copy.py
@@ -4,6 +4,7 @@ from lms.services.moodle import MoodleAPIClient
 
 class MoodleCourseCopyPlugin:
     file_type = "moodle_file"
+    page_type = "moodle_page"
 
     def __init__(
         self,
@@ -18,6 +19,11 @@ class MoodleCourseCopyPlugin:
     def find_matching_file_in_course(self, original_file_id, new_course_id):
         return self._files_helper.find_matching_file_in_course(
             self._api.list_files, self.file_type, original_file_id, new_course_id
+        )
+
+    def find_matching_page_in_course(self, original_page_id, new_course_id):
+        return self._files_helper.find_matching_file_in_course(
+            self._api.list_pages, self.page_type, original_page_id, new_course_id
         )
 
     def find_matching_group_set_in_course(self, course, group_set_id):

--- a/lms/product/moodle/_plugin/grouping.py
+++ b/lms/product/moodle/_plugin/grouping.py
@@ -50,9 +50,9 @@ class MoodleGroupingPlugin(GroupingPlugin):
             course.lms_id, group_set_id, grading_student_id
         )
 
-    def get_groups_for_instructor(self, _svc, _course, group_set_id):
+    def get_groups_for_instructor(self, _svc, course, group_set_id):
         try:
-            groups = self._api.group_set_groups(group_set_id)
+            groups = self._api.group_set_groups(int(course.lms_id), group_set_id)
         except ExternalRequestError as exc:
             if exc.status_code == 404:
                 raise GroupError(

--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -1,0 +1,11 @@
+from lms.product.plugin.misc import MiscPlugin
+
+
+class MoodleMiscPlugin(MiscPlugin):
+    deep_linking_prompt_for_title = False
+    # Moodle's deep linking flow it's included in the activity creating one.
+    # Removing our title prompt to avoid confusion with the one in the LMS.
+
+    @classmethod
+    def factory(cls, _context, request):  # pragma: no cover
+        return cls()

--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -3,7 +3,7 @@ from lms.product.plugin.misc import MiscPlugin
 
 class MoodleMiscPlugin(MiscPlugin):
     deep_linking_prompt_for_title = False
-    # Moodle's deep linking flow it's included in the activity creating one.
+    # Moodle's deep linking flow is included in the activity creating one.
     # Removing our title prompt to avoid confusion with the one in the LMS.
 
     @classmethod

--- a/lms/product/moodle/product.py
+++ b/lms/product/moodle/product.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from lms.product.moodle._plugin.course_copy import MoodleCourseCopyPlugin
 from lms.product.moodle._plugin.grouping import MoodleGroupingPlugin
+from lms.product.moodle._plugin.misc import MoodleMiscPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
 
@@ -10,7 +11,9 @@ class Moodle(Product):
     family: Product.Family = Product.Family.MOODLE
 
     plugin_config: PluginConfig = PluginConfig(
-        grouping=MoodleGroupingPlugin, course_copy=MoodleCourseCopyPlugin
+        grouping=MoodleGroupingPlugin,
+        course_copy=MoodleCourseCopyPlugin,
+        misc=MoodleMiscPlugin,
     )
 
     route: Routes = Routes()

--- a/lms/product/moodle/product.py
+++ b/lms/product/moodle/product.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from lms.product.moodle._plugin.course_copy import MoodleCourseCopyPlugin
 from lms.product.moodle._plugin.grouping import MoodleGroupingPlugin
 from lms.product.product import PluginConfig, Product, Routes
 
@@ -8,7 +9,9 @@ from lms.product.product import PluginConfig, Product, Routes
 class Moodle(Product):
     family: Product.Family = Product.Family.MOODLE
 
-    plugin_config: PluginConfig = PluginConfig(grouping=MoodleGroupingPlugin)
+    plugin_config: PluginConfig = PluginConfig(
+        grouping=MoodleGroupingPlugin, course_copy=MoodleCourseCopyPlugin
+    )
 
     route: Routes = Routes()
 

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -144,7 +144,7 @@ class MoodleAPIClient:
                     file_node = {
                         "type": "Page",
                         "display_name": module["name"],
-                        "lms_id": f"moodle://page/course/{course_id}/page_id/{module['id']}",
+                        "lms_id": module["id"],
                         "id": f"moodle://page/course/{course_id}/page_id/{module['id']}",
                     }
                     current_node["children"].append(file_node)

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -216,7 +216,7 @@ class MoodleAPIClient:
 
         return url + f"&wsfunction={function.value}"
 
-    def _documents_for_storage(
+    def _documents_for_storage(  # pylint:disable=too-many-arguments
         self, course_id, files, folder_type, document_type, parent_id=None
     ):
         for file in files:

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -185,7 +185,7 @@ class MoodleAPIClient:
                 "type": "File",
                 "display_name": path_components[-1],
                 "id": f"moodle://file/course/{course_id}/url/{file_data['url']}",
-                "lms_id": f"moodle://file/course/{course_id}/url/{file_data['url']}",
+                "lms_id": file_data["url"],
                 "updated_at": file_data["updated_at"],
             }
             current_node["children"].append(file_node)
@@ -200,7 +200,7 @@ class MoodleAPIClient:
     def _files_for_storage(self, course_id, files, parent_id=None):
         for file in files:
             yield {
-                "type": "moodle_file" if file["type"] == "File" else "moodle_folder",
+                "type": folder_type if file["type"] == "Folder" else document_type,
                 "course_id": course_id,
                 "lms_id": file["lms_id"],
                 "name": file["display_name"],

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -26,7 +26,7 @@ class MoodleAPIClient:
     def token(self):  # pragma: no cover
         return self._token
 
-    def group_set_groups(self, group_set_id: int) -> list[dict]:
+    def group_set_groups(self, course_id: int, group_set_id: int) -> list[dict]:
         url = self._api_url(Function.GET_GROUPINGS)
         url = f"{url}&groupingids[0]={group_set_id}&returngroups=1"
         response = self._http.post(url).json()
@@ -35,6 +35,9 @@ class MoodleAPIClient:
         return [
             {"id": g["id"], "name": g["name"], "group_set_id": group_set_id}
             for g in groups
+            # While the endpoint is not course based we filter by group on our
+            # end to avoid using groups from one course in another.
+            if g["courseid"] == course_id
         ]
 
     def groups_for_user(self, course_id, group_set_id, user_id):

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -184,8 +184,8 @@ class MoodleAPIClient:
             file_node = {
                 "type": "File",
                 "display_name": path_components[-1],
-                "id": f"moodle://file/url/{file_data['url']}",
-                "lms_id": f"moodle://file/url/{file_data['url']}",
+                "id": f"moodle://file/course/{course_id}/url/{file_data['url']}",
+                "lms_id": f"moodle://file/course/{course_id}/url/{file_data['url']}",
                 "updated_at": file_data["updated_at"],
             }
             current_node["children"].append(file_node)

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -1,12 +1,18 @@
 import re
 
 from pyramid.view import view_config
+from logging import getLogger
 
 from lms.security import Permissions
 from lms.services.moodle import MoodleAPIClient
+from lms.services.exceptions import FileNotFoundInCourse
 from lms.views import helpers
 
-DOCUMENT_URL_REGEX = re.compile(r"moodle:\/\/file\/url\/(?P<url>.*)")
+LOG = getLogger(__name__)
+
+DOCUMENT_URL_REGEX = re.compile(
+    r"moodle:\/\/file\/course\/(?P<course_id>[^\/]*)\/url\/(?P<url>.*)"
+)
 
 
 @view_config(
@@ -29,12 +35,61 @@ def list_files(_context, request):
     permission=Permissions.API,
 )
 def via_url(_context, request):
-    token = request.find_service(MoodleAPIClient).token
+    course_copy_plugin = request.product.plugin.course_copy
+
+    current_course_id = request.lti_user.lti.course_id
+    course = request.find_service(name="course").get_by_context_id(
+        current_course_id, raise_on_missing=True
+    )
 
     document_url = request.params["document_url"]
-    url = DOCUMENT_URL_REGEX.search(document_url)["url"]
+    document_course_id = DOCUMENT_URL_REGEX.search(document_url)["course_id"]
+    document_file_id = DOCUMENT_URL_REGEX.search(document_url)["url"]
+    effective_file_id = None
+    if current_course_id == document_course_id:
+        # Not in a course copy scenario, use the IDs from the document_url
+        effective_file_id = document_file_id
+        LOG.debug("Via URL for file in the same course. %s", document_url)
+
+    mapped_file_id = course.get_mapped_file_id(document_file_id)
+    if not effective_file_id and mapped_file_id != document_file_id:
+        effective_file_id = mapped_file_id
+        LOG.debug(
+            "Via URL for file already mapped for course copy. Document: %s, course: %s, mapped file: %s",
+            document_url,
+            current_course_id,
+            mapped_file_id,
+        )
+
+    # In moodle course copy for files is easier to solve because we don't make
+    # requests in the name of the user so we can fix it for all launches.
+    # It won't only not succeed if the file doesn't have an equivalent file in the new course
+    if not effective_file_id:
+        found_file = course_copy_plugin.find_matching_file_in_course(
+            document_file_id, course.lms_id
+        )
+        if not found_file:
+            LOG.debug(
+                "Via URL for page, couldn't find page in the new course. Document: %s, course: %s.",
+                document_url,
+                current_course_id,
+            )
+            raise FileNotFoundInCourse(
+                "moodle_file_not_found_in_course_instructor", document_url
+            )
+        # Store a mapping so we don't have to re-search next time.
+        LOG.debug(
+            "Via URL for page, found page in the new course. Document: %s, course: %s, new page id: %s",
+            document_url,
+            current_course_id,
+            found_file.lms_id,
+        )
+        course.set_mapped_file_id(document_file_id, found_file.lms_id)
+        effective_file_id = found_file.lms_id
+
+    token = request.find_service(MoodleAPIClient).token
     return {
         "via_url": helpers.via_url(
-            request, url, content_type="pdf", query={"token": token}
+            request, effective_file_id, content_type="pdf", query={"token": token}
         )
     }

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -45,47 +45,9 @@ def via_url(_context, request):
     document_url = request.params["document_url"]
     document_course_id = DOCUMENT_URL_REGEX.search(document_url)["course_id"]
     document_file_id = DOCUMENT_URL_REGEX.search(document_url)["url"]
-    effective_file_id = None
-    if current_course_id == document_course_id:
-        # Not in a course copy scenario, use the IDs from the document_url
-        effective_file_id = document_file_id
-        LOG.debug("Via URL for file in the same course. %s", document_url)
-
-    mapped_file_id = course.get_mapped_file_id(document_file_id)
-    if not effective_file_id and mapped_file_id != document_file_id:
-        effective_file_id = mapped_file_id
-        LOG.debug(
-            "Via URL for file already mapped for course copy. Document: %s, course: %s, mapped file: %s",
-            document_url,
-            current_course_id,
-            mapped_file_id,
-        )
-
-    # In moodle course copy for files is easier to solve because we don't make
-    # requests in the name of the user so we can fix it for all launches.
-    # It won't only not succeed if the file doesn't have an equivalent file in the new course
-    if not effective_file_id:
-        found_file = course_copy_plugin.find_matching_file_in_course(
-            document_file_id, course.lms_id
-        )
-        if not found_file:
-            LOG.debug(
-                "Via URL for page, couldn't find page in the new course. Document: %s, course: %s.",
-                document_url,
-                current_course_id,
-            )
-            raise FileNotFoundInCourse(
-                "moodle_file_not_found_in_course_instructor", document_url
-            )
-        # Store a mapping so we don't have to re-search next time.
-        LOG.debug(
-            "Via URL for page, found page in the new course. Document: %s, course: %s, new page id: %s",
-            document_url,
-            current_course_id,
-            found_file.lms_id,
-        )
-        course.set_mapped_file_id(document_file_id, found_file.lms_id)
-        effective_file_id = found_file.lms_id
+    effective_file_id = _effective_file_id(
+        course_copy_plugin, course, document_url, document_course_id, document_file_id
+    )
 
     token = request.find_service(MoodleAPIClient).token
     return {
@@ -93,3 +55,47 @@ def via_url(_context, request):
             request, effective_file_id, content_type="pdf", query={"token": token}
         )
     }
+
+
+def _effective_file_id(
+    course_copy_plugin, course, document_url, document_course_id, document_file_id
+):
+    if course.lms_id == document_course_id:
+        # Not in a course copy scenario, use the IDs from the document_url
+        LOG.debug("Via URL for file in the same course. %s", document_url)
+        return document_file_id
+
+    mapped_file_id = course.get_mapped_file_id(document_file_id)
+    if mapped_file_id != document_file_id:
+        LOG.debug(
+            "Via URL for file already mapped for course copy. Document: %s, course: %s, mapped file: %s",
+            document_url,
+            course.lms_id,
+            mapped_file_id,
+        )
+        return mapped_file_id
+
+    # In moodle course copy for files is easier to solve because we don't make
+    # requests in the name of the user so we can fix it for all launches.
+    # It won't only not succeed if the file doesn't have an equivalent file in the new course
+    found_file = course_copy_plugin.find_matching_file_in_course(
+        document_file_id, course.lms_id
+    )
+    if not found_file:
+        LOG.debug(
+            "Via URL for page, couldn't find page in the new course. Document: %s, course: %s.",
+            document_url,
+            course.lms_id,
+        )
+        raise FileNotFoundInCourse(
+            "moodle_file_not_found_in_course_instructor", document_url
+        )
+    # Store a mapping so we don't have to re-search next time.
+    LOG.debug(
+        "Via URL for page, found page in the new course. Document: %s, course: %s, new page id: %s",
+        document_url,
+        course.lms_id,
+        found_file.lms_id,
+    )
+    course.set_mapped_file_id(document_file_id, found_file.lms_id)
+    return found_file.lms_id

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -1,11 +1,11 @@
 import re
-
-from pyramid.view import view_config
 from logging import getLogger
 
+from pyramid.view import view_config
+
 from lms.security import Permissions
-from lms.services.moodle import MoodleAPIClient
 from lms.services.exceptions import FileNotFoundInCourse
+from lms.services.moodle import MoodleAPIClient
 from lms.views import helpers
 
 LOG = getLogger(__name__)

--- a/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
@@ -65,8 +65,11 @@ class TestMoodleCourseCopyPlugin:
         assert isinstance(plugin, MoodleCourseCopyPlugin)
 
     @pytest.fixture
-    def plugin(self, moodle_api_client, course_copy_groups_helper):
+    def plugin(
+        self, moodle_api_client, course_copy_groups_helper, course_copy_files_helper
+    ):
         return MoodleCourseCopyPlugin(
             api=moodle_api_client,
             groups_helper=course_copy_groups_helper,
+            files_helper=course_copy_files_helper,
         )

--- a/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
@@ -1,0 +1,36 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.product.moodle import MoodleCourseCopyPlugin
+
+
+class TestMoodleCourseCopyPlugin:
+    def test_find_matching_group_set_in_course(self, plugin, course_copy_groups_helper):
+        result = plugin.find_matching_group_set_in_course(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        course_copy_groups_helper.find_matching_group_set_in_course.assert_called_once_with(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        assert (
+            result
+            == course_copy_groups_helper.find_matching_group_set_in_course.return_value
+        )
+
+    @pytest.mark.usefixtures(
+        "moodle_api_client", "course_copy_files_helper", "course_copy_groups_helper"
+    )
+    def test_factory(self, pyramid_request):
+        plugin = MoodleCourseCopyPlugin.factory(sentinel.context, pyramid_request)
+
+        assert isinstance(plugin, MoodleCourseCopyPlugin)
+
+    @pytest.fixture
+    def plugin(self, moodle_api_client, course_copy_groups_helper):
+        return MoodleCourseCopyPlugin(
+            api=moodle_api_client,
+            groups_helper=course_copy_groups_helper,
+        )

--- a/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/course_copy_test.py
@@ -20,6 +20,42 @@ class TestMoodleCourseCopyPlugin:
             == course_copy_groups_helper.find_matching_group_set_in_course.return_value
         )
 
+    def test_find_matching_file_in_course(
+        self, plugin, course_copy_files_helper, d2l_api_client
+    ):
+        result = plugin.find_matching_file_in_course(
+            sentinel.original_file_id, sentinel.new_course_id
+        )
+
+        course_copy_files_helper.find_matching_file_in_course(
+            d2l_api_client.list_files,
+            "moodle_file",
+            sentinel.original_file_id,
+            sentinel.new_course_id,
+        )
+
+        assert (
+            result == course_copy_files_helper.find_matching_file_in_course.return_value
+        )
+
+    def test_find_matching_page_in_course(
+        self, plugin, course_copy_files_helper, moodle_api_client
+    ):
+        result = plugin.find_matching_page_in_course(
+            sentinel.page_id, sentinel.course_id
+        )
+
+        course_copy_files_helper.find_matching_file_in_course.assert_called_once_with(
+            moodle_api_client.list_pages,
+            "moodle_page",
+            sentinel.page_id,
+            sentinel.course_id,
+        )
+
+        assert (
+            result == course_copy_files_helper.find_matching_file_in_course.return_value
+        )
+
     @pytest.mark.usefixtures(
         "moodle_api_client", "course_copy_files_helper", "course_copy_groups_helper"
     )

--- a/tests/unit/lms/product/moodle/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/grouping_test.py
@@ -1,3 +1,4 @@
+import random
 from unittest.mock import Mock, patch, sentinel
 
 import pytest
@@ -87,7 +88,7 @@ class TestMoodleGroupingPlugin:
         )
 
         moodle_api_client.group_set_groups.assert_called_once_with(
-            sentinel.group_set_id
+            course.lms_id, sentinel.group_set_id
         )
         assert api_groups == moodle_api_client.group_set_groups.return_value
 
@@ -146,6 +147,6 @@ class TestMoodleGroupingPlugin:
 
     @pytest.fixture
     def course(self):
-        course = factories.Course()
+        course = factories.Course(lms_id=random.randint(1, 1000))
         with patch.object(course, "set_group_sets"):
             yield course

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -91,7 +91,7 @@ class TestMoodleAPIClient:
                         "type": "File",
                         "display_name": "dummy.pdf",
                         "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
-                        "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
+                        "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
                         "updated_at": 1707992547 * 1000,
                     },
                     {
@@ -104,7 +104,7 @@ class TestMoodleAPIClient:
                                 "type": "File",
                                 "display_name": "dummy.pdf",
                                 "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
-                                "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
+                                "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
                                 "updated_at": 1708513742 * 1000,
                             },
                             {
@@ -117,7 +117,7 @@ class TestMoodleAPIClient:
                                         "type": "File",
                                         "display_name": "FILE IN NESTED.pdf",
                                         "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
-                                        "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
+                                        "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
                                         "updated_at": 1708513801 * 1000,
                                     }
                                 ],

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -90,8 +90,8 @@ class TestMoodleAPIClient:
                     {
                         "type": "File",
                         "display_name": "dummy.pdf",
-                        "id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
-                        "lms_id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
+                        "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
+                        "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
                         "updated_at": 1707992547 * 1000,
                     },
                     {
@@ -103,8 +103,8 @@ class TestMoodleAPIClient:
                             {
                                 "type": "File",
                                 "display_name": "dummy.pdf",
-                                "id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
-                                "lms_id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
+                                "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
+                                "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
                                 "updated_at": 1708513742 * 1000,
                             },
                             {
@@ -116,8 +116,8 @@ class TestMoodleAPIClient:
                                     {
                                         "type": "File",
                                         "display_name": "FILE IN NESTED.pdf",
-                                        "id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
-                                        "lms_id": "moodle://file/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
+                                        "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
+                                        "lms_id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
                                         "updated_at": 1708513801 * 1000,
                                     }
                                 ],

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -21,7 +21,7 @@ class TestMoodleAPIClient:
     def test_group_set_groups(self, svc, http_service, groups):
         http_service.post.return_value.json.return_value = [{"groups": groups}]
 
-        api_groups = svc.group_set_groups("GROUP_SET")
+        api_groups = svc.group_set_groups(100, "GROUP_SET")
 
         http_service.post.assert_called_once_with(
             "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=core_group_get_groupings&groupingids[0]=GROUP_SET&returngroups=1"
@@ -186,8 +186,8 @@ class TestMoodleAPIClient:
     @pytest.fixture
     def groups(self):
         return [
-            {"id": 1, "name": "1"},
-            {"id": 2, "name": "2"},
+            {"id": 1, "name": "1", "courseid": 100},
+            {"id": 2, "name": "2", "courseid": 100},
         ]
 
     @pytest.fixture

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -143,13 +143,13 @@ class TestMoodleAPIClient:
                     {
                         "type": "Page",
                         "display_name": "A Page",
-                        "lms_id": "moodle://page/course/COURSE_ID/page_id/860",
+                        "lms_id": 860,
                         "id": "moodle://page/course/COURSE_ID/page_id/860",
                     },
                     {
                         "type": "Page",
                         "display_name": "Another Page",
-                        "lms_id": "moodle://page/course/COURSE_ID/page_id/1860",
+                        "lms_id": 1860,
                         "id": "moodle://page/course/COURSE_ID/page_id/1860",
                     },
                 ],
@@ -161,6 +161,7 @@ class TestMoodleAPIClient:
         http_service,
         aes_service,
         pyramid_request,
+        file_service,
     ):
         ai = create_autospec(ApplicationInstance)
         pyramid_request.lti_user.application_instance = ai
@@ -174,6 +175,7 @@ class TestMoodleAPIClient:
         # pylint:disable=protected-access
         assert service._lms_url == ai.lms_url
         assert service._http == http_service
+        assert service._file_service == file_service
         assert service._token == ai.settings.get_secret.return_value
 
     @pytest.fixture
@@ -492,5 +494,7 @@ class TestMoodleAPIClient:
         ]
 
     @pytest.fixture
-    def svc(self, http_service):
-        return MoodleAPIClient(sentinel.lms_url, sentinel.token, http_service)
+    def svc(self, http_service, file_service):
+        return MoodleAPIClient(
+            sentinel.lms_url, sentinel.token, http_service, file_service
+        )

--- a/tests/unit/lms/views/api/moodle/files_test.py
+++ b/tests/unit/lms/views/api/moodle/files_test.py
@@ -78,7 +78,9 @@ def test_via_url_copied_no_page_found(
     lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
         "OTHER_COURSE_ID"
     )
-    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = None
+    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = (
+        "URL"
+    )
     course_copy_plugin.find_matching_file_in_course.return_value = None
 
     with pytest.raises(FileNotFoundInCourse):
@@ -102,7 +104,9 @@ def test_via_url_copied_found_page(
         "OTHER_COURSE_ID"
     )
     pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
-    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = None
+    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = (
+        "URL"
+    )
 
     course_copy_plugin.find_matching_file_in_course.return_value = Mock(
         lms_id="OTHER_FILE_URL"

--- a/tests/unit/lms/views/api/moodle/files_test.py
+++ b/tests/unit/lms/views/api/moodle/files_test.py
@@ -1,11 +1,12 @@
-from unittest.mock import sentinel
+from unittest.mock import Mock, sentinel
 
 import pytest
 
+from lms.services.exceptions import FileNotFoundInCourse
 from lms.views.api.moodle.files import list_files, via_url
 
 
-def test_course_group_sets(pyramid_request, moodle_api_client):
+def test_list_files(pyramid_request, moodle_api_client):
     pyramid_request.matchdict = {"course_id": "test_course_id"}
 
     result = list_files(sentinel.context, pyramid_request)
@@ -14,19 +15,111 @@ def test_course_group_sets(pyramid_request, moodle_api_client):
     assert result == moodle_api_client.list_files.return_value
 
 
+@pytest.mark.usefixtures("course_copy_plugin")
 def test_via_url(
-    moodle_api_client,
     helpers,
+    moodle_api_client,
     pyramid_request,
+    lti_user,
+    course_service,
 ):
     type(moodle_api_client).token = "TOKEN"
-    pyramid_request.params["document_url"] = "moodle://file/url/URL"
+    lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
+        "COURSE_ID"
+    )
+    pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
 
     response = via_url(sentinel.context, pyramid_request)
 
     helpers.via_url.assert_called_once_with(
         pyramid_request,
         "URL",
+        content_type="pdf",
+        query={"token": moodle_api_client.token},
+    )
+    assert response == {"via_url": helpers.via_url.return_value}
+
+
+@pytest.mark.usefixtures("course_copy_plugin")
+def test_via_url_copied_with_mapped_id(
+    helpers,
+    pyramid_request,
+    course_service,
+    lti_user,
+    moodle_api_client,
+):
+    pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
+    type(moodle_api_client).token = "TOKEN"
+    lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
+        "OTHER_COURSE_ID"
+    )
+    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = (
+        "OTHER_FILE_URL"
+    )
+
+    response = via_url(sentinel.context, pyramid_request)
+
+    helpers.via_url.assert_called_once_with(
+        pyramid_request,
+        "OTHER_FILE_URL",
+        content_type="pdf",
+        query={"token": moodle_api_client.token},
+    )
+    assert response == {"via_url": helpers.via_url.return_value}
+
+
+def test_via_url_copied_no_page_found(
+    pyramid_request,
+    course_service,
+    course_copy_plugin,
+    lti_user,
+):
+    pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
+    lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
+        "OTHER_COURSE_ID"
+    )
+    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = None
+    course_copy_plugin.find_matching_file_in_course.return_value = None
+
+    with pytest.raises(FileNotFoundInCourse):
+        via_url(sentinel.context, pyramid_request)
+
+    course_copy_plugin.find_matching_file_in_course.assert_called_once_with(
+        "URL", "OTHER_COURSE_ID"
+    )
+
+
+def test_via_url_copied_found_page(
+    pyramid_request,
+    course_service,
+    course_copy_plugin,
+    helpers,
+    lti_user,
+    moodle_api_client,
+):
+    type(moodle_api_client).token = "TOKEN"
+    lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
+        "OTHER_COURSE_ID"
+    )
+    pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
+    course_service.get_by_context_id.return_value.get_mapped_file_id.return_value = None
+
+    course_copy_plugin.find_matching_file_in_course.return_value = Mock(
+        lms_id="OTHER_FILE_URL"
+    )
+
+    response = via_url(sentinel.context, pyramid_request)
+
+    course_copy_plugin.find_matching_file_in_course.assert_called_once_with(
+        "URL", "OTHER_COURSE_ID"
+    )
+    course_service.get_by_context_id.return_value.set_mapped_file_id(
+        "URL", "OTHER_FILE_URL"
+    )
+
+    helpers.via_url.assert_called_once_with(
+        pyramid_request,
+        "OTHER_FILE_URL",
         content_type="pdf",
         query={"token": moodle_api_client.token},
     )

--- a/tests/unit/lms/views/api/moodle/pages_test.py
+++ b/tests/unit/lms/views/api/moodle/pages_test.py
@@ -112,7 +112,7 @@ class TestPageAPIViews:
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
         course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            None
+            "PAGE_ID"
         )
         course_copy_plugin.find_matching_page_in_course.return_value = None
 
@@ -140,7 +140,7 @@ class TestPageAPIViews:
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
         course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            None
+            "PAGE_ID"
         )
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 

--- a/tests/unit/lms/views/api/moodle/pages_test.py
+++ b/tests/unit/lms/views/api/moodle/pages_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import sentinel
+from unittest.mock import Mock, sentinel
 
 import pytest
 from h_matchers import Any
 
-from lms.views.api.moodle.pages import PagesAPIViews
+from lms.views.api.moodle.pages import PageNotFoundInCourse, PagesAPIViews
 
 
 @pytest.mark.usefixtures(
@@ -29,10 +29,13 @@ class TestPageAPIViews:
         BearerTokenSchema,
         course_service,
     ):
+        # Current course and document course are the same
+        lti_user.lti.course_id = (
+            course_service.get_by_context_id.return_value.lms_id
+        ) = "COURSE_ID"
         assignment_service.get_assignment.return_value.document_url = (
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
-        course_service.get_by_context_id.return_value.lms_id = "COURSE_ID"
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 
         response = PagesAPIViews(pyramid_request).via_url()
@@ -44,12 +47,122 @@ class TestPageAPIViews:
         BearerTokenSchema.return_value.authorization_param.assert_called_once_with(
             lti_user
         )
+
         helpers.via_url.assert_called_once_with(
             pyramid_request,
             Any.url.with_path("/api/moodle/pages/proxy").with_query(
                 {
                     "course_id": "COURSE_ID",
                     "page_id": "PAGE_ID",
+                    "authorization": "TOKEN",
+                }
+            ),
+            options={"via.proxy_frames": "0", "via.proxy_images": "0"},
+        )
+        assert response == {"via_url": helpers.via_url.return_value}
+
+    @pytest.mark.usefixtures("course_copy_plugin")
+    def test_via_url_copied_with_mapped_id(
+        self,
+        helpers,
+        pyramid_request,
+        assignment_service,
+        BearerTokenSchema,
+        course_service,
+        lti_user,
+    ):
+        lti_user.lti.course_id = (
+            course_service.get_by_context_id.return_value.lms_id
+        ) = "OTHER_COURSE_ID"
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
+            "OTHER_PAGE_ID"
+        )
+        assignment_service.get_assignment.return_value.document_url = (
+            "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
+        )
+        BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
+
+        response = PagesAPIViews(pyramid_request).via_url()
+
+        helpers.via_url.assert_called_once_with(
+            pyramid_request,
+            Any.url.with_path("/api/moodle/pages/proxy").with_query(
+                {
+                    "course_id": "OTHER_COURSE_ID",
+                    "page_id": "OTHER_PAGE_ID",
+                    "authorization": "TOKEN",
+                }
+            ),
+            options={"via.proxy_frames": "0", "via.proxy_images": "0"},
+        )
+        assert response == {"via_url": helpers.via_url.return_value}
+
+    def test_via_url_copied_no_page_found(
+        self,
+        pyramid_request,
+        assignment_service,
+        course_service,
+        course_copy_plugin,
+        lti_user,
+    ):
+        lti_user.lti.course_id = (
+            course_service.get_by_context_id.return_value.lms_id
+        ) = "OTHER_COURSE_ID"
+        assignment_service.get_assignment.return_value.document_url = (
+            "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
+        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
+            None
+        )
+        course_copy_plugin.find_matching_page_in_course.return_value = None
+
+        with pytest.raises(PageNotFoundInCourse):
+            PagesAPIViews(pyramid_request).via_url()
+
+        course_copy_plugin.find_matching_page_in_course.assert_called_once_with(
+            "PAGE_ID", "OTHER_COURSE_ID"
+        )
+
+    def test_via_url_copied_found_page(
+        self,
+        pyramid_request,
+        assignment_service,
+        course_service,
+        course_copy_plugin,
+        BearerTokenSchema,
+        helpers,
+        lti_user,
+    ):
+        lti_user.lti.course_id = (
+            course_service.get_by_context_id.return_value.lms_id
+        ) = "OTHER_COURSE_ID"
+        assignment_service.get_assignment.return_value.document_url = (
+            "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
+        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
+            None
+        )
+        BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
+
+        course_copy_plugin.find_matching_page_in_course.return_value = Mock(
+            lms_id="OTHER_PAGE_ID"
+        )
+
+        response = PagesAPIViews(pyramid_request).via_url()
+
+        course_copy_plugin.find_matching_page_in_course.assert_called_once_with(
+            "PAGE_ID", "OTHER_COURSE_ID"
+        )
+        course_service.get_by_context_id.return_value.set_mapped_page_id(
+            "PAGE_ID", "OTHER_PAGE_ID"
+        )
+
+        helpers.via_url.assert_called_once_with(
+            pyramid_request,
+            Any.url.with_path("/api/moodle/pages/proxy").with_query(
+                {
+                    "course_id": "OTHER_COURSE_ID",
+                    "page_id": "OTHER_PAGE_ID",
                     "authorization": "TOKEN",
                 }
             ),


### PR DESCRIPTION
## Testing 

- Login in moodle as `moodleteacher`.
- The course copy fix relies on storing data in the original course. Simulate that using the "Select content" button in  [HTML - Group Assignment](https://hypothesisuniversity.moodlecloud.com/course/modedit.php?update=861&return=1)
- Select any type of content and the checkbox for "This is a group assignment". Do not save the assignment. We are only after the side effect.
- Launch [
HTML - Group Assignment](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=861)

- [Launch the equivalent assignment on the copied course](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=887)

- Check the DB for the state there:

````
select lms_name, extra from grouping where type = 'course';
-[ RECORD 2 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
lms_name | Developers test course
extra    | {"group_sets": [{"id": "2", "name": "Grouping in course"}, {"id": "5", "name": "Grouping without  groups"}]}
-[ RECORD 3 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
lms_name | (Copied-2024) Developer tests course
extra    | {"group_sets": [{"id": "6", "name": "Grouping in course"}, {"id": "7", "name": "Grouping without  groups"}],  "course_copy_group_set_mappings": {"2": "6"}}
```

Note the course_copy_group_set_mappings in the copied course with points the orignal group set (2) to the equivalent new one (6).