### PR TITLE
Check GUID naming to guess the current product family.

### DIFF
--- a/lms/product/factory.py
+++ b/lms/product/factory.py
@@ -44,6 +44,10 @@ def _get_family(
     if "custom_canvas_course_id" in request.lti_params:
         return Product.Family.CANVAS
 
+    # Another canvas-only fix, when the API params are not correctly set use the GUID
+    if request.lti_params.get("tool_consumer_instance_guid", "").endswith("canvas-lms"):
+        return Product.Family.CANVAS
+
     # Finally try to match using the stored family_code in the application instance
     # We use this in LTIOutcomesViews
     if application_instance:


### PR DESCRIPTION
Some canvas instances are both missing the family LMS parameter and the custom course variable.

Use the guid value to guess canvas based as another heuristic.


## Testing

[Checking these values in the DB](https://metabase.hypothes.is/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgKiBmcm9tIGFwcGxpY2F0aW9uX2luc3RhbmNlcyB3aGVyZSB0b29sX2NvbnN1bWVyX2luc3RhbmNlX2d1aWQgbGlrZSAnJWNhbnZhcy1sbXMnIGFuZCB0b29sX2NvbnN1bWVyX2luZm9fcHJvZHVjdF9mYW1pbHlfY29kZSA8PiAnY2FudmFzJyIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjd9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)