### PR TITLE
Miscellaneous python typing fixes

### DIFF
--- a/lms/config.py
+++ b/lms/config.py
@@ -39,8 +39,8 @@ class _Setting:
     """The properties of a setting and how to read it."""
 
     name: str
-    read_from: str = None
-    value_mapper: Callable = None
+    read_from: str | None = None
+    value_mapper: Callable | None = None
 
     def __post_init__(self):
         if not self.read_from:

--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -127,7 +127,7 @@ class AuditTrailEvent(BaseEvent):
             )
 
     type: EventType.Type = EventType.Type.AUDIT_TRAIL
-    change: ModelChange = None
+    change: ModelChange | None = None
 
     def _get_data(self):
         """

--- a/lms/events/subscribers.py
+++ b/lms/events/subscribers.py
@@ -7,4 +7,5 @@ from lms.services import EventService
 @subscriber(BaseEvent)
 def handle_event(event: BaseEvent):
     """Record the event in the Event model's table."""
+    assert event.request
     event.request.find_service(EventService).insert_event(event)

--- a/lms/models/_mixins/public_id.py
+++ b/lms/models/_mixins/public_id.py
@@ -44,7 +44,7 @@ class PublicIdMixin:
     should be used instead which provides a fully qualified id.
     """
 
-    public_id_model_code = None
+    public_id_model_code: str | None = None
     """The short code which identifies this type of model."""
 
     @hybrid_property

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import sqlalchemy as sa
 from pyramid.settings import asbool
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -79,7 +80,7 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     organization_id = sa.Column(
         sa.Integer(), sa.ForeignKey("organization.id"), nullable=True
     )
-    organization = sa.orm.relationship("Organization")
+    organization: Mapped["Organization"] = sa.orm.relationship("Organization")
     """The organization this application instance belongs to."""
 
     name = sa.Column(sa.UnicodeText(), nullable=True)

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import sqlalchemy as sa
 from pyramid.settings import asbool
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -80,7 +80,7 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     organization_id = sa.Column(
         sa.Integer(), sa.ForeignKey("organization.id"), nullable=True
     )
-    organization: Mapped["Organization"] = sa.orm.relationship("Organization")
+    organization = sa.orm.relationship("Organization")
     """The organization this application instance belongs to."""
 
     name = sa.Column(sa.UnicodeText(), nullable=True)
@@ -97,15 +97,13 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     developer_key = sa.Column(sa.Unicode)
     developer_secret = sa.Column(sa.LargeBinary)
     aes_cipher_iv = sa.Column(sa.LargeBinary)
-    provisioning = sa.Column(
+    provisioning: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=True,
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[ApplicationSettings] = mapped_column(
         ApplicationSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -50,17 +51,16 @@ class Assignment(CreatedUpdatedMixin, Base):
     )
     """Assignment this one was copied from."""
 
-    document_url = sa.Column(sa.Unicode, nullable=False)
+    document_url: Mapped[str] = mapped_column(sa.Unicode, nullable=False)
     """The URL of the document to be annotated for this assignment."""
 
-    extra = sa.Column(
-        "extra",
+    extra: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
 
-    is_gradable = sa.Column(
+    is_gradable: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=False,
         server_default=sa.sql.expression.false(),
@@ -74,7 +74,7 @@ class Assignment(CreatedUpdatedMixin, Base):
     description = sa.Column(sa.Unicode, nullable=True)
     """The resource link description from LTI params."""
 
-    deep_linking_uuid = sa.Column(sa.Unicode, nullable=True)
+    deep_linking_uuid: Mapped[str | None] = mapped_column(sa.Unicode, nullable=True)
     """UUID that identifies the deep linking that created this assignment."""
 
     def get_canvas_mapped_file_id(self, file_id):

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models.json_settings import JSONSettings
@@ -27,8 +28,7 @@ class LegacyCourse(Base):
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -3,6 +3,7 @@ from enum import Enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base, varchar_enum
 
@@ -127,7 +128,7 @@ class EventData(Base):
     )
     event = sa.orm.relationship("Event")
 
-    data = sa.Column(
+    data: Mapped[MutableDict] = mapped_column(
         "extra",
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 
@@ -87,7 +88,9 @@ class GroupInfo(Base):
     custom_canvas_course_id = sa.Column(sa.UnicodeText())
 
     #: A dict of info about this group.
-    _info = sa.Column("info", MutableDict.as_mutable(JSONB))
+    _info: Mapped[MutableDict | None] = mapped_column(
+        "info", MutableDict.as_mutable(JSONB)
+    )
 
     @property
     def _safe_info(self):

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -3,6 +3,7 @@ from enum import Enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
@@ -113,15 +114,13 @@ class Grouping(CreatedUpdatedMixin, Base):
 
     type = varchar_enum(Type, nullable=False)
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
 
-    extra = sa.Column(
-        "extra",
+    extra: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -100,7 +100,7 @@ class JSONSettings(MutableDict):
         # pylint:disable=unsupported-assignment-operation
         super().setdefault(group, {})[key] = value
 
-    def set_secret(self, aes_service, group, key, value: str):
+    def set_secret(self, aes_service, group, key, value: str) -> None:
         """
         Store a setting as a secret.
 
