### PR TITLE
Fix unique constraint for `oauth2_token` in new DBs

### DIFF
--- a/lms/models/oauth2_token.py
+++ b/lms/models/oauth2_token.py
@@ -39,7 +39,9 @@ class OAuth2Token(Base):
     """
 
     __tablename__ = "oauth2_token"
-    __table_args__ = (sa.UniqueConstraint("user_id", "application_instance_id"),)
+    __table_args__ = (
+        sa.UniqueConstraint("user_id", "application_instance_id", "service"),
+    )
 
     id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
 

--- a/tests/unit/lms/models/oauth2_token_test.py
+++ b/tests/unit/lms/models/oauth2_token_test.py
@@ -11,6 +11,7 @@ class TestOAuth2Token:
     def test_persist_and_retrieve_all_attrs(self, application_instance, db_session):
         now = datetime.datetime.utcnow()
 
+        # Add a token with the default "lms" service
         db_session.add(
             OAuth2Token(
                 user_id="test_user_id",
@@ -19,7 +20,7 @@ class TestOAuth2Token:
                 refresh_token="test_refresh_token",
                 expires_in=3600,
                 received_at=now,
-                service=Service.CANVAS_STUDIO,
+                service=Service.LMS,
             )
         )
 
@@ -31,6 +32,23 @@ class TestOAuth2Token:
         assert token.refresh_token == "test_refresh_token"
         assert token.expires_in == 3600
         assert token.received_at == now
+        assert token.service == Service.LMS
+
+        # Add a second token with a non-default service
+        db_session.add(
+            OAuth2Token(
+                user_id="test_user_id",
+                application_instance_id=application_instance.id,
+                access_token="test_access_token",
+                refresh_token="test_refresh_token",
+                expires_in=3600,
+                received_at=now,
+                service=Service.CANVAS_STUDIO,
+            )
+        )
+        token = (
+            db_session.query(OAuth2Token).filter_by(service=Service.CANVAS_STUDIO).one()
+        )
         assert token.service == Service.CANVAS_STUDIO
 
     @pytest.mark.parametrize("column", ["user_id", "access_token"])


### PR DESCRIPTION
Update the unique constraint to match the migration that was added in ad5f11445d60822d587cfe9c1495578a3311684f, where the new `service` field is part of the constraint.