### PR TITLE
Re-enable title prompt for Moodle assignments

### DIFF
--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -2,10 +2,6 @@ from lms.product.plugin.misc import MiscPlugin
 
 
 class MoodleMiscPlugin(MiscPlugin):
-    deep_linking_prompt_for_title = False
-    # Moodle's deep linking flow is included in the activity creating one.
-    # Removing our title prompt to avoid confusion with the one in the LMS.
-
     @classmethod
     def factory(cls, _context, request):  # pragma: no cover
         return cls()


### PR DESCRIPTION
The way moodle handles the title means there's no perfect solution.

Prompting for the title is less confusing while creating new assignments but not ideal for editing.

Not prompting for the title makes both new/editing equally confusing always overriding the LMS with tour default.

Ideally we can prompt for the title with this commit and steer the instructors to use our own editing flow over the one in the LMS