@@ -112,12 +112,14 @@ class JSONSettings(MutableDict):
         :param value: The value to set
         """
         aes_iv = aes_service.build_iv()
-        value = aes_service.encrypt(aes_iv, value)
+        encrypted_value: bytes = aes_service.encrypt(aes_iv, value)
 
         # Store both the setting and the IV
         # We can't store the bytes directly in JSON so we store it as base64
         # pylint:disable=unsupported-assignment-operation
-        super().setdefault(group, {})[key] = base64.b64encode(value).decode("utf-8")
+        super().setdefault(group, {})[key] = base64.b64encode(encrypted_value).decode(
+            "utf-8"
+        )
         super().setdefault(group, {})[f"{key}_aes_iv"] = base64.b64encode(
             aes_iv
         ).decode("utf-8")

--- a/lms/models/jwt_oauth2_token.py
+++ b/lms/models/jwt_oauth2_token.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -44,7 +45,7 @@ class JWTOAuth2Token(CreatedUpdatedMixin, Base):
     scopes = sa.Column(sa.UnicodeText(), nullable=False)
 
     # The OAuth 2.0 access token, as received from the authorization server.
-    access_token = sa.Column(sa.UnicodeText(), nullable=False)
+    access_token: Mapped[str] = mapped_column(sa.UnicodeText(), nullable=False)
 
     # Time at which the toke will expire
-    expires_at = sa.Column(sa.DateTime, nullable=False)
+    expires_at = mapped_column(sa.DateTime, nullable=False)

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -55,7 +55,7 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
     request.lti_session or similar with contains the user and any other relevant values.
     """
 
-    application_instance: ApplicationInstance = None
+    application_instance: ApplicationInstance | None = None
     """Application instance this user belongs to"""
 
     email: str = ""

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin, PublicIdMixin
@@ -19,10 +20,10 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, Base):
     name = sa.Column(sa.UnicodeText(), nullable=True)
     """Human readable name for the organization."""
 
-    enabled = sa.Column(sa.Boolean(), nullable=False, default=True)
+    enabled: Mapped[bool] = mapped_column(sa.Boolean(), nullable=False, default=True)
     """Is this organization allowed to use LMS?"""
 
-    parent_id = sa.Column(
+    parent_id: Mapped[int | None] = mapped_column(
         sa.Integer(),
         sa.ForeignKey("organization.id", ondelete="cascade"),
         nullable=True,
@@ -39,8 +40,7 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, Base):
     )
     """Get any application instances associated with this organization."""
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/public_id.py
+++ b/lms/models/public_id.py
@@ -28,7 +28,7 @@ class PublicId:
     app_code: str = "lms"
     """Code representing the product this model is in."""
 
-    instance_id: str = None
+    instance_id: str | None = None
     """Identifier for the specific model instance."""
 
     def __post_init__(self):

--- a/lms/models/rsa_key.py
+++ b/lms/models/rsa_key.py
@@ -1,6 +1,7 @@
 import uuid
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -23,7 +24,7 @@ class RSAKey(CreatedUpdatedMixin, Base):
     aes_cipher_iv = sa.Column(sa.LargeBinary)
     """IV for the private key AES encryption"""
 
