### PR TITLE
Allow editing and deep linking in Moodle

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -74,6 +74,9 @@ class Assignment(CreatedUpdatedMixin, Base):
     description = sa.Column(sa.Unicode, nullable=True)
     """The resource link description from LTI params."""
 
+    deep_linking_uuid = sa.Column(sa.Unicode, nullable=True)
+    """UUID that identifies the deep linking that created this assignment."""
+
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)
 

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -112,11 +112,6 @@ class CanvasGroupingPlugin(GroupingPlugin):
 
         return course.settings.get("canvas", "sections_enabled")
 
-    def get_group_set_id(self, request, _assignment, historical_assignment=None):
-        # For canvas we add parameter to the launch URL as we don't store the
-        # assignment during deep linking.
-        return request.params.get("group_set")
-
     def _custom_course_id(self, course):
         return course.extra["canvas"]["custom_canvas_course_id"]
 

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -2,7 +2,8 @@ import re
 from functools import lru_cache
 from urllib.parse import unquote, urlencode, urlparse
 
-from lms.product.plugin.misc import MiscPlugin
+from lms.models import Assignment
+from lms.product.plugin.misc import AssignmentConfig, MiscPlugin
 from lms.services.vitalsource import VSBookLocation
 
 
@@ -37,10 +38,23 @@ class CanvasMiscPlugin(MiscPlugin):
         if focused_user := request.params.get("focused_user"):
             js_config.set_focused_user(focused_user)
 
+    def get_assignment_configuration(
+        self,
+        request,
+        assignment: Assignment | None,
+        historical_assignment: Assignment | None,
+    ) -> AssignmentConfig:
+        document_url = self._get_document_url(request)
+
+        return {
+            "document_url": document_url,
+            # For canvas we add parameter to the launch URL as we don't store the
+            # assignment during deep linking.
+            "group_set_id": request.params.get("group_set"),
+        }
+
     @lru_cache(1)
-    def get_document_url(
-        self, request, assignment, historical_assignment
-    ) -> str | None:
+    def _get_document_url(self, request) -> str | None:
         """
         Get the configured document for this LTI launch.
 

--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -2,6 +2,41 @@ from lms.product.plugin.misc import MiscPlugin
 
 
 class MoodleMiscPlugin(MiscPlugin):
+    def get_document_url(
+        self, request, assignment, _historical_assignment
+    ) -> str | None:
+        """Get a document URL from an assignment launch."""
+
+        deep_linked_config = self.get_deep_linked_assignment_configuration(request)
+
+        if (
+            # We found an assignment that corresponds to this launch on the DB
+            assignment
+            # that assignment was originally deep linked
+            and assignment.deep_linking_uuid
+            # the UUID we generated on the deep link doesn't match our record in the DB
+            and assignment.deep_linking_uuid
+            != deep_linked_config.get("deep_linking_uuid")
+        ):
+            # The assignment must have been re-deep-linked in Moodle our our DB record is outdated
+            # Update our uuid so we can trust our DB again
+            assignment.deep_linking_uuid = deep_linked_config.get("deep_linking_uuid")
+            # Get the URL from the DL
+            return deep_linked_config.get("url")
+
+        if assignment:
+            # In other cases, if we have a record of the assignment in our DB, trust that info.
+            return assignment.document_url
+
+        # In other LMSes we'd look at historical_assignment here.
+        # Moodle doesn't support resource_link_id so we will never have an historical_assignment
+
+        # If we don't have an assignment in the DB this means
+        # - This is the first launch of a deep linked assignment, get the info from the DL.
+        # - This install doesn't use deep linking, rely on `.get`'s default to return None.
+        #     That will make this an "un_configured assignment" and we'll show the file picker.
+        return deep_linked_config.get("url")
+
     @classmethod
     def factory(cls, _context, request):  # pragma: no cover
         return cls()

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -87,22 +87,9 @@ class GroupingPlugin:
         is only relevant to get the config when creating an assignment for the
         first time.
         """
