### PR TITLE
Modals to handle Moodle error codes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -167,6 +167,41 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'moodle_file_not_found_in_course':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          title="Hypothesis couldn't find the file in the course"
+        >
+          <p>This might have happened because:</p>
+          <ul className="px-4 list-disc">
+            <li>The file has been deleted from Moodle</li>
+            <li>
+              The course was copied and the selected file is not available in
+              the new course.
+            </li>
+          </ul>
+          <p>
+            To fix the issue an instructor needs to edit this assignment and
+            select a different file.
+          </p>
+        </ErrorModal>
+      );
+
+    case 'moodle_page_not_found_in_course':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          title="Hypothesis couldn't find the page in the course"
+        >
+          <p>This might have happened because:</p>
+          <ul className="px-4 list-disc">
+            <li>The page has been deleted from Moodle</li>
+            <li>The course was copied from another course</li>
+          </ul>
+        </ErrorModal>
+      );
+
     case 'canvas_api_permission_error':
       return (
         <ErrorModal {...defaultProps} title="Couldn't get the file from Canvas">

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -295,6 +295,26 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'moodle_group_set_not_found':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Assignment's grouping no longer exists"
+        >
+          <p>
+            Hypothesis couldn&apos;t load this assignment because the
+            assignment&apos;s grouping no longer exists.
+          </p>
+          <p>
+            <b>
+              To fix this problem, an instructor needs to edit the assignment
+              settings and select a new grouping.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
     case 'blackboard_group_set_empty':
     case 'canvas_group_set_empty':
       return (
@@ -324,6 +344,23 @@ export default function LaunchErrorDialog({
             <b>
               To fix this problem, add groups to the group category or use a
               different group category for this assignment.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'moodle_group_set_empty':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Assignment's grouping is empty"
+        >
+          <p>The grouping for this Hypothesis assignment is empty. </p>
+          <p>
+            <b>
+              To fix this problem, add groups to the grouping or use a different
+              grouping for this assignment.
             </b>
           </p>
         </ErrorModal>
@@ -385,6 +422,26 @@ export default function LaunchErrorDialog({
             <b>
               To fix the problem, an instructor needs to add your D2L user
               account to one of this assignment&apos;s groups.
+            </b>
+          </p>
+        </ErrorModal>
+      );
+
+    case 'moodle_student_not_in_group':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="You're not in any of this assignment's groups"
+        >
+          <p>
+            Hypothesis couldn&apos;t launch this assignment because you
+            aren&apos;t in any of the groups in the assignment&apos;s grouping.
+          </p>
+          <p>
+            <b>
+              To fix the problem, an instructor needs to add your Moodle user
+              account to one of this assignment&apos;s groupings.
             </b>
           </p>
         </ErrorModal>

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -98,6 +98,21 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'moodle_file_not_found_in_course',
+      expectedText:
+        'To fix the issue an instructor needs to edit this assignment and select a different file.',
+      expectedTitle: "Hypothesis couldn't find the file in the course",
+      hasRetry: true,
+      withError: true,
+    },
+    {
+      errorState: 'moodle_page_not_found_in_course',
+      expectedText: 'The page has been deleted from Moodle',
+      expectedTitle: "Hypothesis couldn't find the page in the course",
+      hasRetry: true,
+      withError: true,
+    },
+    {
       errorState: 'canvas_group_set_not_found',
       expectedText:
         "Hypothesis couldn't find this assignment's group set. This could be because:The group set has been deleted from Canvas.This course was created by copying another course (Canvas doesn't copy the group sets over when you copy a course).",

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -122,6 +122,14 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'moodle_group_set_not_found',
+      expectedText:
+        "Hypothesis couldn't load this assignment because the assignment's grouping no longer exists.To fix this problem, an instructor needs to edit the assignment settings and select a new grouping.",
+      expectedTitle: "Assignment's grouping no longer exists",
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'blackboard_group_set_empty',
       expectedText: 'The group set for this Hypothesis assignment is empty',
       expectedTitle: "Assignment's group set is empty",
@@ -144,6 +152,13 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'moodle_group_set_empty',
+      expectedText: 'The grouping for this Hypothesis assignment is empty',
+      expectedTitle: "Assignment's grouping is empty",
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'blackboard_student_not_in_group',
       expectedText: 'an instructor needs to add your Blackboard user',
       expectedTitle: "You're not in any of this assignment's groups",
@@ -162,6 +177,14 @@ describe('LaunchErrorDialog', () => {
       errorState: 'd2l_student_not_in_group',
       expectedText:
         "you aren't in any of the groups in the assignment's group category",
+      expectedTitle: "You're not in any of this assignment's groups",
+      hasRetry: false,
+      withError: true,
+    },
+    {
+      errorState: 'moodle_student_not_in_group',
+      expectedText:
+        "you aren't in any of the groups in the assignment's grouping",
       expectedTitle: "You're not in any of this assignment's groups",
       hasRetry: false,
       withError: true,

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -20,6 +20,8 @@ export type LTILaunchServerErrorCode =
   | 'd2l_group_set_empty'
   | 'd2l_group_set_not_found'
   | 'd2l_student_not_in_group'
+  | 'moodle_page_not_found_in_course'
+  | 'moodle_file_not_found_in_course'
   | 'moodle_group_set_not_found'
   | 'moodle_group_set_empty'
   | 'moodle_student_not_in_group'
@@ -159,6 +161,8 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_student_not_in_group',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
+      'moodle_page_not_found_in_course',
+      'moodle_file_not_found_in_course',
       'moodle_group_set_not_found',
       'moodle_group_set_empty',
       'moodle_student_not_in_group',

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -20,6 +20,9 @@ export type LTILaunchServerErrorCode =
   | 'd2l_group_set_empty'
   | 'd2l_group_set_not_found'
   | 'd2l_student_not_in_group'
+  | 'moodle_group_set_not_found'
+  | 'moodle_group_set_empty'
+  | 'moodle_student_not_in_group'
   | 'vitalsource_no_book_license'
   | 'vitalsource_user_not_found';
 
@@ -156,6 +159,9 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_student_not_in_group',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
+      'moodle_group_set_not_found',
+      'moodle_group_set_empty',
+      'moodle_student_not_in_group',
     ].includes(error.errorCode)
   );
 }

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -91,9 +91,7 @@ def _effective_file_id(
             document_url,
             course.lms_id,
         )
-        raise FileNotFoundInCourse(
-            "moodle_file_not_found_in_course_instructor", document_url
-        )
+        raise FileNotFoundInCourse("moodle_file_not_found_in_course", document_url)
     # Store a mapping so we don't have to re-search next time.
     LOG.debug(
         "Via URL for page, found page in the new course. Document: %s, course: %s, new page id: %s",


### PR DESCRIPTION
The group related ones are very similar to other LMSes dialogs but each LMS uses a different word for "group sets". Moodle uses "grouping".

The file/pages we'll get a link to a KB article once those exists.