-    expired = sa.Column(
+    expired: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=False,
         server_default=sa.sql.expression.false(),

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.orm import mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -40,8 +41,8 @@ class User(CreatedUpdatedMixin, Base):
     h_userid = sa.Column(sa.Unicode, nullable=False)
     """The H userid which is created from LTI provided values."""
 
-    email = sa.Column(sa.Unicode, nullable=True)
+    email = mapped_column(sa.Unicode, nullable=True)
     """Email address of the user"""
 
-    display_name = sa.Column(sa.Unicode, nullable=True)
+    display_name = mapped_column(sa.Unicode, nullable=True)
     """The user's display name."""

--- a/lms/models/user_preferences.py
+++ b/lms/models/user_preferences.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, Unicode, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -11,7 +12,7 @@ class UserPreferences(CreatedUpdatedMixin, Base):
 
     id = Column(Integer, autoincrement=True, primary_key=True)
     h_userid = Column(Unicode, nullable=False, unique=True)
-    preferences = Column(
+    preferences: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=text("'{}'::jsonb"),
         nullable=False,

--- a/lms/product/blackboard/product.py
+++ b/lms/product/blackboard/product.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from lms.product.blackboard._plugin.course_copy import BlackboardCourseCopyPlugin
 from lms.product.blackboard._plugin.grouping import BlackboardGroupingPlugin
 from lms.product.blackboard._plugin.misc import BlackboardMiscPlugin
-from lms.product.product import PluginConfig, Product, Routes
+from lms.product.product import Family, PluginConfig, Product, Routes
 
 
 @dataclass
 class Blackboard(Product):
     """A product for Blackboard specific settings and tweaks."""
 
-    family: Product.Family = Product.Family.BLACKBOARD
+    family: Family = Family.BLACKBOARD
 
     route: Routes = Routes(
         oauth2_authorize="blackboard_api.oauth.authorize",

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from lms.product.canvas._plugin.course_copy import CanvasCourseCopyPlugin
 from lms.product.canvas._plugin.grouping import CanvasGroupingPlugin
 from lms.product.canvas._plugin.misc import CanvasMiscPlugin
-from lms.product.product import PluginConfig, Product, Routes
+from lms.product.product import Family, PluginConfig, Product, Routes
 
 
 @dataclass
 class Canvas(Product):
     """A product for Canvas specific settings and tweaks."""
 
-    family: Product.Family = Product.Family.CANVAS
+    family: Family = Family.CANVAS
 
     route: Routes = Routes(
         oauth2_authorize="canvas_api.oauth.authorize",

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from lms.product.d2l._plugin.course_copy import D2LCourseCopyPlugin
 from lms.product.d2l._plugin.grouping import D2LGroupingPlugin
 from lms.product.d2l._plugin.misc import D2LMiscPlugin
-from lms.product.product import PluginConfig, Product, Routes
+from lms.product.product import Family, PluginConfig, Product, Routes
 
 
 @dataclass
 class D2L(Product):
     """A product for D2L specific settings and tweaks."""
 
-    family: Product.Family = Product.Family.D2L
+    family: Family = Family.D2L
 
     plugin_config: PluginConfig = PluginConfig(
         grouping=D2LGroupingPlugin, misc=D2LMiscPlugin, course_copy=D2LCourseCopyPlugin

--- a/lms/product/moodle/product.py
+++ b/lms/product/moodle/product.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass
 from lms.product.moodle._plugin.course_copy import MoodleCourseCopyPlugin
 from lms.product.moodle._plugin.grouping import MoodleGroupingPlugin
 from lms.product.moodle._plugin.misc import MoodleMiscPlugin
-from lms.product.product import PluginConfig, Product, Routes
+from lms.product.product import Family, PluginConfig, Product, Routes
 
 
 @dataclass
 class Moodle(Product):
-    family: Product.Family = Product.Family.MOODLE
+    family: Family = Family.MOODLE
 
     plugin_config: PluginConfig = PluginConfig(
         grouping=MoodleGroupingPlugin,

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import cast
 
 from lms.product.plugin.course_copy import CourseCopyPlugin
 from lms.product.plugin.grouping import GroupingPlugin
@@ -31,9 +32,9 @@ class Plugins:
             setattr(instance, self.plugin_name, plugin)  # Overwrite the attr
             return plugin
 
-    grouping: GroupingPlugin = _LazyPlugin()  # type: ignore
-    course_copy: CourseCopyPlugin = _LazyPlugin()  # type:ignore
-    misc: MiscPlugin = _LazyPlugin()  # type:ignore
+    grouping = cast(GroupingPlugin, _LazyPlugin())
+    misc = cast(MiscPlugin, _LazyPlugin())
+    course_copy = cast(CourseCopyPlugin, _LazyPlugin())
 
     def __init__(self, request, plugin_config: PluginConfig):
         self._request = request

--- a/lms/product/plugin/plugin.py
+++ b/lms/product/plugin/plugin.py
@@ -31,9 +31,9 @@ class Plugins:
             setattr(instance, self.plugin_name, plugin)  # Overwrite the attr
             return plugin
 
-    grouping: GroupingPlugin = _LazyPlugin()
-    course_copy: CourseCopyPlugin = _LazyPlugin()
-    misc: MiscPlugin = _LazyPlugin()
+    grouping: GroupingPlugin = _LazyPlugin()  # type: ignore
+    course_copy: CourseCopyPlugin = _LazyPlugin()  # type:ignore
+    misc: MiscPlugin = _LazyPlugin()  # type:ignore
 
     def __init__(self, request, plugin_config: PluginConfig):
         self._request = request

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict
+from typing import Literal, Type, TypedDict
 from urllib.parse import urlencode, urljoin, urlparse, urlunparse
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
@@ -284,7 +284,7 @@ class CanvasStudioService:
 
         return None
 
-    def _api_request(self, path: str, schema_cls: RequestsResponseSchema) -> dict:
+    def _api_request(self, path: str, schema_cls: Type[RequestsResponseSchema]) -> dict:
         """Make a request to the Canvas Studio API and parse the JSON response."""
         try:
             response = self._oauth_http_service.get(self._api_url(path))

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -256,7 +256,7 @@ class SerializableError(Exception):
 
     def __init__(
         self,
-        message: str = None,
+        message: str | None = None,
         error_code: str | None = None,
         details: dict | None = None,
     ):

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,7 +7,7 @@ class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
     # This is here mostly to let auto-spec know about it in the tests
-    session: Session = None
+    session: Session
     """The underlying requests Session."""
 
     def __init__(self):

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,7 +7,7 @@ class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
     # This is here mostly to let auto-spec know about it in the tests
-    session: Session
+    session: Session = None  # typing: ignore
     """The underlying requests Session."""
 
     def __init__(self):

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,7 +7,7 @@ class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
     # This is here mostly to let auto-spec know about it in the tests
-    session: Session = None  # typing: ignore
+    session: Session = None  # type: ignore
     """The underlying requests Session."""
 
     def __init__(self):

--- a/lms/services/upsert.py
+++ b/lms/services/upsert.py
@@ -45,12 +45,12 @@ def bulk_upsert(
 
     index_elements_columns = [getattr(model_class, c) for c in index_elements]
 
-    stmt = insert(model_class).values(values)
-    stmt = stmt.on_conflict_do_update(
+    base = insert(model_class).values(values)
+    stmt = base.on_conflict_do_update(
         # The columns to use to find matching rows.
         index_elements=index_elements,
         # The columns to update.
-        set_={element: getattr(stmt.excluded, element) for element in update_columns},
+        set_={element: getattr(base.excluded, element) for element in update_columns},
     ).returning(*index_elements_columns)
 
     result = db.execute(stmt)

--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 
 import xmltodict
 from marshmallow import EXCLUDE, Schema, fields
-from requests import JSONDecodeError, Request
+from requests import JSONDecodeError, PreparedRequest
 from requests.auth import AuthBase
 
 from lms.services.exceptions import ExternalRequestError, SerializableError
@@ -244,7 +244,7 @@ class _VSUserAuth(AuthBase):
         self._client = client
         self._user_reference = user_reference
 
-    def __call__(self, request: Request) -> Request:
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
         credentials = self._client.get_user_credentials(self._user_reference)
         request.headers["X-VitalSource-Access-Token"] = credentials["access_token"]
 

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -86,9 +86,9 @@ class VitalSourceService:
         url = urlparse(url)
         params = parse_qs(url.query)
         if end_page:
-            params["end_page"] = end_page
+            params["end_page"] = end_page  # type: ignore
         if end_cfi:
-            params["end_cfi"] = end_cfi
+            params["end_cfi"] = end_cfi  # type: ignore
         url = url._replace(query=urlencode(params, doseq=True))
 
         return urlunparse(url)

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -56,11 +56,13 @@ class VitalSourceService:
 
     def get_book_info(self, book_id: str) -> dict:
         """Get details of a book."""
+        assert self._metadata_client
 
         return self._metadata_client.get_book_info(book_id)
 
     def get_table_of_contents(self, book_id: str) -> list[dict]:
         """Get the table of contents for a book."""
+        assert self._metadata_client
 
         return self._metadata_client.get_table_of_contents(book_id)
 
@@ -151,6 +153,7 @@ class VitalSourceService:
         :param user_reference: The user reference (you can use
             `get_user_reference()` to help you with this)
         """
+        assert self._sso_client
         return self._sso_client.get_sso_redirect(
             user_reference, self.get_book_reader_url(document_url)
         )

--- a/lms/tasks/email_digests.py
+++ b/lms/tasks/email_digests.py
@@ -144,12 +144,12 @@ def send_instructor_email_digest(
     """
     # Caution: datetime.fromisoformat() doesn't support all ISO 8601 strings!
     # This only works for the subset of ISO 8601 produced by datetime.isoformat().
-    created_before = datetime.fromisoformat(created_before)
+    created_before: datetime = datetime.fromisoformat(created_before)
 
     if created_after is None:
         created_after = created_before - timedelta(days=7)  # type: ignore
     else:
-        created_after = datetime.fromisoformat(created_after)
+        created_after: datetime = datetime.fromisoformat(created_after)
 
     with app.request_context() as request:  # pylint:disable=no-member
         with request.tm:

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -12,11 +12,11 @@ from lms.validation._exceptions import ValidationError
 class PlainSchema(marshmallow.Schema):
     """Base class for all schemas."""
 
-    many = None
+    many: bool = False
     """
     Whether or not this schema validates collections of objects by default.
 
-    If this is ``None`` then marshmallow's default behavior will be used -- the
+    If this is ``False`` then marshmallow's default behavior will be used -- the
     schema will expect to validate a single object rather than a collection of
     similar objects.
 

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -49,7 +49,7 @@ class PlainSchema(marshmallow.Schema):
 class PyramidRequestSchema(PlainSchema):
     """Base class for schemas that validate Pyramid requests."""
 
-    location = None
+    location: str | None = None
     """
     The location where webargs should look for the parameters.
 

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -228,9 +228,9 @@ class APIExceptionViews:
 
 @dataclass
 class ErrorBody:
-    error_code: str = None
-    message: str = None
-    details: dict = None
+    error_code: str | None = None
+    message: str | None = None
+    details: dict | None = None
 
     def __json__(self, request):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ disable_error_code = [
     "no-redef",
     "no-untyped-call",
     "no-untyped-def",
-    "override",
     "return-value",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ python_version = 3.11
 
 disable_error_code = [
     "arg-type",
-    "assignment",
     "attr-defined",
     "has-type",
     "import-untyped",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,7 @@ disable_error_code = [
     "valid-type",
 ]
 
-plugins = [
-    "sqlalchemy.ext.mypy.plugin",
-]
+plugins = []
 
 [[tool.mypy.overrides]]
 module="tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ python_version = 3.11
 disable_error_code = [
     "arg-type",
     "attr-defined",
-    "has-type",
     "import-untyped",
     "index",
     "list-item",
@@ -158,9 +157,6 @@ disable_error_code = [
     "no-untyped-def",
     "override",
     "return-value",
-    "type-arg",
-    "union-attr",
-    "valid-type",
 ]
 
 plugins = []


### PR DESCRIPTION
The python typecheker (mypy) can be run with `make typecheck`. It's not enabled in either `make sure` or in CI.


Fix some low-hanging-fruit issues and add a few `ignores` in more complicated ones.