-        if not self.group_type:
-            # Groups not enabled on this product
-            return None
-
-        if assignment:
-            return assignment.extra.get("group_set_id")
-
-        if historical_assignment:
-            # When creating new assignments, take the value from the previous
-            # version of the assignment
-            return historical_assignment.extra.get("group_set_id")
-
-        # For LMS that also supports deep linking, use that as the last fallback
-        return request.product.plugin.misc.get_deep_linked_assignment_configuration(
-            request
-        ).get("group_set")
+        return request.product.plugin.misc.get_assignment_configuration(
+            request, assignment, historical_assignment
+        ).get("group_set_id")
 
 
 class GroupError(Exception):

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -80,7 +80,7 @@ class MiscPlugin:
     def get_deep_linked_assignment_configuration(self, request) -> dict:
         """Get the configuration of an assignment that was original deep linked."""
         params = {}
-        possible_parameters = ["url", "group_set"]
+        possible_parameters = ["url", "group_set", "deep_linking_uuid"]
 
         for param in possible_parameters:
             # Get the value from the custom parameters set during deep linking

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -133,6 +133,13 @@ class AssignmentService:
             # copied this one from. Reference this in the DB.
             assignment.copied_from = historical_assignment
 
+            # If the request contains a DL UUID keep track of it on the DB
+            assignment.deep_linking_uuid = (
+                self._misc_plugin.get_deep_linked_assignment_configuration(request).get(
+                    "deep_linking_uuid"
+                )
+            )
+
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -18,10 +18,9 @@ LOG = logging.getLogger(__name__)
 class AssignmentService:
     """A service for getting and setting assignments."""
 
-    def __init__(self, db: Session, misc_plugin, grouping_plugin):
+    def __init__(self, db: Session, misc_plugin):
         self._db = db
         self._misc_plugin = misc_plugin
-        self._grouping_plugin = grouping_plugin
 
     def get_assignment(self, tool_consumer_instance_guid, resource_link_id):
         """Get an assignment by resource_link_id."""
@@ -108,12 +107,11 @@ class AssignmentService:
 
         # Get the configuration for the assignment
         # it might be based on the assignments we just queried or the request
-        document_url = self._misc_plugin.get_document_url(
+        assignment_config = self._misc_plugin.get_assignment_configuration(
             request, assignment, historical_assignment
         )
-        group_set_id = self._grouping_plugin.get_group_set_id(
-            request, assignment, historical_assignment
-        )
+        document_url = assignment_config.get("document_url")
+        group_set_id = assignment_config.get("group_set_id")
 
         if not document_url:
             # We can't find a document_url, we shouldn't try to create an
@@ -200,8 +198,4 @@ class AssignmentService:
 
 
 def factory(_context, request):
-    return AssignmentService(
-        db=request.db,
-        misc_plugin=request.product.plugin.misc,
-        grouping_plugin=request.product.plugin.grouping,
-    )
+    return AssignmentService(db=request.db, misc_plugin=request.product.plugin.misc)

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -241,7 +241,11 @@ class DeepLinkingFieldsViews:
         """Turn front-end content information into assignment configuration."""
         content = request.parsed_params["content"]
 
-        params = {}
+        params = {
+            # Always include a UUID in the parameters.
+            # This will identify this DL attempt uniquely.
+            "deep_linking_uuid": uuid.uuid4().hex,
+        }
 
         if group_set := request.parsed_params.get("group_set"):
             params["group_set"] = group_set

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -191,11 +191,6 @@ class TestCanvasGroupingPlugin:
             == enabled
         )
 
-    def test_get_group_set_id(self, pyramid_request, plugin):
-        pyramid_request.params.update({"group_set": 1})
-
-        assert plugin.get_group_set_id(pyramid_request, sentinel.assignment) == 1
-
     def test_factory(self, pyramid_request, canvas_api_client):
         plugin = CanvasGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, CanvasGroupingPlugin)

--- a/tests/unit/lms/product/moodle/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/grouping_test.py
@@ -128,13 +128,6 @@ class TestMoodleGroupingPlugin:
             )
         assert err.value.error_code == ErrorCodes.GROUP_SET_EMPTY
 
