### PR TITLE
Remove deprecated sqlalchemy typing plugin

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import sqlalchemy as sa
 from pyramid.settings import asbool
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -80,7 +80,7 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     organization_id = sa.Column(
         sa.Integer(), sa.ForeignKey("organization.id"), nullable=True
     )
-    organization: Mapped["Organization"] = sa.orm.relationship("Organization")
+    organization = sa.orm.relationship("Organization")
     """The organization this application instance belongs to."""
 
     name = sa.Column(sa.UnicodeText(), nullable=True)
@@ -97,15 +97,13 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     developer_key = sa.Column(sa.Unicode)
     developer_secret = sa.Column(sa.LargeBinary)
     aes_cipher_iv = sa.Column(sa.LargeBinary)
-    provisioning = sa.Column(
+    provisioning: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=True,
         server_default=sa.sql.expression.true(),
         nullable=False,
     )
-
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[ApplicationSettings] = mapped_column(
         ApplicationSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -50,17 +51,16 @@ class Assignment(CreatedUpdatedMixin, Base):
     )
     """Assignment this one was copied from."""
 
-    document_url = sa.Column(sa.Unicode, nullable=False)
+    document_url: Mapped[str] = mapped_column(sa.Unicode, nullable=False)
     """The URL of the document to be annotated for this assignment."""
 
