### PR TITLE
Moodle API integration error handling

### DIFF
--- a/lms/product/moodle/_plugin/grouping.py
+++ b/lms/product/moodle/_plugin/grouping.py
@@ -34,7 +34,11 @@ class MoodleGroupingPlugin(GroupingPlugin):
             ):
                 return learner_groups
         except ExternalRequestError as exc:
-            if exc.status_code == 404:
+            if (
+                exc.validation_errors
+                # There are no error codes in Moodle's APIs
+                and exc.validation_errors.get("errorcode") == "invalidrecord"
+            ):
                 raise GroupError(
                     ErrorCodes.GROUP_SET_NOT_FOUND, group_set=group_set_id
                 ) from exc
@@ -54,7 +58,11 @@ class MoodleGroupingPlugin(GroupingPlugin):
         try:
             groups = self._api.group_set_groups(int(course.lms_id), group_set_id)
         except ExternalRequestError as exc:
-            if exc.status_code == 404:
+            if (
+                exc.validation_errors
+                # There are no semantic HTTP error codes in Moodle's APIs
+                and exc.validation_errors.get("errorcode") == "invalidrecord"
+            ):
                 raise GroupError(
                     ErrorCodes.GROUP_SET_NOT_FOUND, group_set=group_set_id
                 ) from exc

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -107,6 +107,16 @@ class MoodleAPIClient:
         )
         return file_tree
 
+    def file_exists(self, file_id) -> bool:
+        """Check if the file exists in the course."""
+        # Moodle file IDs are URLs, but they need the token to be accessible
+        response = self._http.request("HEAD", f"{file_id}&token={self.token}")
+        # Moodle API doesn't use status codes, we can't rely on that.
+        # We don't want to download the full file so we'll do a HEAD request and assume:
+        #   - JSON response, it's an error response
+        #   - Anything else, it's  the file we are after
+        return not response.headers["content-type"].startswith("application/json")
+
     def page(self, course_id, page_id) -> dict | None:
         url = self._api_url(Function.GET_PAGES)
         url = f"{url}&courseids[0]={course_id}"

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -6,12 +6,19 @@ from lms.services.http import HTTPService
 
 class Function(str, Enum):
     GET_COURSE_GROUPINGS = "core_group_get_course_groupings"
+    """Returns all groupings in specified course."""
+
     GET_GROUPINGS = "core_group_get_groupings"
+    """Return grouping details."""
+
     GET_USER_GROUPS = "core_group_get_course_user_groups"
+    """Returns all groups in specified course for the specified user."""
 
     GET_COURSE_CONTENTS = "core_course_get_contents"
+    """Get course contents."""
 
     GET_PAGES = "mod_page_get_pages_by_courses"
+    """Returns a list of pages in a provided list of courses."""
 
 
 class MoodleAPIClient:

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -35,6 +35,7 @@ def list_files(_context, request):
     permission=Permissions.API,
 )
 def via_url(_context, request):
+    api = request.find_service(MoodleAPIClient)
     course_copy_plugin = request.product.plugin.course_copy
 
     current_course_id = request.lti_user.lti.course_id
@@ -49,10 +50,13 @@ def via_url(_context, request):
         course_copy_plugin, course, document_url, document_course_id, document_file_id
     )
 
-    token = request.find_service(MoodleAPIClient).token
+    # Try to access the file, we have to check that we have indeed access to this file.
+    if not api.file_exists(effective_file_id):
+        raise FileNotFoundInCourse("moodle_file_not_found_in_course", document_url)
+
     return {
         "via_url": helpers.via_url(
-            request, effective_file_id, content_type="pdf", query={"token": token}
+            request, effective_file_id, content_type="pdf", query={"token": api.token}
         )
     }
 

--- a/lms/views/api/moodle/pages.py
+++ b/lms/views/api/moodle/pages.py
@@ -56,7 +56,7 @@ class PagesAPIViews:
         )
 
         # Try to access the page
-        # We don't need the  result of this exact call but
+        # We don't need the result of this exact call but
         # we can check that we have indeed access to this page.
         if not self.api.page(current_course.lms_id, effective_page_id):
             raise PageNotFoundInCourse("moodle_page_not_found_in_course", document_url)

--- a/lms/views/api/moodle/pages.py
+++ b/lms/views/api/moodle/pages.py
@@ -55,6 +55,12 @@ class PagesAPIViews:
             document_page_id,
         )
 
+        # Try to access the page
+        # We don't need the  result of this exact call but
+        # we can check that we have indeed access to this page.
+        if not self.api.page(current_course.lms_id, effective_page_id):
+            raise PageNotFoundInCourse("moodle_page_not_found_in_course", document_url)
+
         # We build a token to authorize the view that fetches the actual
         # pages content as the user making this request.
         auth_token = BearerTokenSchema(self.request).authorization_param(

--- a/tests/unit/lms/product/moodle/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/grouping_test.py
@@ -46,7 +46,7 @@ class TestMoodleGroupingPlugin:
         self, moodle_api_client, plugin, grouping_service, course
     ):
         moodle_api_client.groups_for_user.side_effect = ExternalRequestError(
-            response=Mock(status_code=404)
+            validation_errors={"errorcode": "invalidrecord"}
         )
 
         with pytest.raises(GroupError) as err:
