### PR TITLE
Remove feature flag checks for `vitalsource.page_ranges` flag

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -37,7 +37,6 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("moodle", "files_enabled", asbool),
         JSONSetting("moodle", "pages_enabled", asbool),
         JSONSetting("vitalsource", "enabled", asbool),
-        JSONSetting("vitalsource", "page_ranges", asbool),
         JSONSetting("vitalsource", "user_lti_param"),
         JSONSetting("vitalsource", "user_lti_pattern"),
         JSONSetting("vitalsource", "api_key"),

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -41,7 +41,7 @@ class JSConfig:
     def _application_instance(self):
         return self._lti_user.application_instance
 
-    def add_document_url(  # pylint: disable=too-complex,too-many-branches
+    def add_document_url(  # pylint: disable=too-complex,too-many-branches,useless-suppression
         self, document_url
     ) -> None:
         """
@@ -129,11 +129,9 @@ class JSConfig:
                     document_url=document_url
                 )
 
-            if svc.page_ranges_enabled:
-                self.enable_client_feature("search_panel")
-                content_config = svc.get_client_focus_config(document_url)
-                if content_config:
-                    self._update_focus_config(content_config)
+            content_config = svc.get_client_focus_config(document_url)
+            if content_config:
+                self._update_focus_config(content_config)
 
         elif jstor_service.enabled and document_url.startswith("jstor://"):
             self._config["viaUrl"] = jstor_service.via_url(self._request, document_url)

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -160,7 +160,6 @@ class FilePickerConfig:
         svc = request.find_service(VitalSourceService)
         return {
             "enabled": svc.enabled,
-            "pageRangesEnabled": svc.page_ranges_enabled,
         }
 
     @classmethod

--- a/lms/services/vitalsource/factory.py
+++ b/lms/services/vitalsource/factory.py
@@ -17,5 +17,4 @@ def service_factory(_context, request):
         customer_client=VitalSourceClient(customer_key) if customer_key else None,
         user_lti_param=settings.get("vitalsource", "user_lti_param"),
         user_lti_pattern=settings.get("vitalsource", "user_lti_pattern"),
-        page_ranges_enabled=settings.get("vitalsource", "page_ranges", default=False),
     )

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -18,7 +18,6 @@ class VitalSourceService:
         customer_client: VitalSourceClient | None = None,
         user_lti_param: str | None = None,
         user_lti_pattern: str | None = None,
-        page_ranges_enabled: bool = False,
     ):
         """
         Initialise the service.
@@ -42,7 +41,6 @@ class VitalSourceService:
         self._sso_client = customer_client
         self._user_lti_param = user_lti_param
         self._user_lti_pattern = user_lti_pattern
-        self._page_ranges_enabled = page_ranges_enabled
 
     @property
     def enabled(self) -> bool:
@@ -55,10 +53,6 @@ class VitalSourceService:
         """Check if the service can use single sign on."""
 
         return bool(self.enabled and self._sso_client and self._user_lti_param)
-
-    @property
-    def page_ranges_enabled(self) -> bool:
-        return self._page_ranges_enabled
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -98,10 +98,7 @@ export default function ContentSelector({
         clientId: oneDriveClientId,
         redirectURI: oneDriveRedirectURI,
       },
-      vitalSource: {
-        enabled: vitalSourceEnabled,
-        pageRangesEnabled: vitalSourcePageRangesEnabled,
-      },
+      vitalSource: { enabled: vitalSourceEnabled },
       youtube: { enabled: youtubeEnabled },
     },
   } = useConfig(['api', 'filePicker']);