-    extra = sa.Column(
-        "extra",
+    extra: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
 
-    is_gradable = sa.Column(
+    is_gradable: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=False,
         server_default=sa.sql.expression.false(),
@@ -74,7 +74,7 @@ class Assignment(CreatedUpdatedMixin, Base):
     description = sa.Column(sa.Unicode, nullable=True)
     """The resource link description from LTI params."""
 
-    deep_linking_uuid = sa.Column(sa.Unicode, nullable=True)
+    deep_linking_uuid: Mapped[str | None] = mapped_column(sa.Unicode, nullable=True)
     """UUID that identifies the deep linking that created this assignment."""
 
     def get_canvas_mapped_file_id(self, file_id):

--- a/lms/models/course.py
+++ b/lms/models/course.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models.json_settings import JSONSettings
@@ -27,8 +28,7 @@ class LegacyCourse(Base):
     #: settings belong to.
     authority_provided_id = sa.Column(sa.UnicodeText(), primary_key=True)
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/event.py
+++ b/lms/models/event.py
@@ -3,6 +3,7 @@ from enum import Enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base, varchar_enum
 
@@ -127,7 +128,7 @@ class EventData(Base):
     )
     event = sa.orm.relationship("Event")
 
-    data = sa.Column(
+    data: Mapped[MutableDict] = mapped_column(
         "extra",
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),

--- a/lms/models/group_info.py
+++ b/lms/models/group_info.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 
@@ -87,7 +88,9 @@ class GroupInfo(Base):
     custom_canvas_course_id = sa.Column(sa.UnicodeText())
 
     #: A dict of info about this group.
-    _info = sa.Column("info", MutableDict.as_mutable(JSONB))
+    _info: Mapped[MutableDict | None] = mapped_column(
+        "info", MutableDict.as_mutable(JSONB)
+    )
 
     @property
     def _safe_info(self):

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -3,6 +3,7 @@ from enum import Enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
@@ -113,15 +114,13 @@ class Grouping(CreatedUpdatedMixin, Base):
 
     type = varchar_enum(Type, nullable=False)
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )
 
-    extra = sa.Column(
-        "extra",
+    extra: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/jwt_oauth2_token.py
+++ b/lms/models/jwt_oauth2_token.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -44,7 +45,7 @@ class JWTOAuth2Token(CreatedUpdatedMixin, Base):
     scopes = sa.Column(sa.UnicodeText(), nullable=False)
 
     # The OAuth 2.0 access token, as received from the authorization server.
-    access_token = sa.Column(sa.UnicodeText(), nullable=False)
+    access_token: Mapped[str] = mapped_column(sa.UnicodeText(), nullable=False)
 
     # Time at which the toke will expire
-    expires_at = sa.Column(sa.DateTime, nullable=False)
+    expires_at = mapped_column(sa.DateTime, nullable=False)

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin, PublicIdMixin
@@ -19,10 +20,10 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, Base):
     name = sa.Column(sa.UnicodeText(), nullable=True)
     """Human readable name for the organization."""
 
-    enabled = sa.Column(sa.Boolean(), nullable=False, default=True)
+    enabled: Mapped[bool] = mapped_column(sa.Boolean(), nullable=False, default=True)
     """Is this organization allowed to use LMS?"""
 
-    parent_id = sa.Column(
+    parent_id: Mapped[int | None] = mapped_column(
         sa.Integer(),
         sa.ForeignKey("organization.id", ondelete="cascade"),
         nullable=True,
@@ -39,8 +40,7 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, Base):
     )
     """Get any application instances associated with this organization."""
 
-    settings = sa.Column(
-        "settings",
+    settings: Mapped[JSONSettings] = mapped_column(
         JSONSettings.as_mutable(JSONB),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,

--- a/lms/models/rsa_key.py
+++ b/lms/models/rsa_key.py
@@ -1,6 +1,7 @@
 import uuid
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -23,7 +24,7 @@ class RSAKey(CreatedUpdatedMixin, Base):
     aes_cipher_iv = sa.Column(sa.LargeBinary)
     """IV for the private key AES encryption"""
 
-    expired = sa.Column(
+    expired: Mapped[bool] = mapped_column(
         sa.Boolean(),
         default=False,
         server_default=sa.sql.expression.false(),

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.orm import mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -40,8 +41,8 @@ class User(CreatedUpdatedMixin, Base):
     h_userid = sa.Column(sa.Unicode, nullable=False)
     """The H userid which is created from LTI provided values."""
 
-    email = sa.Column(sa.Unicode, nullable=True)
+    email = mapped_column(sa.Unicode, nullable=True)
     """Email address of the user"""
 
-    display_name = sa.Column(sa.Unicode, nullable=True)
+    display_name = mapped_column(sa.Unicode, nullable=True)
     """The user's display name."""

--- a/lms/models/user_preferences.py
+++ b/lms/models/user_preferences.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, Unicode, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -11,7 +12,7 @@ class UserPreferences(CreatedUpdatedMixin, Base):
 
     id = Column(Integer, autoincrement=True, primary_key=True)
     h_userid = Column(Unicode, nullable=False, unique=True)
-    preferences = Column(
+    preferences: Mapped[MutableDict] = mapped_column(
         MutableDict.as_mutable(JSONB),
         server_default=text("'{}'::jsonb"),
         nullable=False,

--- a/lms/services/http.py
+++ b/lms/services/http.py
@@ -7,7 +7,7 @@ class HTTPService:
     """Send HTTP requests with `requests` and receive the responses."""
 
     # This is here mostly to let auto-spec know about it in the tests
-    session: Session = None  # typing: ignore
+    session: Session = None  # type: ignore
     """The underlying requests Session."""
 
     def __init__(self):

--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 
 import xmltodict
 from marshmallow import EXCLUDE, Schema, fields
-from requests import JSONDecodeError, Request
+from requests import JSONDecodeError, PreparedRequest
 from requests.auth import AuthBase
 
 from lms.services.exceptions import ExternalRequestError, SerializableError
@@ -244,7 +244,7 @@ class _VSUserAuth(AuthBase):
         self._client = client
         self._user_reference = user_reference
 
-    def __call__(self, request: Request) -> Request:
+    def __call__(self, request: PreparedRequest) -> PreparedRequest:
         credentials = self._client.get_user_credentials(self._user_reference)
         request.headers["X-VitalSource-Access-Token"] = credentials["access_token"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ disable_error_code = [
     "no-redef",
     "no-untyped-call",
     "no-untyped-def",
-    "override",
     "return-value",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,7 @@ disable_error_code = [
     "valid-type",
 ]
 
-plugins = [
-    "sqlalchemy.ext.mypy.plugin",
-]
+plugins = []
 
 [[tool.mypy.overrides]]
 module="tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ python_version = 3.11
 disable_error_code = [
     "arg-type",
     "attr-defined",
-    "has-type",
     "import-untyped",
     "index",
     "list-item",
@@ -158,9 +157,6 @@ disable_error_code = [
     "no-untyped-def",
     "override",
     "return-value",
-    "type-arg",
-    "union-attr",
-    "valid-type",
 ]
 
 plugins = []


### PR DESCRIPTION
Add type annotations to columns that SQLAlchemy can't infer.


From: https://docs.sqlalchemy.org/en/20/orm/extensions/mypy.html#mypy-pep-484-support-for-orm-mappings


```
The SQLAlchemy Mypy plugin, while it has technically never left the “alpha” stage, should now be considered as deprecated in SQLAlchemy 2.0, even though it is still necessary for full Mypy support when using SQLAlchemy 1.4.
```