@@ -108,7 +108,7 @@ class TestMoodleGroupingPlugin:
         self, moodle_api_client, plugin, grouping_service, course
     ):
         moodle_api_client.group_set_groups.side_effect = ExternalRequestError(
-            response=Mock(status_code=404)
+            validation_errors={"errorcode": "invalidrecord"}
         )
 
         with pytest.raises(GroupError) as err:

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import create_autospec, sentinel
+from unittest.mock import Mock, create_autospec, sentinel
 
 import pytest
 
@@ -145,6 +145,20 @@ class TestMoodleAPIClient:
                 ],
             }
         ]
+
+    @pytest.mark.parametrize(
+        "header,expected",
+        [
+            ("application/json", False),
+            ("application/pdf", True),
+        ],
+    )
+    def test_file_exists(self, svc, http_service, header, expected):
+        http_service.request.return_value = Mock(headers={"content-type": header})
+
+        assert svc.file_exists("URL") == expected
+
+        http_service.request.assert_called_once_with("HEAD", "URL&token=sentinel.token")
 
     def test_list_pages(self, svc, http_service, contents):
         http_service.post.return_value.json.return_value = contents

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -3,10 +3,25 @@ from unittest.mock import create_autospec, sentinel
 import pytest
 
 from lms.models import ApplicationInstance
+from lms.services.exceptions import ExternalRequestError
 from lms.services.moodle import MoodleAPIClient
 
 
 class TestMoodleAPIClient:
+    def test_failed_request(self, svc, http_service):
+        http_service.post.return_value.json.return_value = {
+            "errorcode": "ERROR_CODE",
+            "message": "MESSAGE",
+        }
+
+        with pytest.raises(ExternalRequestError) as exc:
+            svc.course_group_sets("COURSE_ID")
+
+        exc.validation_errors = {
+            "errorcode": "ERROR_CODE",
+            "message": "MESSAGE",
+        }
+
     def test_course_group_sets(self, svc, http_service, group_sets):
         http_service.post.return_value.json.return_value = group_sets
 
@@ -24,7 +39,8 @@ class TestMoodleAPIClient:
         api_groups = svc.group_set_groups(100, "GROUP_SET")
 
         http_service.post.assert_called_once_with(
-            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=core_group_get_groupings&groupingids[0]=GROUP_SET&returngroups=1"
+            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=core_group_get_groupings&groupingids[0]=GROUP_SET&returngroups=1",
+            params=None,
         )
         assert api_groups == [
             {"id": g["id"], "name": g["name"], "group_set_id": "GROUP_SET"}
@@ -37,7 +53,8 @@ class TestMoodleAPIClient:
         api_groups = svc.groups_for_user("COURSE_ID", "GROUP_SET", "USER_ID")
 
         http_service.post.assert_called_once_with(
-            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=core_group_get_course_user_groups&groupingid=GROUP_SET&userid=USER_ID&courseid=COURSE_ID"
+            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=core_group_get_course_user_groups&groupingid=GROUP_SET&userid=USER_ID&courseid=COURSE_ID",
+            params=None,
         )
         assert api_groups == [
             {"id": g["id"], "name": g["name"], "group_set_id": "GROUP_SET"}
@@ -66,7 +83,8 @@ class TestMoodleAPIClient:
         page = svc.page("COURSE_ID", "1")
 
         http_service.post.assert_called_once_with(
-            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=mod_page_get_pages_by_courses&courseids[0]=COURSE_ID"
+            "sentinel.lms_url/webservice/rest/server.php?wstoken=sentinel.token&moodlewsrestformat=json&wsfunction=mod_page_get_pages_by_courses&courseids[0]=COURSE_ID",
+            params=None,
         )
         assert page == {
             "id": "ID 1",

--- a/tests/unit/lms/views/api/moodle/files_test.py
+++ b/tests/unit/lms/views/api/moodle/files_test.py
@@ -68,6 +68,7 @@ def test_via_url_copied_with_mapped_id(
     assert response == {"via_url": helpers.via_url.return_value}
 
 
+@pytest.mark.usefixtures("moodle_api_client")
 def test_via_url_copied_no_page_found(
     pyramid_request,
     course_service,

--- a/tests/unit/lms/views/api/moodle/files_test.py
+++ b/tests/unit/lms/views/api/moodle/files_test.py
@@ -41,6 +41,21 @@ def test_via_url(
 
 
 @pytest.mark.usefixtures("course_copy_plugin")
+def test_via_url_deleted_file(
+    moodle_api_client, pyramid_request, lti_user, course_service
+):
+    type(moodle_api_client).token = "TOKEN"
+    lti_user.lti.course_id = course_service.get_by_context_id.return_value.lms_id = (
+        "COURSE_ID"
+    )
+    moodle_api_client.file_exists.return_value = False
+    pyramid_request.params["document_url"] = "moodle://file/course/COURSE_ID/url/URL"
+
+    with pytest.raises(FileNotFoundInCourse):
+        via_url(sentinel.context, pyramid_request)
+
+
+@pytest.mark.usefixtures("course_copy_plugin")
 def test_via_url_copied_with_mapped_id(
     helpers,
     pyramid_request,


### PR DESCRIPTION
## Testing

I created a few test assignments to reproduce these scenarios. These all return the correct error code but it still displayed a generic error. We'd need wording and KD articles to link to before having the final dialogs.

- [localhost - Group assignment - Grouping without groups](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=862)

- [localhost - Group assignment - Deleted group](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=918)

- [localhost - Page assignment - Deleted page](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=917)

- [localhost - Deleted Moodle file](https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=916)