### PR TITLE
Add styles matching Moodle defaults for Moodle pages

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -16,6 +16,7 @@ gulp.task('build-css', () =>
   buildCSS(
     [
       './lms/static/styles/canvas_pages/canvas_pages.scss',
+      './lms/static/styles/moodle_pages/moodle_pages.scss',
       './lms/static/styles/frontend_apps.scss',
       './lms/static/styles/lms.scss',
       './lms/static/styles/ui-playground.scss',

--- a/lms/assets.ini
+++ b/lms/assets.ini
@@ -3,6 +3,9 @@
 canvas_pages_css =
   styles/canvas_pages.css
 
+moodle_pages_css =
+  styles/moodle_pages.css
+
 frontend_apps_js =
   scripts/browser_check.bundle.js
   scripts/frontend_apps.bundle.js

--- a/lms/static/styles/moodle_pages/moodle_pages.scss
+++ b/lms/static/styles/moodle_pages/moodle_pages.scss
@@ -1,0 +1,237 @@
+// This stylesheet contains a re-implementation of some of Moodle styles for
+// pages, so that Moodle pages served through our LMS app + Via look close to
+// how the page looks in Moodle.
+//
+// The markup generated for pages does not include specific classes, so we only
+// need to define styles for HTML elements.
+//
+// The styles defined here are mainly extracted from the following Moodle files:
+// * Base definition:
+//   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/bootstrap/_reboot.scss
+// * Variables:
+//   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/preset/default.scss
+//   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/bootstrap/_variables.scss
+
+// These are some of the sass variables defined in the files mentioned above:
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+  'Helvetica Neue', Arial, 'Noto Sans', 'Liberation Sans', sans-serif,
+  'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+$font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas,
+  'Liberation Mono', 'Courier New', monospace;
+$font-size-base: 0.9375rem;
+$gray-600: #6a737b;
+$gray-900: #1d2125;
+$link-color: #ec7f13;
+$link-hover-color: darken($link-color, 15%);
+
+body {
+  font-family: $font-family-sans-serif;
+  font-size: $font-size-base;
+  line-height: 1.5;
+  color: $gray-900;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol,
+ul,
+dl {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+}
+
+blockquote {
+  margin: 0 0 1rem;
+}
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+a {
+  color: $link-color;
+  text-decoration: none;
+  background-color: transparent;
+
+  &:hover {
+    color: $link-hover-color;
+    text-decoration: underline;
+  }
+}
+
+a:not([href]):not([class]) {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+pre,
+code,
+kbd,
+samp {
+  font-family: $font-family-monospace;
+  font-size: 1em;
+}
+
+pre {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto;
+  -ms-overflow-style: scrollbar;
+}
+
+figure {
+  margin: 0 0 1rem;
+}
+
+img {
+  vertical-align: middle;
+  border-style: none;
+}
+
+svg {
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+caption {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: $gray-600;
+  text-align: left;
+  caption-side: bottom;
+}
+
+th {
+  text-align: inherit;
+  text-align: -webkit-match-parent;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: 2.34375rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(1.044375rem + 1.7325vw);
+  }
+}
+
+h2 {
+  font-size: 1.875rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(0.9975rem + 1.17vw);
+  }
+}
+
+h3 {
+  font-size: 1.640625rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(0.9740625rem + 0.88875vw);
+  }
+}
+
+h4 {
+  font-size: 1.40625rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(0.950625rem + 0.6075vw);
+  }
+}
+
+h5 {
+  font-size: 1.171875rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(0.9271875rem + 0.32625vw);
+  }
+}
+
+h6 {
+  font-size: 0.9375rem;
+
+  @media (max-width: 1200px) {
+    font-size: calc(0.90375rem + 0.045vw);
+  }
+}
+
+hr {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+small {
+  font-size: 0.875em;
+  font-weight: 400;
+}

--- a/lms/templates/api/moodle/page.html.jinja2
+++ b/lms/templates/api/moodle/page.html.jinja2
@@ -3,12 +3,13 @@
   <head>
     <meta charset=utf-8>
     <link rel="canonical" href="{{canonical_url}}" />
+    {% for url in asset_urls("moodle_pages_css") %}
+      <link rel="stylesheet" href="{{ url }}">
+    {% endfor %}
     <title>{{title}}</title>
   </head>
   <body>
-    <main class="user-content">
-      <h1 class="page-title">{{title}}</h1>
-      {{body|safe}}
-    </main>
+    <h1>{{title}}</h1>
+    {{body|safe}}
   </body>
 </html>


### PR DESCRIPTION
Following what was done in https://github.com/hypothesis/lms/pull/5761 for Canvas Pages, this PR defines some basic styles to make pages loaded in assignments look as close as possible to Moodle Pages loaded inside Moodle itself.

Moodle seems to have a single `all` stylesheet that's apparently the server-side merging of a bunch of stylesheets and served in a single `/theme/styles.php/boost/{timestamp}/all` URL.

I observed pages do not add any classes to the generated markup, but only a few inlined styles. Based on that I took the bare minimum from that `all` stylesheet so that it looks close enough, which in essence only includes styles applied directly to tags.

### Testing steps

1. Check out this branch.
2. If your LMS server is already running, run `yarn gulp build-css`
3. Open this Moodle page: https://hypothesisuniversity.moodlecloud.com/mod/page/view.php?id=860&forceview=1
4. Open this Moodle assignment, which uses that page: https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=865
5. Check that styles are close enough.

### TODO

- [x] Simplify styles as much as possible
- [x] Find out if styles in Moodle instances can be customized (colors and such) -> I could not find this anyway in settings and such. That doesn't mean this is not possible in self-hosted Moodle instances. 