@@ -328,7 +325,7 @@ export default function ContentSelector({
     case 'vitalSourceBook':
       dialog = (
         <BookPicker
-          allowPageRangeSelection={vitalSourcePageRangesEnabled}
+          allowPageRangeSelection
           onCancel={cancelDialog}
           onSelectBook={selectVitalSourceBook}
         />

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -128,7 +128,6 @@ export type FilePickerConfig = {
   };
   vitalSource: {
     enabled: boolean;
-    pageRangesEnabled: boolean;
   };
 };
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -164,7 +164,6 @@
                             {{ settings_text_field('VitalSource API key', 'vitalsource', 'api_key') }}
                             {{ settings_text_field('VitalSource SSO user ID field', 'vitalsource', 'user_lti_param') }}
                             {{ settings_text_field('VitalSource SSO user ID regex', 'vitalsource', 'user_lti_pattern') }}
-                            {{ settings_checkbox("VitalSource page range selection", "vitalsource", "page_ranges") }}
                             {{ settings_checkbox('JSTOR enabled', 'jstor', 'enabled') }}
                             {{ settings_text_field('JSTOR site code', 'jstor', 'site_code') }}
                             {{ settings_checkbox("YouTube enabled", "youtube", "enabled", default=True) }}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -334,22 +334,13 @@ class TestAddDocumentURL:
             == vitalsource_service.get_book_reader_url.return_value
         )
 
-    @pytest.mark.parametrize(
-        "page_ranges_enabled,assignment_has_content_range",
-        [
-            (False, False),
-            (False, True),
-            (True, False),
-            (True, True),
-        ],
-    )
+    @pytest.mark.parametrize("assignment_has_content_range", [True, False])
     def test_vitalsource_sets_content_focus(
         self,
         js_config,
         vitalsource_service,
         course,
         assignment,
-        page_ranges_enabled,
         assignment_has_content_range,
     ):
         document_url = "vitalsource://book/bookID/book-id/page/20?end_page=30"
@@ -358,7 +349,6 @@ class TestAddDocumentURL:
         else:
             focus_config_from_url = None
 
-        vitalsource_service.page_ranges_enabled = page_ranges_enabled
         vitalsource_service.get_client_focus_config.return_value = focus_config_from_url
 
         # `add_document_url` fetches the content range, `enable_lti_launch_mode`
@@ -369,10 +359,7 @@ class TestAddDocumentURL:
         client_config = js_config.asdict()["hypothesisClient"]
         focus_config = client_config.get("focus", {})
 
-        if page_ranges_enabled:
-            assert "search_panel" in js_config.asdict()["hypothesisClient"]["features"]
-
-        if page_ranges_enabled and assignment_has_content_range:
+        if assignment_has_content_range:
             assert focus_config["page"] == "20-30"
         else:
             assert "page" not in focus_config

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -190,7 +190,6 @@ class TestFilePickerConfig:
 
         assert config == {
             "enabled": vitalsource_service.enabled,
-            "pageRangesEnabled": vitalsource_service.page_ranges_enabled,
         }
 
     @pytest.mark.parametrize("enabled", (True, False))

--- a/tests/unit/lms/services/vitalsource/factory_test.py
+++ b/tests/unit/lms/services/vitalsource/factory_test.py
@@ -29,7 +29,6 @@ class TestServiceFactory:
         ai.settings.set("vitalsource", "api_key", customer_api_key)
         if enabled:
             ai.settings.set("vitalsource", "enabled", enabled)
-        ai.settings.set("vitalsource", "page_ranges", sentinel.page_ranges_enabled)
 
         svc = service_factory(sentinel.context, pyramid_request)
 
@@ -46,7 +45,6 @@ class TestServiceFactory:
             ),
             user_lti_param=sentinel.user_lti_param,
             user_lti_pattern=sentinel.user_lti_pattern,
-            page_ranges_enabled=sentinel.page_ranges_enabled,
         )
         assert svc == VitalSourceService.return_value
 
@@ -69,7 +67,6 @@ class TestServiceFactory:
             customer_client=Any(),
             user_lti_param=Any(),
             user_lti_pattern=Any(),
-            page_ranges_enabled=Any(),
         )
 
     @pytest.fixture

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -35,10 +35,6 @@ class TestVitalSourceService:
 
         assert svc.sso_enabled == bool(enabled and customer_client and user_lti_param)
 
-    def test_page_ranges_enabled(self):
-        svc = VitalSourceService(page_ranges_enabled=sentinel.page_ranges)
-        assert svc.page_ranges_enabled == sentinel.page_ranges
-
     @pytest.mark.parametrize(
         "doc_url,reader_url",
         [


### PR DESCRIPTION
This enables VitalSource page range selection for all installs. The consequences of this are:

- When configuring a VitalSource assignment, there is the option to "Choose a chapter or page range" instead of "Pick a place to start reading"
- In the assignment, we show only annotations from the selected chapter or page range, and show a toggle button in the client to choose whether to show annotations from the rest of the book
- Existing VitalSource assignments are unaffected, and work the same as before