-    def test_get_group_set_id_when_no_assignment(
-        self, plugin, pyramid_request, misc_plugin
-    ):
-        misc_plugin.get_deep_linked_assignment_configuration.return_value = {}
-
-        assert not plugin.get_group_set_id(pyramid_request, None, None)
-
     def test_factory(self, pyramid_request, moodle_api_client):
         plugin = MoodleGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, MoodleGroupingPlugin)

--- a/tests/unit/lms/product/moodle/_plugin/misc_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/misc_test.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch, sentinel
+
+import pytest
+
+from lms.product.moodle._plugin.misc import MoodleMiscPlugin
+from tests import factories
+
+
+class TestMoodlePlugin:
+    def test_get_assignment_configuration_outdated_db_info(
+        self, plugin, pyramid_request, get_deep_linked_assignment_configuration
+    ):
+        assignment = factories.Assignment(
+            document_url=sentinel.db_document_url,
+            extra={"group_set_id": sentinel.db_group_set_id},
+            deep_linking_uuid=sentinel.old_dl_uuid,
+        )
+        get_deep_linked_assignment_configuration.return_value = {
+            "url": sentinel.dl_document_url,
+            "group_set": sentinel.dl_group_set_id,
+            "deep_linking_uuid": sentinel.new_dl_uuid,
+        }
+
+        result = plugin.get_assignment_configuration(
+            pyramid_request, assignment, sentinel.historical_assignment
+        )
+
+        assert result == {
+            "document_url": sentinel.dl_document_url,
+            "group_set_id": sentinel.dl_group_set_id,
+        }
+        assert assignment.deep_linking_uuid == sentinel.new_dl_uuid
+
+    def test_get_assignment_configuration_with_assignment_in_db_existing_assignment(
+        self, plugin, pyramid_request
+    ):
+        assignment = factories.Assignment(
+            document_url=sentinel.document_url,
+            extra={"group_set_id": sentinel.group_set_id},
+        )
+
+        result = plugin.get_assignment_configuration(
+            pyramid_request, assignment, sentinel.historical_assignment
+        )
+
+        assert result == {
+            "document_url": sentinel.document_url,
+            "group_set_id": sentinel.group_set_id,
+        }
+
+    def test_get_assignment_configuration_deep_linked_fallback(
+        self, plugin, get_deep_linked_assignment_configuration
+    ):
+        get_deep_linked_assignment_configuration.return_value = {
+            "url": sentinel.url,
+            "group_set": sentinel.group_set_id,
+        }
+
+        result = plugin.get_assignment_configuration(sentinel.request, None, None)
+
+        assert result == {
+            "document_url": sentinel.url,
+            "group_set_id": sentinel.group_set_id,
+        }
+
+    @pytest.fixture
+    def plugin(self):
+        return MoodleMiscPlugin()
+
+    @pytest.fixture
+    def get_deep_linked_assignment_configuration(self, plugin):
+        with patch.object(
+            plugin, "get_deep_linked_assignment_configuration", autospec=True
+        ) as patched:
+            yield patched

--- a/tests/unit/lms/product/plugin/grouping_test.py
+++ b/tests/unit/lms/product/plugin/grouping_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from lms.models import Grouping
 from lms.product.plugin.grouping import GroupingPlugin
-from tests import factories
 
 
 class TestGroupingPlugin:
@@ -21,61 +20,21 @@ class TestGroupingPlugin:
             == expected
         )
 
