### PR TITLE
Reduce log noise for 404 requests

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -23,7 +23,10 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_settings(
         {
             "exclog.extra_info": True,
-            "exclog.ignore": ["lms.services.exceptions.OAuth2TokenError"],
+            "exclog.ignore": [
+                "lms.services.exceptions.OAuth2TokenError",
+                "pyramid.httpexceptions.HTTPNotFound",
+            ],
         }
     )
     config.include("pyramid_exclog")

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -221,6 +221,7 @@ class APIExceptionViews:
 
     @notfound_view_config()
     def notfound(self):
+        LOG.error("Page not found: %s", self.request.url)
         self.request.response.status_int = 404
         return ErrorBody(message=_("Endpoint not found."))
 

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -27,6 +27,7 @@ class ExceptionViews:
 
     @notfound_view_config()
     def notfound(self):
+        LOG.error("Page not found: %s", self.request.url)
         return self.error_response(404, _("Page not found"))
 
     @forbidden_view_config()


### PR DESCRIPTION
Exclude HTTPNotFound from the more verbose logging but add an explicit logging line so 404 are not completely silent.