### PR TITLE
Update Canvas Studio picker to use the term "video" instead of "page"

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -258,7 +258,7 @@ export default function ContentSelector({
           onCancel={cancelDialog}
           onSelectFile={selectCanvasStudio}
           missingFilesHelpLink="https://community.canvaslms.com/t5/Canvas-Studio-Guide/How-do-I-use-Canvas-Studio/ta-p/1678"
-          documentType="page"
+          documentType="video"
         />
       );
       break;
@@ -421,7 +421,7 @@ export default function ContentSelector({
         {canvasStudioEnabled && (
           <OptionButton
             data-testid="canvas-studio-button"
-            details="Canvas Studio"
+            details="Video"
             onClick={() => selectDialog('canvasStudio')}
           >
             Canvas Studio

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -259,6 +259,7 @@ export default function ContentSelector({
           onSelectFile={selectCanvasStudio}
           missingFilesHelpLink="https://community.canvaslms.com/t5/Canvas-Studio-Guide/How-do-I-use-Canvas-Studio/ta-p/1678"
           documentType="video"
+          withBreadcrumbs
         />
       );
       break;

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -26,7 +26,7 @@ type NoFilesMessageProps = {
    */
   inSubfolder: boolean;
 
-  documentType: 'file' | 'page';
+  documentType: 'file' | 'page' | 'video';
 };
 
 /**
@@ -91,7 +91,7 @@ type LMSFilePickerProps = {
    * The type of documents handled by the file picker, which can influence user-facing messages.
    * Defaults to 'file'
    */
-  documentType?: 'file' | 'page';
+  documentType?: 'file' | 'page' | 'video';
 };
 
 type FetchingState = {

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -39,10 +39,19 @@ function NoFilesMessage({
   documentType,
 }: NoFilesMessageProps) {
   const documentContext = inSubfolder ? 'folder' : 'course';
-  const action =
-    documentType === 'file'
-      ? `Upload some files to the ${documentContext}`
-      : `Create some pages in the ${documentContext}`;
+
+  let action;
+  switch (documentType) {
+    case 'file':
+      action = `Upload some files to the ${documentContext}`;
+      break;
+    case 'page':
+      action = `Create some pages in the ${documentContext}`;
+      break;
+    case 'video':
+      action = `Upload some videos to the ${documentContext}`;
+      break;
+  }
 
   return (
     <div>

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -583,6 +583,11 @@ describe('LMSFilePicker', () => {
         expectedContent:
           'There are no files in this folder. Upload some files to the folder and try again.',
       },
+      {
+        options: { documentType: 'video' },
+        expectedContent:
+          'There are no videos in this course. Upload some videos to the course and try again.',
+      },
     ].forEach(({ options, expectedContent }) => {
       it('renders no-file message with expected content', async () => {
         const noFilesMessage = await getNoFilesMessage(options);


### PR DESCRIPTION
The existing UI messages work because they use the document type enum value directly in the message, and do a naive pluralization by appending "s" (ie. "videos", "pages"). This works in English, but we'll obviously need to revise how this works to support other languages in future.

Also enable breadcrumbs for Canvas Studio so the user can navigate from a collection up to the root easily.

The icon for videos still needs updating, but I will do that separately.

<img width="682" alt="Canvas Studio file type" src="https://github.com/hypothesis/lms/assets/2458/796efd4b-6803-4dd3-a4bc-5bbc673f6662">

<img width="705" alt="Select video 2" src="https://github.com/hypothesis/lms/assets/2458/792715fc-1e86-4e95-bfe7-cc5133c1d874">