-    def test_get_group_set_id_when_disabled(
-        self, plugin_without_groups, pyramid_request
-    ):
-        assert not plugin_without_groups.get_group_set_id(
-            pyramid_request, sentinel.assignment
+    def test_get_group_set_id_when_disabled(self, misc_plugin, plugin, pyramid_request):
+        group_set_id = plugin.get_group_set_id(
+            pyramid_request, sentinel.assignment, sentinel.historical_assignment
         )
 
-    @pytest.mark.usefixtures("with_non_deep_linked_group_set")
-    def test_get_group_set_id_when_no_assignment(self, plugin, pyramid_request):
-        assert not plugin.get_group_set_id(pyramid_request, None)
-
-    def test_get_group_set_id_when_no_group_set(self, plugin, pyramid_request):
-        assignment = factories.Assignment(extra={})
-
-        assert not plugin.get_group_set_id(pyramid_request, assignment, None)
-
-    def test_get_group_set_id_from_historical_assignment(self, plugin, pyramid_request):
-        historical_assignment = factories.Assignment(
-            extra={"group_set_id": sentinel.id}
+        misc_plugin.get_assignment_configuration.assert_called_once_with(
+            pyramid_request, sentinel.assignment, sentinel.historical_assignment
         )
-
         assert (
-            plugin.get_group_set_id(pyramid_request, None, historical_assignment)
-            == sentinel.id
+            group_set_id
+            == misc_plugin.get_assignment_configuration.return_value.get.return_value
         )
-
-    def test_get_group_set_id(self, plugin, pyramid_request):
-        assignment = factories.Assignment(extra={"group_set_id": sentinel.id})
-
-        assert plugin.get_group_set_id(pyramid_request, assignment) == sentinel.id
-
-    @pytest.mark.usefixtures("with_deep_linked_group_set")
-    def test_get_group_set_id_from_deep_linking(self, plugin, pyramid_request):
-        assert (
-            plugin.get_group_set_id(pyramid_request, None, None)
-            == sentinel.deep_linked_id
-        )
-
-    @pytest.fixture
-    def with_deep_linked_group_set(self, misc_plugin):
-        misc_plugin.get_deep_linked_assignment_configuration.return_value = {
-            "group_set": sentinel.deep_linked_id
-        }
-
-    @pytest.fixture
-    def with_non_deep_linked_group_set(self, misc_plugin):
-        misc_plugin.get_deep_linked_assignment_configuration.return_value = {}
 
     @pytest.fixture
     def plugin(self):
         plugin = GroupingPlugin()
         plugin.group_type = Grouping.Type.BLACKBOARD_GROUP
-        return plugin
-
-    @pytest.fixture
-    def plugin_without_groups(self, plugin):
-        plugin.group_type = None
         return plugin

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -31,36 +31,47 @@ class TestMiscPlugin:
     def test_get_ltia_aud_claim(self, plugin, lti_registration):
         assert plugin.get_ltia_aud_claim(lti_registration) == lti_registration.token_url
 
-    def test_get_document_url_with_assignment_in_db_existing_assignment(
+    def test_get_assignment_configuration_with_assignment_in_db_existing_assignment(
         self, plugin, pyramid_request
     ):
         assignment = factories.Assignment(document_url=sentinel.document_url)
         pyramid_request.lti_params["resource_link_id"] = sentinel.link_id
 
-        result = plugin.get_document_url(
+        result = plugin.get_assignment_configuration(
             pyramid_request, assignment, sentinel.historical_assignment
         )
 
-        assert result == sentinel.document_url
+        assert result["document_url"] == sentinel.document_url
 
-    def test_get_document_url_with_assignment_in_db_copied_assignment(
+    def test_get_assignment_configuration_with_assignment_in_db_copied_assignment(
         self, plugin, pyramid_request
     ):
         historical_assignment = factories.Assignment(document_url=sentinel.document_url)
 
-        result = plugin.get_document_url(pyramid_request, None, historical_assignment)
+        result = plugin.get_assignment_configuration(
+            pyramid_request, None, historical_assignment
+        )
 
-        assert result == sentinel.document_url
+        assert result["document_url"] == sentinel.document_url
 
     def test_get_document_deep_linked_fallback(
         self, plugin, get_deep_linked_assignment_configuration
     ):
         get_deep_linked_assignment_configuration.return_value = {"url": sentinel.url}
 
-        assert plugin.get_document_url(sentinel.request, None, None) == sentinel.url
+        assert (
+            plugin.get_assignment_configuration(sentinel.request, None, None)[
+                "document_url"
+            ]
+            == sentinel.url
+        )
 
-    def test_get_document_url_with_no_document(self, plugin, pyramid_request):
-        assert not plugin.get_document_url(pyramid_request, None, None)
+    def test_get_assignment_configuration_with_no_document(
+        self, plugin, pyramid_request
+    ):
+        assert not plugin.get_assignment_configuration(pyramid_request, None, None)[
+            "document_url"
+        ]
 
     def test_get_deeplinking_launch_url(self, plugin, pyramid_request):
         assert (

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -213,19 +213,18 @@ class TestDeepLinkingFieldsView:
         ],
     )
     def test_get_assignment_configuration(
-        self,
-        content,
-        expected_from_content,
-        pyramid_request,
-        data,
-        expected,
+        self, content, expected_from_content, pyramid_request, data, expected, uuid
     ):
         pyramid_request.parsed_params.update({"content": content, **data})
 
         # pylint:disable=protected-access
         config = DeepLinkingFieldsViews._get_assignment_configuration(pyramid_request)
 
-        assert config == {**expected, **expected_from_content}
+        assert config == {
+            "deep_linking_uuid": uuid.uuid4().hex,
+            **expected,
+            **expected_from_content,
+        }
 
     def test_it_with_unknown_file_type(self, pyramid_request):
         pyramid_request.parsed_params.update({"content": {"type": "other"}})


### PR DESCRIPTION
This PR does two things:

- Enables Moodle edits using both of our editing button and re-deep-linking in the LMS.

That done mostly in this commit: https://github.com/hypothesis/lms/pull/6113/commits/51b0fe8ecb05bf947738af521dc84ae0b2808e4b

With the caveat that it's only done for `document_url`.

- Generalized "getting assignment configuration" 

Instead of having to duplicate the logic of `document_url` also for group_set_id this commit 

https://github.com/hypothesis/lms/pull/6113/commits/51b0fe8ecb05bf947738af521dc84ae0b2808e4b

centers the logic of where to get that config from in one method and then callers can decide on which part of the config they are interested. 



#### Testing

- Apply the migration from https://github.com/hypothesis/lms/pull/6114 with:

`tox -e dev --run-command 'alembic upgrade head'`


- We are going edit an assignment it with different setting, the last edit should be the one displayed. 


- Truncate assignments to start fresh: 
`docker compose exec postgres psql -U postgres -c "truncate assignment cascade;"`


- "Select content" for: https://hypothesisuniversity.moodlecloud.com/course/modedit.php?update=920&return=1

Pick "https://example.com" and no groups

- Save and display, you get the example.com URL and the course group
- Query the DB for the current state


```
docker compose exec postgres psql -U postgres -c "select deep_linking_uuid, document_url, extra->'group_set_id' from assignment;"
        deep_linking_uuid         |    document_url     | ?column? 
----------------------------------+---------------------+----------
 f526e0c68c584f08ab72954693cf3429 | https://example.com | null
(1 row)
```


- Now click "edit" on our toolbar and pick `https://arstechnica.com/` and a group set


```
docker compose exec postgres psql -U postgres -c "select deep_linking_uuid, document_url, extra->'group_set_id' from assignment;"
        deep_linking_uuid         |       document_url       | ?column? 
----------------------------------+--------------------------+----------
 f526e0c68c584f08ab72954693cf3429 | https://arstechnica.com/ | "2"
(1 row)
```


- "Select Content" on the LMS again, pick a different URL (https://www.compart.com/en/unicode/U+1F44D)  and no group set now. Save and display to launch it.



```
docker compose exec postgres psql -U postgres -c "select deep_linking_uuid, document_url, extra->'group_set_id' from assignment;"
        deep_linking_uuid         |                document_url                | ?column? 
----------------------------------+--------------------------------------------+----------
 e0c7f6a320234958a72b3faaa56f1b50 | https://www.compart.com/en/unicode/U+1F44D | null
(1 row)
```

Note the new UUID.


- Finally do another toolbar edit, new URL and groups:

```
docker compose exec postgres psql -U postgres -c "select deep_linking_uuid, document_url, extra->'group_set_id' from assignment;"
        deep_linking_uuid         |    document_url     | ?column? 
----------------------------------+---------------------+----------
 e0c7f6a320234958a72b3faaa56f1b50 | https://example.com | "2"
(1 row)
```


