### PR TITLE
Small improvement on Moodle pages stylesheet comment

### DIFF
--- a/lms/static/styles/moodle_pages/moodle_pages.scss
+++ b/lms/static/styles/moodle_pages/moodle_pages.scss
@@ -5,7 +5,8 @@
 // The markup generated for pages does not include specific classes, so we only
 // need to define styles for HTML elements.
 //
-// The styles defined here are mainly extracted from the following Moodle files:
+// The styles defined here have been composed both by inspecting Moodle generated
+// CSS, but also by checking the following source files:
 // * Base definition:
 //   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/bootstrap/_reboot.scss
 // * Variables:


### PR DESCRIPTION
Update the comment in `moddle_pages.scss` to indicate that its contents come from a combination of Moodle's generated CSS and Moddle's source code.