### PR TITLE
Implement Canvas Studio access token refresh

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -137,6 +137,9 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "canvas_studio_api.oauth.callback", "/api/canvas_studio/oauth/callback"
     )
+    config.add_route(
+        "canvas_studio_api.oauth.refresh", "/api/canvas_studio/oauth/refresh"
+    )
     config.add_route("canvas_studio_api.media.list", "/api/canvas_studio/media")
     config.add_route(
         "canvas_studio_api.collections.media.list",

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, TypedDict
+from typing import Literal, TypedDict
 from urllib.parse import urlencode, urlunparse
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
@@ -61,7 +61,7 @@ class File(TypedDict):
     display_name: str
     updated_at: str
 
-    contents: Optional[APICallInfo]
+    contents: APICallInfo | None
     """API call to use to fetch contents of a folder."""
 
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from lms.models.oauth2_token import Service
+
+
 class JWTError(Exception):
     """A problem with a JWT."""
 
@@ -17,6 +22,15 @@ class ExternalRequestError(Exception):
     :arg message: A short error message for displaying to the user
     :type message: str
 
+    :arg refreshable: True if the error can be fixed by refreshing an access token
+    :arg refresh_route:
+        If `refreshable` is True, the name of the API route that should be
+        invoked to perform the token refresh. If `None`, the default route for
+        the current LMS is used.
+    :arg refresh_service:
+        If `refreshable` is True, the API service whose token should be refreshed.
+        If `None`, the LMS's main API is assumed.
+
     :arg request: The request that was sent
     :type request: requests.PreparedRequest
 
@@ -34,6 +48,8 @@ class ExternalRequestError(Exception):
         response=None,
         validation_errors=None,
         refreshable=False,
+        refresh_route: Optional[str] = None,
+        refresh_service: Optional[Service] = None,
     ):  # pylint: disable=too-many-arguments
         super().__init__()
         self.message = message
@@ -41,6 +57,8 @@ class ExternalRequestError(Exception):
         self.response = response
         self.validation_errors = validation_errors
         self.refreshable = refreshable
+        self.refresh_route = refresh_route
+        self.refresh_service = refresh_service
 
     @property
     def url(self) -> str | None:

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from lms.models.oauth2_token import Service
 
 
@@ -48,8 +46,8 @@ class ExternalRequestError(Exception):
         response=None,
         validation_errors=None,
         refreshable=False,
-        refresh_route: Optional[str] = None,
-        refresh_service: Optional[Service] = None,
+        refresh_route: str | None = None,
+        refresh_service: Service | None = None,
     ):  # pylint: disable=too-many-arguments
         super().__init__()
         self.message = message

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -93,7 +93,7 @@ class OAuthHTTPService:
         :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
-        refresh_token = self._oauth2_token_service.get().refresh_token
+        refresh_token = self._oauth2_token_service.get(self.service).refresh_token
 
         try:
             return self._token_request(

--- a/lms/views/api/canvas_studio.py
+++ b/lms/views/api/canvas_studio.py
@@ -9,6 +9,7 @@ from pyramid.view import view_config
 
 from lms.security import Permissions
 from lms.services import CanvasStudioService
+from lms.services.canvas_studio import replace_localhost_in_url
 from lms.validation.authentication import OAuthCallbackSchema
 
 
@@ -53,11 +54,9 @@ from lms.validation.authentication import OAuthCallbackSchema
     permission=Permissions.API,
 )
 def authorize(request):
-    if request.host_url == "http://localhost:8001":
-        redirect_url = request.url.replace(
-            request.host_url, "https://hypothesis.local:48001"
-        )
-        return HTTPFound(location=redirect_url)
+    updated_url = replace_localhost_in_url(request.url)
+    if updated_url != request.url:
+        return HTTPFound(location=updated_url)
 
     canvas_studio_svc = request.find_service(CanvasStudioService)
     oauth_state = OAuthCallbackSchema(request).state_param()

--- a/lms/views/api/refresh.py
+++ b/lms/views/api/refresh.py
@@ -1,6 +1,7 @@
 from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
+from lms.services.canvas_studio import CanvasStudioService
 from lms.services.d2l_api import D2LAPIClient
 
 
@@ -19,6 +20,10 @@ class RefreshViews:
         refresh_token = oauth2_token_service.get().refresh_token
 
         canvas_api_client.get_refreshed_token(refresh_token)
+
+    @view_config(route_name="canvas_studio_api.oauth.refresh")
+    def get_refreshed_token_from_canvas_studio(self):
+        self.request.find_service(CanvasStudioService).refresh_access_token()
 
     @view_config(route_name="blackboard_api.oauth.refresh")
     def get_refreshed_token_from_blackboard(self):

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -134,6 +134,7 @@ class TestOAuthHTTPService:
             sentinel.token_url, sentinel.redirect_uri, sentinel.auth
         )
 
+        oauth2_token_service.get.assert_called_once_with(svc.service)
         http_service.post.assert_called_once_with(
             sentinel.token_url,
             data={

--- a/tests/unit/lms/views/api/refresh_test.py
+++ b/tests/unit/lms/views/api/refresh_test.py
@@ -20,6 +20,11 @@ class TestRefreshViews:
 
         blackboard_api_client.refresh_access_token.assert_called_once_with()
 
+    def test_get_refreshed_token_from_canvas_studio(self, canvas_studio_service, views):
+        views.get_refreshed_token_from_canvas_studio()
+
+        canvas_studio_service.refresh_access_token.assert_called_once_with()
+
     def test_get_refreshed_token_from_d2l(self, d2l_api_client, views):
         views.get_refreshed_token_from_d2l()
 


### PR DESCRIPTION
This implements refreshing of Canvas Studio access tokens when required, in the same way as we do with access tokens for other APIs. Some changes were needed in the generic OAuth refresh code paths to handle the fact that we're not refreshing the access token of the LMS's main API.

 - Detect when API request failure to Canvas Studio can be fixed by refreshing the access token.
 - Add views and service methods to handle Canvas Studio OAuth token refresh
 - Fix an issue in `OAuthHTTPService.refresh_access_token` where the service type was not passed to `OAuth2TokenService.get`.

**Testing:**

1. Authenticate with Canvas Studio as described in https://github.com/hypothesis/lms/pull/6104
2. Invalidate the access token by running `UPDATE oauth2_token SET access_token = '' WHERE service = 'canvas_studio'` in your local lms DB
3. Create a new assignment and, with browser devtools open at the Network tab, select the Canvas Studio option

You should see a request to the `/api/canvas_studio/oauth/refresh` endpoint to refresh the access token, and then your media library should be listed.