### PR TITLE
Add MVP of Canvas Studio media selection in file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ To upgrade **all** packages to their latest versions:
 make requirements --always-make args=--upgrade
 ```
 
+## HTTPS/SSL setup
+
 ### Using self signed certificates with HTTPS
 
 By default `make dev` runs the web application on two ports: 8001 for HTTP and 48001 for HTTPS with a self-signed certificate.
@@ -157,6 +159,14 @@ You should also see an "Insecure content blocked" icon in the top right of the l
 !["Insecure content blocked" dialog](docs/images/insecure-content-blocked.png "'Insecure content blocked' dialog")
 
 Click on the <samp>Load unsafe scripts</samp> link and the app should load successfully.
+
+
+### Localhost alias
+
+Some services that the LMS app integrates with (eg. Canvas Studio) do not allow
+the use of `localhost` in OAuth callback URLs. For this reason we use
+`https://hypothesis.local` URLs in some places. To make this work you must
+declare `hypothesis.local` as an alias for `127.0.0.1` in your `/etc/hosts` file.
 
 ## Overview and code design
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -293,6 +293,7 @@ class JSConfig:
                     "d2l": FilePickerConfig.d2l_config(*args),
                     "moodle": FilePickerConfig.moodle_config(*args),
                     "canvas": FilePickerConfig.canvas_config(*args),
+                    "canvasStudio": FilePickerConfig.canvas_studio_config(*args),
                     "google": FilePickerConfig.google_files_config(*args),
                     "microsoftOneDrive": FilePickerConfig.microsoft_onedrive(*args),
                     "vitalSource": FilePickerConfig.vitalsource_config(*args),

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -102,6 +102,23 @@ class FilePickerConfig:
         return config
 
     @classmethod
+    def canvas_studio_config(cls, request, application_instance):
+        enabled = (
+            application_instance.settings.get("canvas_studio", "client_id") is not None
+        )
+
+        if not enabled:
+            return {"enabled": False}
+
+        return {
+            "enabled": True,
+            "listMedia": {
+                "authUrl": request.route_url("canvas_studio_api.oauth.authorize"),
+                "path": request.route_path("canvas_studio_api.media.list"),
+            },
+        }
+
+    @classmethod
     def google_files_config(cls, request, application_instance):
         """Get Google file picker config."""
         enabled = application_instance.settings.get(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -131,6 +131,18 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("canvas_api.pages.via_url", "/api/canvas/pages/via_url")
     config.add_route("canvas_api.pages.proxy", "/api/canvas/pages/proxy")
 
+    config.add_route(
+        "canvas_studio_api.oauth.authorize", "/api/canvas_studio/oauth/authorize"
+    )
+    config.add_route(
+        "canvas_studio_api.oauth.callback", "/api/canvas_studio/oauth/callback"
+    )
+    config.add_route("canvas_studio_api.media.list", "/api/canvas_studio/media")
+    config.add_route(
+        "canvas_studio_api.collections.media.list",
+        "/api/canvas_studio/collections/{collection_id}/media",
+    )
+
     # JSTOR article IDs need a custom pattern because they may contain a slash,
     # after URL-decoding of the path.
     jstor_article_id_pat = r"(10\.[0-9]+/)?[^/]+"

--- a/lms/security.py
+++ b/lms/security.py
@@ -100,6 +100,7 @@ class SecurityPolicy:
         if path in {
             "/canvas_oauth_callback",
             "/api/blackboard/oauth/callback",
+            "/api/canvas_studio/oauth/callback",
             "/api/d2l/oauth/callback",
         }:
             # LTIUser serialized in the state param for the oauth flow

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -1,6 +1,7 @@
 from lms.services.aes import AESService
 from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.canvas import CanvasService
+from lms.services.canvas_studio import CanvasStudioService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
 from lms.services.email_preferences import EmailPreferencesService, EmailPrefs
@@ -55,6 +56,9 @@ def includeme(config):
         "lms.services.canvas_api.canvas_api_client_factory", name="canvas_api_client"
     )
     config.register_service_factory("lms.services.canvas.factory", iface=CanvasService)
+    config.register_service_factory(
+        "lms.services.canvas_studio.factory", iface=CanvasStudioService
+    )
     config.register_service_factory("lms.services.user.factory", iface=UserService)
     config.register_service_factory(
         "lms.services.user_preferences.factory", iface=UserPreferencesService

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,0 +1,221 @@
+from typing import Literal, Optional, TypedDict
+from urllib.parse import urlencode, urlunparse
+
+from marshmallow import EXCLUDE, Schema, fields, post_load
+
+from lms.models.oauth2_token import Service
+from lms.services.aes import AESService
+from lms.services.oauth_http import factory as oauth_http_factory
+from lms.validation._base import RequestsResponseSchema
+
+
+class CanvasStudioCollectionsSchema(RequestsResponseSchema):
+    """Schema for Canvas Studio /collections responses."""
+
+    class CollectionSchema(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        id = fields.Integer(required=True)
+        name = fields.Str(required=True)
+        type = fields.Str(required=True)
+        created_at = fields.Str(required=False)
+
+    collections = fields.List(fields.Nested(CollectionSchema), required=True)
+
+    @post_load
+    def post_load(self, data, **_kwargs):
+        return data["collections"]
+
+
+class CanvasStudioCollectionMediaSchema(RequestsResponseSchema):
+    """Schema for Canvas Studio /collections/{id}/media responses."""
+
+    class MediaSchema(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        id = fields.Integer(required=True)
+        title = fields.Str(required=True)
+        created_at = fields.Str(required=False)
+
+    media = fields.List(fields.Nested(MediaSchema), required=True)
+
+    @post_load
+    def post_load(self, data, **_kwargs):
+        return data["media"]
+
+
+class APICallInfo(TypedDict):
+    path: str
+    authUrl: str | None
+
+
+class File(TypedDict):
+    """Represents a file or folder in an LMS's file storage."""
+
+    type: Literal["File", "Folder"]
+
+    id: str
+    display_name: str
+    updated_at: str
+
+    contents: Optional[APICallInfo]
+    """API call to use to fetch contents of a folder."""
+
+
+class CanvasStudioService:
+    """
+        Service for authenticating with and making calls to the Canvas Studio API.
+
+    Useful links:
+
+        Authorization guide: https://community.canvaslms.com/t5/Canvas-Studio-Blog/Connecting-Studio-OAuth-via-Postman/ba-p/259739
+        API reference: https://tw.instructuremedia.com/api/public/docs/
+    """
+
+    def __init__(self, request):
+        application_instance = request.lti_user.application_instance
+
+        self._domain = application_instance.settings.get("canvas_studio", "domain")
+        self._client_id = application_instance.settings.get(
+            "canvas_studio", "client_id"
+        )
+        self._client_secret = application_instance.settings.get_secret(
+            request.find_service(AESService), "canvas_studio", "client_secret"
+        )
+        self._oauth_http_service = oauth_http_factory(
+            {}, request, service=Service.CANVAS_STUDIO
+        )
+        self._request = request
+
+    def get_access_token(self, code: str) -> None:
+        """
+        Fetch and persist an access token for Canvas Studio API calls.
+
+        :param code: Authorization code received from OAuth callback
+        """
+        token_url = self._api_url("oauth/token")
+        self._oauth_http_service.get_access_token(
+            token_url,
+            self.redirect_uri(),
+            auth=(self._client_id, self._client_secret),
+            authorization_code=code,
+        )
+
+    def authorization_url(self, state: str) -> str:
+        """
+        Construct the authorization endpoint URL for Canvas Studio.
+
+        This constructs the authorization URL for the Canvas Studio instance
+        associated with the current application instance.
+
+        :param state: `state` query param for the authorization request
+        """
+        auth_url = urlunparse(
+            (
+                "https",
+                self._domain,
+                "api/public/oauth/authorize",
+                "",
+                urlencode(
+                    {
+                        "client_id": self._client_id,
+                        "response_type": "code",
+                        "redirect_uri": self.redirect_uri(),
+                        "state": state,
+                    }
+                ),
+                "",
+            )
+        )
+
+        return auth_url
+
+    def redirect_uri(self) -> str:
+        """Return OAuth redirect URI for Canvas Studio."""
+        return self._request.route_url("canvas_studio_api.oauth.callback")
+
+    def list_media_library(self) -> list[File]:
+        """
+        List the videos and collections for the current user.
+
+        The result of this call corresponds to what the user sees if they
+        visit Canvas Studio from within their LMS, or use the Canvas Studio
+        picker when creating a Page.
+        """
+
+        collections = self._api_request("v1/collections", CanvasStudioCollectionsSchema)
+        user_collection = None
+
+        files = []
+        for collection in collections:
+            if collection["type"] == "user":
+                user_collection = collection
+                continue
+
+            files.append(
+                {
+                    "type": "Folder",
+                    "display_name": collection["name"],
+                    "updated_at": collection["created_at"],
+                    "id": str(collection["id"]),
+                    "contents": {
+                        "path": self._request.route_url(
+                            "canvas_studio_api.collections.media.list",
+                            collection_id=collection["id"],
+                        )
+                    },
+                }
+            )
+
+        if user_collection:
+            files += self.list_collection(str(user_collection["id"]))
+
+        return files
+
+    def list_collection(self, collection_id: str) -> list[File]:
+        """List the videos in a collection."""
+
+        media = self._api_request(
+            f"v1/collections/{collection_id}/media", CanvasStudioCollectionMediaSchema
+        )
+
+        files = []
+        for item in media:
+            media_id = item["id"]
+            files.append(
+                {
+                    "type": "File",
+                    "id": f"canvas-studio://media/{media_id}",
+                    "display_name": item["title"],
+                    "updated_at": item["created_at"],
+                }
+            )
+
+        return files
+
+    def _api_request(self, path: str, schema_cls: RequestsResponseSchema) -> dict:
+        """Make a request to the Canvas Studio API and parse the JSON response."""
+        response = self._oauth_http_service.get(self._api_url(path))
+        return schema_cls(response).parse()
+
+    def _api_url(self, path: str) -> str:
+        """
+        Return the URL of a Canvas Studio API endpoint.
+
+        See https://tw.instructuremedia.com/api/public/docs/ for available
+        endpoints.
+
+        :param path: Path of endpoint relative to the API root
+        """
+
+        site = self._canvas_studio_site()
+        return f"{site}/api/public/{path}"
+
+    def _canvas_studio_site(self) -> str:
+        return f"https://{self._domain}"
+
+
+def factory(_context, request):
+    return CanvasStudioService(request)

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -66,7 +66,7 @@ class File(TypedDict):
 
 class CanvasStudioService:
     """
-        Service for authenticating with and making calls to the Canvas Studio API.
+    Service for authenticating with and making calls to the Canvas Studio API.
 
     Useful links:
 
@@ -74,9 +74,7 @@ class CanvasStudioService:
         API reference: https://tw.instructuremedia.com/api/public/docs/
     """
 
-    def __init__(self, request):
-        application_instance = request.lti_user.application_instance
-
+    def __init__(self, request, application_instance):
         self._domain = application_instance.settings.get("canvas_studio", "domain")
         self._client_id = application_instance.settings.get(
             "canvas_studio", "client_id"
@@ -218,4 +216,4 @@ class CanvasStudioService:
 
 
 def factory(_context, request):
-    return CanvasStudioService(request)
+    return CanvasStudioService(request, request.lti_user.application_instance)

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,6 +1,7 @@
 from marshmallow import fields
 
-from lms.services import ExternalRequestError, OAuth2TokenError
+from lms.models.oauth2_token import Service
+from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
 from lms.validation import RequestsResponseSchema
 from lms.validation.authentication import OAuthTokenResponseSchema
 
@@ -14,9 +15,12 @@ class _OAuthAccessTokenErrorResponseSchema(RequestsResponseSchema):
 class OAuthHTTPService:
     """Send OAuth 2.0 requests and return the responses."""
 
-    def __init__(self, http_service, oauth2_token_service):
+    def __init__(
+        self, http_service, oauth2_token_service, service: Service = Service.LMS
+    ):
         self._http_service = http_service
         self._oauth2_token_service = oauth2_token_service
+        self.service = service
 
     def get(self, *args, **kwargs):
         return self.request("GET", *args, **kwargs)
@@ -51,7 +55,7 @@ class OAuthHTTPService:
 
         assert "Authorization" not in headers
 
-        access_token = self._oauth2_token_service.get().access_token
+        access_token = self._oauth2_token_service.get(service=self.service).access_token
         headers["Authorization"] = f"Bearer {access_token}"
 
         return self._http_service.request(method, url, headers=headers, **kwargs)
@@ -122,12 +126,15 @@ class OAuthHTTPService:
             validated_data["access_token"],
             validated_data.get("refresh_token"),
             validated_data.get("expires_in"),
+            service=self.service,
         )
 
         return validated_data["access_token"]
 
 
-def factory(_context, request):
+def factory(_context, request, service: Service = Service.LMS) -> OAuthHTTPService:
     return OAuthHTTPService(
-        request.find_service(name="http"), request.find_service(name="oauth2_token")
+        request.find_service(name="http"),
+        request.find_service(name="oauth2_token"),
+        service=service,
     )

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -194,12 +194,8 @@ export default function ContentSelector({
     selectPageAsURL(page, 'Canvas');
 
   const selectCanvasStudio = (video: File | Page) => {
-    cancelDialog();
-    onSelectContent({
-      type: 'url',
-      url: video.id,
-      name: `Canvas Studio video: ${video.display_name}`,
-    });
+    const name = `Canvas Studio video: ${video.display_name}`;
+    selectURL(video.id, name);
   };
 
   const selectMoodlePage = (page: File | Page) =>

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -19,6 +19,7 @@ type DialogType =
   | 'blackboardFile'
   | 'canvasFile'
   | 'canvasPage'
+  | 'canvasStudio'
   | 'd2lFile'
   | 'moodleFile'
   | 'moodlePage'
@@ -80,6 +81,10 @@ export default function ContentSelector({
         foldersEnabled: canvasWithFolders,
         pagesEnabled: canvasPagesEnabled,
         listPages: listPagesApi,
+      },
+      canvasStudio: {
+        enabled: canvasStudioEnabled,
+        listMedia: listCanvasStudioMediaApi,
       },
       google: {
         enabled: googleDriveEnabled,
@@ -188,6 +193,15 @@ export default function ContentSelector({
   const selectCanvasPage = (page: File | Page) =>
     selectPageAsURL(page, 'Canvas');
 
+  const selectCanvasStudio = (video: File | Page) => {
+    cancelDialog();
+    onSelectContent({
+      type: 'url',
+      url: video.id,
+      name: `Canvas Studio video: ${video.display_name}`,
+    });
+  };
+
   const selectMoodlePage = (page: File | Page) =>
     selectPageAsURL(page, 'Moodle');
 
@@ -236,6 +250,18 @@ export default function ContentSelector({
           onCancel={cancelDialog}
           onSelectFile={selectCanvasPage}
           missingFilesHelpLink="https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-create-a-new-page-in-a-course/ta-p/1031"
+          documentType="page"
+        />
+      );
+      break;
+    case 'canvasStudio':
+      dialog = (
+        <LMSFilePicker
+          authToken={authToken}
+          listFilesApi={listCanvasStudioMediaApi}
+          onCancel={cancelDialog}
+          onSelectFile={selectCanvasStudio}
+          missingFilesHelpLink="https://community.canvaslms.com/t5/Canvas-Studio-Guide/How-do-I-use-Canvas-Studio/ta-p/1678"
           documentType="page"
         />
       );
@@ -396,7 +422,15 @@ export default function ContentSelector({
             Canvas Page
           </OptionButton>
         )}
-
+        {canvasStudioEnabled && (
+          <OptionButton
+            data-testid="canvas-studio-button"
+            details="Canvas Studio"
+            onClick={() => selectDialog('canvasStudio')}
+          >
+            Canvas Studio
+          </OptionButton>
+        )}
         {blackboardFilesEnabled && (
           <OptionButton
             data-testid="blackboard-file-button"

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -63,6 +63,9 @@ function formatContentURL(content: URLContent) {
   if (content.url.startsWith('blackboard://')) {
     return 'PDF file in Blackboard';
   }
+  if (content.url.startsWith('canvas-studio://')) {
+    return 'Video in Canvas Studio';
+  }
   if (content.url.startsWith('d2l://')) {
     return 'PDF file in D2L';
   }

--- a/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ContentSelector-test.js
@@ -53,6 +53,13 @@ describe('ContentSelector', () => {
             path: 'https://lms.anno.co/api/canvas/pages',
           },
         },
+        canvasStudio: {
+          enabled: true,
+          listMedia: {
+            authUrl: 'https://lms.anno.co/api/canvas_studio/oauth/authorize',
+            path: 'https://lms.anno.co/api/canvas_studio/media',
+          },
+        },
         moodle: {
           enabled: true,
           pagesEnabled: true,
@@ -138,6 +145,7 @@ describe('ContentSelector', () => {
         'url-button',
         'canvas-file-button',
         'canvas-page-button',
+        'canvas-studio-button',
         'blackboard-file-button',
         'd2l-file-button',
         'moodle-file-button',
@@ -336,12 +344,18 @@ describe('ContentSelector', () => {
     });
   });
 
-  describe('LMS page dialog', () => {
+  // Tests for other content sources that use our standard file picker.
+  describe('LMS page and media pickers', () => {
     [
       {
         name: 'Canvas',
         buttonTestId: 'canvas-page-button',
         pages: () => fakeConfig.filePicker.canvas.listPages,
+      },
+      {
+        name: 'Canvas Studio',
+        buttonTestId: 'canvas-studio-button',
+        pages: () => fakeConfig.filePicker.canvasStudio.listMedia,
       },
       {
         name: 'Moodle',
@@ -370,17 +384,22 @@ describe('ContentSelector', () => {
 
       [
         {
-          name: 'Canvas',
+          name: 'Canvas Pages',
           dialog: 'canvasPage',
-          displayName: 'Canvas page: Page title',
+          displayName: 'Canvas page: Item title',
         },
         {
-          name: 'Moodle',
+          name: 'Canvas Studio',
+          dialog: 'canvasStudio',
+          displayName: 'Canvas Studio video: Item title',
+        },
+        {
+          name: 'Moodle Pages',
           dialog: 'moodlePage',
-          displayName: 'Moodle page: Page title',
+          displayName: 'Moodle page: Item title',
         },
       ].forEach(test => {
-        it(`'supports selecting a page from the ${test.name} page dialog'`, () => {
+        it(`'supports selecting content from the ${test.name} dialog'`, () => {
           const onSelectContent = sinon.stub();
           const wrapper = renderContentSelector({
             defaultActiveDialog: test.dialog,
@@ -391,7 +410,7 @@ describe('ContentSelector', () => {
           interact(wrapper, () => {
             picker
               .props()
-              .onSelectFile({ id: 123, display_name: 'Page title' });
+              .onSelectFile({ id: 123, display_name: 'Item title' });
           });
 
           assert.calledWith(onSelectContent, {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -291,11 +291,17 @@ describe('FilePickerApp', () => {
       {
         content: {
           type: 'url',
+          url: 'canvas-studio://media/5',
+        },
+        summary: 'Video in Canvas Studio',
+      },
+      {
+        content: {
+          type: 'url',
           url: 'd2l://file/course/123/file_id/456',
         },
         summary: 'PDF file in D2L',
       },
-
       {
         content: { type: 'file', id: 'abcd' },
         summary: 'PDF file in Canvas',

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -105,6 +105,10 @@ export type FilePickerConfig = {
     listFiles: APICallInfo;
     listPages: APICallInfo;
   };
+  canvasStudio: {
+    enabled: boolean;
+    listMedia: APICallInfo;
+  };
   google: {
     enabled: boolean;
     clientId?: string;

--- a/lms/templates/api/oauth2/client_side_redirect.html.jinja2
+++ b/lms/templates/api/oauth2/client_side_redirect.html.jinja2
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Redirecting to {{ link_text }}</title>
+    <meta http-equiv="refresh" content="0; url={{ redirect_url }}">
+  </head>
+  <body>
+  <p>Redirecting to <a href="{{ redirect_url }}">{{ link_text }}</a></p>.
+  </body>
+</html>

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -5,8 +5,9 @@ from datetime import timedelta
 import marshmallow
 
 from lms.models import LTIUser
-from lms.services import JWTService, LTIUserService
 from lms.services.exceptions import ExpiredJWTError, InvalidJWTError
+from lms.services.jwt import JWTService
+from lms.services.lti_user import LTIUserService
 from lms.validation import ValidationError
 from lms.validation._base import PyramidRequestSchema
 

--- a/lms/validation/authentication/_lti.py
+++ b/lms/validation/authentication/_lti.py
@@ -1,11 +1,9 @@
 import marshmallow
 
 from lms.models import CLAIM_PREFIX, LTIUser
-from lms.services import (
-    ApplicationInstanceNotFound,
-    LTILaunchVerificationError,
-    LTIUserService,
-)
+from lms.services.application_instance import ApplicationInstanceNotFound
+from lms.services.launch_verifier import LTILaunchVerificationError
+from lms.services.lti_user import LTIUserService
 from lms.validation._exceptions import ValidationError
 from lms.validation._lti_launch_params import LTIV11CoreSchema
 

--- a/lms/views/api/canvas_studio.py
+++ b/lms/views/api/canvas_studio.py
@@ -1,0 +1,118 @@
+"""
+Views for authorizing with Canvas Studio and listing videos.
+
+See `CanvasStudioService` for more details.
+"""
+
+from pyramid.httpexceptions import HTTPFound
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.services import CanvasStudioService
+from lms.validation.authentication import OAuthCallbackSchema
+
+
+# View for authorization popup which redirects to Canvas Studio's OAuth
+# authorization endpoint.
+#
+# Canvas Studio's OAuth implementation has several issues which complicate
+# using the standard OAuth flow:
+#
+# 1. Canvas Studio does not return the `state` parameter to us when it redirects
+#    after a successful authorization [1].
+# 2. Canvas Studio does not allow the use of unencrypted HTTP or `localhost`
+#    as a redirect URL for an OAuth client.
+#
+# To work around these issues, we use the following authentication flow:
+#
+# 1. User clicks button in UI to initiate Canvas Studio authorization
+# 2. The button opens `/api/canvas_studio/oauth/authorize` in a popup
+# 3. In development only, the popup redirects to change the host from
+#    http://localhost:8001 to https://hypothesis.local:48001/, keeping the
+#    path the same.
+# 4. The popup returns a 200 response which sets a cookie and does a client-side
+#    redirect to the Canvas Studio authorization endpoint.
+#
+#    We use a client-side redirect because setting cookies as part of a 302
+#    redirect response does not work in some browsers (including Chrome).
+# 5. The user completes authorization in the Canvas Studio UI
+# 6. Canvas Studio redirects to our `/api/canvas_studio/oauth/callback`
+#    endpoint, passing the authorization code, but not the `state`.
+# 7. We read the `state` parameter out of the cookie and then
+#    redirect to the `/api/canvas_studio/oauth/callback` URL that Canvas Studio
+#    should have used.
+#
+# [1] https://community.canvaslms.com/t5/Canvas-Developers-Group/Canvas-Studio-OAuth-authorization-does-not-send-state-parameter/td-p/596747
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.authorize",
+    renderer="lms:templates/api/oauth2/client_side_redirect.html.jinja2",
+    permission=Permissions.API,
+)
+def authorize(request):
+    if request.host_url == "http://localhost:8001":
+        redirect_url = request.url.replace(
+            request.host_url, "https://hypothesis.local:48001"
+        )
+        return HTTPFound(location=redirect_url)
+
+    canvas_studio_svc = request.find_service(CanvasStudioService)
+    oauth_state = OAuthCallbackSchema(request).state_param()
+    auth_url = canvas_studio_svc.authorization_url(oauth_state)
+
+    request.response.set_cookie("canvas_studio_oauth_state", oauth_state)
+
+    return {"redirect_url": auth_url, "link_text": "Canvas Studio login"}
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+    request_param="state",
+    schema=OAuthCallbackSchema,
+)
+def oauth2_redirect(request):
+    code = request.parsed_params["code"]
+    request.find_service(CanvasStudioService).get_access_token(code)
+    return {}
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.oauth.callback",
+    renderer="lms:templates/api/oauth2/redirect.html.jinja2",
+)
+def oauth2_redirect_missing_state(request):
+    code = request.params["code"]
+    state = request.cookies.get("canvas_studio_oauth_state")
+
+    # Generate the redirect URL which Canvas Studio should have generated.
+    url = request.route_url(
+        "canvas_studio_api.oauth.callback", _query={"code": code, "state": state}
+    )
+
+    return HTTPFound(location=url)
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.media.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_media(request):
+    svc = request.find_service(CanvasStudioService)
+    return svc.list_media_library()
+
+
+@view_config(
+    request_method="GET",
+    route_name="canvas_studio_api.collections.media.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_collection(request):
+    svc = request.find_service(CanvasStudioService)
+    collection_id = request.matchdict["collection_id"]
+    return svc.list_collection(collection_id)

--- a/lms/views/api/canvas_studio.py
+++ b/lms/views/api/canvas_studio.py
@@ -42,6 +42,9 @@ from lms.validation.authentication import OAuthCallbackSchema
 #    redirect to the `/api/canvas_studio/oauth/callback` URL that Canvas Studio
 #    should have used.
 #
+# To make step (3) work for local development, add `hypothesis.local` as an
+# alias for `127.0.0.1` in /etc/hosts.
+#
 # [1] https://community.canvaslms.com/t5/Canvas-Developers-Group/Canvas-Studio-OAuth-authorization-does-not-send-state-parameter/td-p/596747
 @view_config(
     request_method="GET",

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -46,6 +46,7 @@ class TestFilePickerMode:
         (
             ("blackboard_config", "blackboard"),
             ("canvas_config", "canvas"),
+            ("canvas_studio_config", "canvasStudio"),
             ("google_files_config", "google"),
             ("microsoft_onedrive", "microsoftOneDrive"),
             ("vitalsource_config", "vitalSource"),

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -119,6 +119,23 @@ class TestFilePickerConfig:
 
         assert config == expected_config
 
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_canvas_studio_config(self, pyramid_request, application_instance, enabled):
+        application_instance.settings.set(
+            "canvas_studio", "client_id", "some_id" if enabled else None
+        )
+        config = FilePickerConfig.canvas_studio_config(
+            pyramid_request, application_instance
+        )
+
+        assert config["enabled"] is enabled
+
+        if enabled:
+            assert config["listMedia"] == {
+                "authUrl": "http://example.com/api/canvas_studio/oauth/authorize",
+                "path": "/api/canvas_studio/media",
+            }
+
     @pytest.mark.parametrize("enabled", (True, False))
     @pytest.mark.parametrize(
         "origin_from", (None, "custom_canvas_api_domain", "lms_url")

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -407,6 +407,7 @@ class TestSecurityPolicy:
             ("/content_item_selection", get_lti_user_from_launch_params),
             ("/canvas_oauth_callback", get_lti_user_from_oauth_callback),
             ("/api/blackboard/oauth/callback", get_lti_user_from_oauth_callback),
+            ("/api/canvas_studio/oauth/callback", get_lti_user_from_oauth_callback),
             ("/api/d2l/oauth/callback", get_lti_user_from_oauth_callback),
         ],
     )

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -83,7 +83,9 @@ class TestCanvasStudioService:
 
     @pytest.fixture
     def svc(self, pyramid_request):
-        return CanvasStudioService(pyramid_request)
+        return CanvasStudioService(
+            pyramid_request, pyramid_request.lti_user.application_instance
+        )
 
     @pytest.fixture
     def oauth_http_service(self):
@@ -165,7 +167,9 @@ class TestCanvasStudioService:
 class TestFactory:
     def test_it(self, pyramid_request, CanvasStudioService):
         result = factory(sentinel.context, pyramid_request)
-        CanvasStudioService.assert_called_once_with(pyramid_request)
+        CanvasStudioService.assert_called_once_with(
+            pyramid_request, pyramid_request.lti_user.application_instance
+        )
         assert result == CanvasStudioService.return_value
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -1,0 +1,173 @@
+from unittest.mock import create_autospec, sentinel
+from urllib.parse import urlencode
+
+import pytest
+
+from lms.services.canvas_studio import CanvasStudioService, factory
+from lms.services.oauth_http import OAuthHTTPService
+from tests import factories
+
+
+@pytest.mark.usefixtures("aes_service", "canvas_studio_settings", "oauth_http_factory")
+class TestCanvasStudioService:
+
+    def test_get_access_token(self, svc, oauth_http_service, client_secret):
+        svc.get_access_token("some_code")
+
+        oauth_http_service.get_access_token.assert_called_with(
+            "https://hypothesis.instructuremedia.com/api/public/oauth/token",
+            "http://example.com/api/canvas_studio/oauth/callback",
+            auth=("the_client_id", client_secret),
+            authorization_code="some_code",
+        )
+
+    def test_authorization_url(self, svc):
+        state = "the_callback_state"
+        auth_url = svc.authorization_url(state)
+
+        expected_query = urlencode(
+            {
+                "client_id": "the_client_id",
+                "response_type": "code",
+                "redirect_uri": svc.redirect_uri(),
+                "state": state,
+            }
+        )
+
+        assert (
+            auth_url
+            == "https://hypothesis.instructuremedia.com/api/public/oauth/authorize?"
+            + expected_query
+        )
+
+    def test_redirect_uri(self, svc):
+        assert (
+            svc.redirect_uri() == "http://example.com/api/canvas_studio/oauth/callback"
+        )
+
+    def test_list_media_library(self, svc):
+        files = svc.list_media_library()
+        assert files == [
+            {
+                "type": "Folder",
+                "display_name": "More videos",
+                "updated_at": "2024-02-01",
+                "id": "8",
+                "contents": {
+                    "path": "http://example.com/api/canvas_studio/collections/8/media"
+                },
+            },
+            {
+                "type": "File",
+                "display_name": "Test video",
+                "updated_at": "2024-02-03",
+                "id": "canvas-studio://media/5",
+            },
+        ]
+
+    def test_list_media_library_no_user_collection(self, svc, oauth_http_service):
+        oauth_http_service.get.side_effect = self.get_request_handler(collections=[])
+        files = svc.list_media_library()
+        assert files == []
+
+    def test_list_collection(self, svc):
+        files = svc.list_collection("8")
+        assert files == [
+            {
+                "type": "File",
+                "display_name": "Another video",
+                "updated_at": "2024-02-04",
+                "id": "canvas-studio://media/6",
+            }
+        ]
+
+    @pytest.fixture
+    def svc(self, pyramid_request):
+        return CanvasStudioService(pyramid_request)
+
+    @pytest.fixture
+    def oauth_http_service(self):
+        svc = create_autospec(OAuthHTTPService, spec_set=True)
+        svc.get.side_effect = self.get_request_handler()
+        return svc
+
+    def get_request_handler(self, collections=None):
+        """Create a handler for `GET` requests to the Canvas Studio API."""
+
+        def make_collection(id_, name, type_, created_at):
+            return {"id": id_, "name": name, "type": type_, "created_at": created_at}
+
+        def make_file(id_, title, created_at):
+            return {"id": id_, "title": title, "created_at": created_at}
+
+        if collections is None:
+            # Add default collections
+            collections = [
+                make_collection(1, "", "user", "2024-02-01"),
+                make_collection(8, "More videos", "some_type", "2024-02-01"),
+            ]
+
+        def handler(url):
+            api_prefix = "https://hypothesis.instructuremedia.com/api/public/v1/"
+            assert url.startswith(api_prefix)
+
+            url_suffix = url[len(api_prefix) :]
+            json_data = None
+
+            match url_suffix:
+                case "collections":
+                    json_data = {
+                        "collections": collections.copy(),
+                    }
+                case "collections/1/media":
+                    json_data = {
+                        "media": [
+                            make_file(5, "Test video", "2024-02-03"),
+                        ]
+                    }
+                case "collections/8/media":
+                    json_data = {
+                        "media": [
+                            make_file(6, "Another video", "2024-02-04"),
+                        ]
+                    }
+                case _:  # pragma: nocover
+                    raise ValueError(f"Unexpected URL {url}")
+
+            return factories.requests.Response(json_data=json_data)
+
+        return handler
+
+    @pytest.fixture
+    def oauth_http_factory(self, oauth_http_service, patch):
+        factory = patch("lms.services.canvas_studio.oauth_http_factory")
+        factory.return_value = oauth_http_service
+        return factory
+
+    @pytest.fixture
+    def client_secret(self, pyramid_request, aes_service):
+        return pyramid_request.lti_user.application_instance.settings.get_secret(
+            aes_service, "canvas_studio", "client_secret"
+        )
+
+    @pytest.fixture
+    def canvas_studio_settings(self, pyramid_request, aes_service):
+        application_instance = pyramid_request.lti_user.application_instance
+        application_instance.settings.set("canvas_studio", "client_id", "the_client_id")
+        application_instance.settings.set(
+            "canvas_studio", "domain", "hypothesis.instructuremedia.com"
+        )
+        application_instance.settings.set_secret(
+            aes_service, "canvas_studio", "client_secret", "the_client_secret"
+        )
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, CanvasStudioService):
+        result = factory(sentinel.context, pyramid_request)
+        CanvasStudioService.assert_called_once_with(pyramid_request)
+        assert result == CanvasStudioService.return_value
+
+    @pytest.fixture(autouse=True)
+    def CanvasStudioService(self, patch):
+        return patch("lms.services.canvas_studio.CanvasStudioService")

--- a/tests/unit/lms/validation/authentication/_oauth_test.py
+++ b/tests/unit/lms/validation/authentication/_oauth_test.py
@@ -54,7 +54,19 @@ class TestOauthCallbackSchema:
         )
         assert returned == lti_user_service.deserialize.return_value
 
-    def test_lti_user_raises_if_theres_no_state_param(self, schema, pyramid_request):
+    def test_lti_user_uses_explicitly_passed_state(
+        self, schema, jwt_service, lti_user_service, pyramid_request
+    ):
+        del pyramid_request.params["state"]
+
+        returned = schema.lti_user("custom_state")
+
+        jwt_service.decode_with_secret.assert_called_once_with(
+            "custom_state", "test_oauth2_state_secret"
+        )
+        assert returned == lti_user_service.deserialize.return_value
+
+    def test_lti_user_raises_if_theres_no_state(self, schema, pyramid_request):
         del pyramid_request.params["state"]
 
         with pytest.raises(MissingStateParamError):

--- a/tests/unit/lms/views/api/canvas_studio_test.py
+++ b/tests/unit/lms/views/api/canvas_studio_test.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+import pytest
+from h_matchers import Any
+from pyramid.httpexceptions import HTTPFound
+
+import lms.views.api.canvas_studio as views
+
+
+class TestAuthorize:
+    def test_it(
+        self, pyramid_request, canvas_studio_service, OAuthCallbackSchema, set_cookie
+    ):
+        result = views.authorize(pyramid_request)
+
+        expected_state = OAuthCallbackSchema(pyramid_request).state_param()
+        OAuthCallbackSchema.assert_called_with(pyramid_request)
+        canvas_studio_service.authorization_url.assert_called_with(expected_state)
+        assert result == {
+            "redirect_url": canvas_studio_service.authorization_url.return_value,
+            "link_text": "Canvas Studio login",
+        }
+        set_cookie.assert_called_once_with("canvas_studio_oauth_state", expected_state)
+
+    def test_it_redirects_localhost(self, pyramid_request):
+        pyramid_request.host_url = "http://localhost:8001"
+        pyramid_request.url = "http://localhost:8001/api/canvas_studio/oauth/authorize"
+
+        result = views.authorize(pyramid_request)
+
+        assert result == Any.instance_of(HTTPFound).with_attrs(
+            {
+                "location": "https://hypothesis.local:48001/api/canvas_studio/oauth/authorize"
+            }
+        )
+
+    @pytest.fixture
+    def OAuthCallbackSchema(self, patch):
+        OAuthCallbackSchema = patch("lms.views.api.canvas_studio.OAuthCallbackSchema")
+        schema = OAuthCallbackSchema.return_value
+        schema.state_param.return_value = "the-state"
+        return OAuthCallbackSchema
+
+    @pytest.fixture
+    def set_cookie(self, pyramid_request):
+        with patch.object(
+            pyramid_request.response, "set_cookie", autospec=True
+        ) as patched:
+            yield patched
+
+
+def test_oauth2_redirect(pyramid_request, canvas_studio_service):
+    pyramid_request.parsed_params = {"code": "some_code"}
+    views.oauth2_redirect(pyramid_request)
+    canvas_studio_service.get_access_token.assert_called_once_with("some_code")
+
+
+def test_oauth2_redirect_missing_state(pyramid_request):
+    pyramid_request.params["code"] = "test_code"
+    pyramid_request.cookies["canvas_studio_oauth_state"] = "test_state"
+
+    redirect = views.oauth2_redirect_missing_state(pyramid_request)
+
+    expected_location = "http://example.com/api/canvas_studio/oauth/callback?code=test_code&state=test_state"
+    assert redirect == Any.instance_of(HTTPFound).with_attrs(
+        {"location": expected_location}
+    )
+
+
+def test_list_media(canvas_studio_service, pyramid_request):
+    result = views.list_media(pyramid_request)
+    assert result == canvas_studio_service.list_media_library.return_value
+
+
+def test_list_collection(canvas_studio_service, pyramid_request):
+    pyramid_request.matchdict = {"collection_id": "42"}
+
+    result = views.list_collection(pyramid_request)
+
+    canvas_studio_service.list_collection.assert_called_with("42")
+    assert result == canvas_studio_service.list_collection.return_value

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -16,6 +16,7 @@ from lms.services.assignment import AssignmentService
 from lms.services.async_oauth_http import AsyncOAuthHTTPService
 from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
+from lms.services.canvas_studio import CanvasStudioService
 from lms.services.course import CourseService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.digest import DigestService
@@ -60,6 +61,7 @@ __all__ = (
     "blackboard_api_client",
     "canvas_api_client",
     "canvas_service",
+    "canvas_studio_service",
     "course_service",
     "d2l_api_client",
     "digest_service",
@@ -165,6 +167,11 @@ def canvas_service(mock_service, canvas_api_client):
     canvas_service.api = canvas_api_client
 
     return canvas_service
+
+
+@pytest.fixture
+def canvas_studio_service(mock_service):
+    return mock_service(CanvasStudioService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Implement the necessary pieces to enable authorizing with Canvas Studio and selecting a video from Canvas Studio in the content picker. Launching a Canvas Studio assignment is not yet implemented and will follow separately.

This includes:

 - Support for fetching, saving and reading access tokens for OAuth-based APIs other than the LMSs main API in `OAuth2TokenService` and `OAuthHTTPService`. Note that _refreshing_ of access tokens is not yet implemented. That will follow separately.

 - A `CanvasStudioService` service which exposes methods to handle the OAuth authentication flow for Canvas Studio and list media files and collections available to the user.

 - A set of API views for Canvas Studio authorization and listing videos. The Canvas Studio authorization currently needs some workarounds for limitations with their OAuth implementation. These issues and workarounds are documented in comments in `lms/views/api/canvas_studio.py`.

 - A minimal implementation of listing media from Canvas Studio using the existing file picker components. These components have not yet been customized for video and still use the term "pages" in the dialog, although it is showing media from Canvas Studio.

**Testing:**

Before testing locally, you will need to set up `hypothesis.local` as an alias for `localhost`. This can be done by adding the following to `/etc/hosts`:

```
# Added for testing Hypothesis local dev server with third-party services that
# don't allow `localhost` URLs in certain contexts.
127.0.0.1 hypothesis.local
```

Also make sure you have Canvas Studio settings (domain, client ID, client secret) configured for the Canvas test instance (http://localhost:8001/admin/instance/8/settings). See https://github.com/hypothesis/devdata/pull/105.

Then test as follows:

1. Log in to our Canvas instance and select the "Studio" link at the bottom of the toolbar on the left hand side
2. Select the media record or upload options and either record a short video or audio clip or upload one
3. Open the newly added media in Canvas Studio and select the "Captions" tab. Request generation of captions. This will take a few seconds.
4. Create a new Hypothesis assignment. In the file picker you should see a "Canvas Studio" option. Select this.
5. When the authorization popup appears, the URL will redirect from http://localhost:8001 to https://hypothesis.local:48001. You will need to bypass Chrome's SSL warning screen to continue. This only happens in development.
6. After completing the authorization flow, your newly added video should be listed in the picker. Select it.
7. After selecting a video, the file picker summary screen will show "Canvas Studio video: {title}".