### PR TITLE
Generic usage of LMS API

### DIFF
--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -33,7 +33,7 @@ class D2LCourseCopyPlugin:
     @classmethod
     def factory(cls, _context, request):
         return cls(
-            request.find_service(D2LAPIClient),
+            request.find_service(name="d2l"),
             files_helper=request.find_service(CourseCopyFilesHelper),
             groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -2,7 +2,6 @@ from enum import Enum
 
 from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin
-from lms.services import D2LAPIClient
 from lms.services.exceptions import ExternalRequestError
 
 
@@ -74,7 +73,7 @@ class D2LGroupingPlugin(GroupingPlugin):
 
     @classmethod
     def factory(cls, _context, request):
-        d2l_api = request.find_service(D2LAPIClient)
+        d2l_api = request.find_service(name="d2l")
         return cls(
             d2l_api=d2l_api,
             api_user_id=d2l_api.get_api_user_id(request.lti_user.user_id),

--- a/lms/product/d2l/product.py
+++ b/lms/product/d2l/product.py
@@ -22,3 +22,5 @@ class D2L(Product):
     )
 
     settings_key = "desire2learn"
+
+    api_client_name = "d2l"

--- a/lms/product/moodle/_plugin/course_copy.py
+++ b/lms/product/moodle/_plugin/course_copy.py
@@ -34,7 +34,7 @@ class MoodleCourseCopyPlugin:
     @classmethod
     def factory(cls, _context, request):
         return cls(
-            request.find_service(MoodleAPIClient),
+            request.find_service(name="moodle"),
             files_helper=request.find_service(CourseCopyFilesHelper),
             groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/product/moodle/_plugin/grouping.py
+++ b/lms/product/moodle/_plugin/grouping.py
@@ -3,7 +3,6 @@ from enum import Enum
 from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin
 from lms.services.exceptions import ExternalRequestError
-from lms.services.moodle import MoodleAPIClient
 
 
 class ErrorCodes(str, Enum):
@@ -76,4 +75,4 @@ class MoodleGroupingPlugin(GroupingPlugin):
 
     @classmethod
     def factory(cls, _context, request):
-        return cls(api=request.find_service(MoodleAPIClient), lti_user=request.lti_user)
+        return cls(api=request.find_service(name="moodle"), lti_user=request.lti_user)

--- a/lms/product/moodle/product.py
+++ b/lms/product/moodle/product.py
@@ -19,3 +19,5 @@ class Moodle(Product):
     route: Routes = Routes()
 
     settings_key = "moodle"
+
+    api_client_name = "moodle"

--- a/lms/resources/_js_config/file_picker_config.py
+++ b/lms/resources/_js_config/file_picker_config.py
@@ -19,7 +19,7 @@ class FilePickerConfig:
             config["listFiles"] = {
                 "authUrl": request.route_url(D2L.route.oauth2_authorize),
                 "path": request.route_path(
-                    "d2l_api.courses.files.list",
+                    "api.courses.files.list",
                     course_id=request.lti_params.get("context_id"),
                 ),
             }
@@ -54,8 +54,7 @@ class FilePickerConfig:
             config["listFiles"] = {
                 "authUrl": None,
                 "path": request.route_path(
-                    "moodle_api.courses.files.list",
-                    course_id=course_id,
+                    "api.courses.files.list", course_id=course_id
                 ),
             }
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -43,6 +43,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route("api.grant_token", "/api/grant_token", request_method="GET")
 
     config.add_route("api.assignments.create", "/api/assignment", request_method="POST")
+    config.add_route("api.courses.files.list", "/api/courses/{course_id}/files")
 
     config.add_route(
         "d2l_api.oauth.authorize",
@@ -55,14 +56,10 @@ def includeme(config):  # pylint:disable=too-many-statements
         factory="lms.resources.OAuth2RedirectResource",
     )
     config.add_route("d2l_api.oauth.refresh", "/api/d2l/oauth/refresh")
-    config.add_route("d2l_api.courses.files.list", "/api/d2l/courses/{course_id}/files")
     config.add_route(
         "d2l_api.courses.files.via_url", "/api/d2l/courses/{course_id}/via_url"
     )
 
-    config.add_route(
-        "moodle_api.courses.files.list", "/api/moodle/courses/{course_id}/files"
-    )
     config.add_route(
         "moodle_api.courses.files.via_url", "/api/moodle/courses/{course_id}/via_url"
     )

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -129,7 +129,7 @@ def includeme(config):
     )
     config.register_service_factory("lms.services.region.factory", iface=RegionService)
     config.register_service_factory(
-        "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient
+        "lms.services.d2l_api.d2l_api_client_factory", name="d2l"
     )
     config.register_service_factory(
         "lms.services.digest.service_factory", iface=DigestService
@@ -140,7 +140,7 @@ def includeme(config):
     config.register_service_factory(
         "lms.services.youtube.factory", iface=YouTubeService
     )
-    config.register_service_factory(MoodleAPIClient.factory, iface=MoodleAPIClient)
+    config.register_service_factory(MoodleAPIClient.factory, name="moodle")
 
     # Plugins are not the same as top level services but we want to register them as pyramid services too
     # Importing them here to:

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -126,7 +126,13 @@ class D2LAPIClient(LMSAPI):
         """Get a nested list of files and folders for the given `org_unit`."""
         modules = self._get_course_modules(course_id)
         files = list(self._find_files(course_id, modules))
-        self._file_service.upsert(list(self._files_for_storage(course_id, files)))
+        self._file_service.upsert(
+            list(
+                self._documents_for_storage(
+                    course_id, files, folder_type="d2l_folder", document_type="d2l_file"
+                )
+            )
+        )
 
         return files
 
@@ -225,17 +231,3 @@ class D2LAPIClient(LMSAPI):
                 "updated_at": module["updated_at"],
                 "children": module_files + list(module_children),
             }
-
-    def _files_for_storage(self, course_id, files, parent_id=None):
-        for file in files:
-            yield {
-                "type": "d2l_file" if file["type"] == "File" else "d2l_folder",
-                "course_id": course_id,
-                "lms_id": file["lms_id"],
-                "name": file["display_name"],
-                "parent_lms_id": parent_id,
-            }
-
-            yield from self._files_for_storage(
-                course_id, file.get("children", []), file["id"]
-            )

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -1,6 +1,7 @@
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema
 
 from lms.services.exceptions import ExternalRequestError, FileNotFoundInCourse
+from lms.services.lms_api import LMSAPI, LMSDocument
 from lms.validation._base import RequestsResponseSchema
 
 
@@ -67,7 +68,7 @@ class D2LTableOfContentsSchema(RequestsResponseSchema):
     )
 
 
-class D2LAPIClient:
+class D2LAPIClient(LMSAPI):
     def __init__(self, basic_client, file_service, lti_user):
         self._api = basic_client
         self._file_service = file_service
@@ -121,11 +122,11 @@ class D2LAPIClient:
 
         return groups
 
-    def list_files(self, org_unit) -> list[dict]:
+    def list_files(self, course_id) -> list[LMSDocument]:
         """Get a nested list of files and folders for the given `org_unit`."""
-        modules = self._get_course_modules(org_unit)
-        files = list(self._find_files(org_unit, modules))
-        self._file_service.upsert(list(self._files_for_storage(org_unit, files)))
+        modules = self._get_course_modules(course_id)
+        files = list(self._find_files(course_id, modules))
+        self._file_service.upsert(list(self._files_for_storage(course_id, files)))
 
         return files
 

--- a/lms/services/lms_api.py
+++ b/lms/services/lms_api.py
@@ -17,3 +17,29 @@ class LMSDocument(TypedDict):
 class LMSAPI(Protocol):
     def list_files(self, course_id: int) -> list[LMSDocument]:  # pragma: no cover
         ...
+
+    def _documents_for_storage(  # pylint:disable=too-many-arguments
+        self,
+        course_id,
+        files: list[LMSDocument],
+        folder_type: str,
+        document_type: str,
+        parent_id=None,
+    ):
+        """Reshape a list of LMSDocument for storage in the File table."""
+        for file in files:
+            yield {
+                "type": folder_type if file["type"] == "Folder" else document_type,
+                "course_id": course_id,
+                "lms_id": file["lms_id"],
+                "name": file["display_name"],
+                "parent_lms_id": parent_id,
+            }
+
+            yield from self._documents_for_storage(
+                course_id,
+                file.get("children", []),
+                folder_type,
+                document_type,
+                file["id"],
+            )

--- a/lms/services/lms_api.py
+++ b/lms/services/lms_api.py
@@ -1,17 +1,31 @@
-from typing import Literal, Protocol, Self, TypedDict
+from typing import Literal, NotRequired, Protocol, TypedDict
+
+
+class APICallInfo(TypedDict):
+    path: str
+    authUrl: NotRequired[str]
 
 
 class LMSDocument(TypedDict):
     """Represents a document or folder in an LMS's file storage."""
 
     type: Literal["File", "Folder"]
+    mime_type: NotRequired[Literal["text/html", "application/pdf", "video"]]
 
     id: str
+    """ID of the document in our sytem. Often in the form schema://DETAILS/"""
+
     lms_id: str
+    """ID of the document in the LMS itself."""
+
     display_name: str
     updated_at: str
 
-    children: list[Self]
+    children: NotRequired[list["LMSDocument"]]
+    """Children of the current folder."""
+
+    contents: NotRequired[APICallInfo]
+    """API call to use to fetch contents of a folder."""
 
 
 class LMSAPI(Protocol):

--- a/lms/services/lms_api.py
+++ b/lms/services/lms_api.py
@@ -1,0 +1,19 @@
+from typing import Literal, Protocol, Self, TypedDict
+
+
+class LMSDocument(TypedDict):
+    """Represents a document or folder in an LMS's file storage."""
+
+    type: Literal["File", "Folder"]
+
+    id: str
+    lms_id: str
+    display_name: str
+    updated_at: str
+
+    children: list[Self]
+
+
+class LMSAPI(Protocol):
+    def list_files(self, course_id: int) -> list[LMSDocument]:  # pragma: no cover
+        ...

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -254,26 +254,6 @@ class MoodleAPIClient(LMSAPI):
 
         return url + f"&wsfunction={function.value}"
 
-    def _documents_for_storage(  # pylint:disable=too-many-arguments
-        self, course_id, files, folder_type, document_type, parent_id=None
-    ):
-        for file in files:
-            yield {
-                "type": folder_type if file["type"] == "Folder" else document_type,
-                "course_id": course_id,
-                "lms_id": file["lms_id"],
-                "name": file["display_name"],
-                "parent_lms_id": parent_id,
-            }
-
-            yield from self._documents_for_storage(
-                course_id,
-                file.get("children", []),
-                folder_type,
-                document_type,
-                file["id"],
-            )
-
     def _request(self, url: str, params: dict | None = None):
         response = self._http.post(url, params=params).json()
 

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -3,6 +3,7 @@ from enum import Enum
 from lms.services.aes import AESService
 from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService
+from lms.services.lms_api import LMSAPI, LMSDocument
 
 
 class Function(str, Enum):
@@ -22,7 +23,7 @@ class Function(str, Enum):
     """Returns a list of pages in a provided list of courses."""
 
 
-class MoodleAPIClient:
+class MoodleAPIClient(LMSAPI):
     API_PATH = "webservice/rest/server.php"
 
     def __init__(
@@ -72,7 +73,7 @@ class MoodleAPIClient:
         response = self._request(url, params={"courseid": course_id})
         return response
 
-    def list_files(self, course_id: int):
+    def list_files(self, course_id: int) -> list[LMSDocument]:
         contents = self.course_contents(course_id)
         files = []
 

--- a/lms/views/api/d2l/authorize.py
+++ b/lms/views/api/d2l/authorize.py
@@ -4,7 +4,6 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.view import exception_view_config, view_config
 
 from lms.security import Permissions
-from lms.services.d2l_api import D2LAPIClient
 from lms.validation.authentication import OAuthCallbackSchema
 
 GROUPS_SCOPES = ("groups:group:read",)
@@ -63,7 +62,7 @@ def authorize(request):
     schema=OAuthCallbackSchema,
 )
 def oauth2_redirect(request):
-    request.find_service(D2LAPIClient).get_token(request.params["code"])
+    request.find_service(name="d2l").get_token(request.params["code"])
     return {}
 
 

--- a/lms/views/api/d2l/files.py
+++ b/lms/views/api/d2l/files.py
@@ -3,7 +3,6 @@ import re
 from pyramid.view import view_config
 
 from lms.security import Permissions
-from lms.services.d2l_api import D2LAPIClient
 from lms.services.exceptions import FileNotFoundInCourse
 from lms.views import helpers
 
@@ -14,24 +13,13 @@ DOCUMENT_URL_REGEX = re.compile(
 
 @view_config(
     request_method="GET",
-    route_name="d2l_api.courses.files.list",
-    renderer="json",
-    permission=Permissions.API,
-)
-def list_files(_context, request):
-    """Return the list of files in the given course."""
-    return request.find_service(D2LAPIClient).list_files(request.matchdict["course_id"])
-
-
-@view_config(
-    request_method="GET",
     route_name="d2l_api.courses.files.via_url",
     renderer="json",
     permission=Permissions.API,
 )
 def via_url(_context, request):
     course_copy_plugin = request.product.plugin.course_copy
-    api_client = request.find_service(D2LAPIClient)
+    api_client = request.find_service(name="d2l")
 
     course_id = request.matchdict["course_id"]
     document_url = request.params["document_url"]

--- a/lms/views/api/files.py
+++ b/lms/views/api/files.py
@@ -1,0 +1,13 @@
+from pyramid.view import view_config
+
+from lms.security import Permissions
+
+
+@view_config(
+    request_method="GET",
+    route_name="api.courses.files.list",
+    renderer="json",
+    permission=Permissions.API,
+)
+def list_files(_context, request):
+    return request.product.api_client.list_files(request.matchdict["course_id"])

--- a/lms/views/api/moodle/files.py
+++ b/lms/views/api/moodle/files.py
@@ -5,7 +5,6 @@ from pyramid.view import view_config
 
 from lms.security import Permissions
 from lms.services.exceptions import FileNotFoundInCourse
-from lms.services.moodle import MoodleAPIClient
 from lms.views import helpers
 
 LOG = getLogger(__name__)
@@ -17,25 +16,12 @@ DOCUMENT_URL_REGEX = re.compile(
 
 @view_config(
     request_method="GET",
-    route_name="moodle_api.courses.files.list",
-    renderer="json",
-    permission=Permissions.API,
-)
-def list_files(_context, request):
-    """Return the list of files in the given course."""
-    return request.find_service(MoodleAPIClient).list_files(
-        request.matchdict["course_id"]
-    )
-
-
-@view_config(
-    request_method="GET",
     route_name="moodle_api.courses.files.via_url",
     renderer="json",
     permission=Permissions.API,
 )
 def via_url(_context, request):
-    api = request.find_service(MoodleAPIClient)
+    api = request.find_service(name="moodle")
     course_copy_plugin = request.product.plugin.course_copy
 
     current_course_id = request.lti_user.lti.course_id

--- a/lms/views/api/moodle/pages.py
+++ b/lms/views/api/moodle/pages.py
@@ -5,7 +5,6 @@ from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.services.exceptions import FileNotFoundInCourse
-from lms.services.moodle import MoodleAPIClient
 from lms.validation.authentication import BearerTokenSchema
 from lms.views import helpers
 
@@ -25,11 +24,12 @@ class PageNotFoundInCourse(FileNotFoundInCourse):
 class PagesAPIViews:
     def __init__(self, request):
         self.request = request
-        self.api = request.find_service(MoodleAPIClient)
+
+        self.api = request.find_service(name="moodle")
 
     @view_config(request_method="GET", route_name="moodle_api.courses.pages.list")
     def list_pages(self):
-        return self.request.find_service(MoodleAPIClient).list_pages(
+        return self.request.find_service(name="moodle").list_pages(
             self.request.matchdict["course_id"]
         )
 

--- a/lms/views/api/refresh.py
+++ b/lms/views/api/refresh.py
@@ -2,7 +2,6 @@ from pyramid.view import view_config, view_defaults
 
 from lms.security import Permissions
 from lms.services.canvas_studio import CanvasStudioService
-from lms.services.d2l_api import D2LAPIClient
 
 
 @view_defaults(request_method="POST", permission=Permissions.API, renderer="json")
@@ -32,4 +31,4 @@ class RefreshViews:
 
     @view_config(route_name="d2l_api.oauth.refresh")
     def get_refreshed_token_from_d2l(self):
-        self.request.find_service(D2LAPIClient).refresh_access_token()
+        self.request.find_service(name="d2l").refresh_access_token()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,7 @@ from lms.models import ApplicationSettings, LTIParams
 from lms.models.lti_role import Role, RoleScope, RoleType
 from lms.product import Product
 from lms.security import Identity
+from lms.services.lms_api import LMSAPI
 from tests import factories
 from tests.conftest import TEST_SETTINGS
 from tests.unit.services import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -136,6 +137,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     pyramid_request.product = Product.from_request(
         pyramid_request, dict(application_instance.settings)
     )
+    type(pyramid_request.product).api_client = mock.create_autospec(LMSAPI)
 
     # The DummyRequest request lacks a content_type property which the real
     # request has

--- a/tests/unit/lms/resources/_js_config/file_picker_config_test.py
+++ b/tests/unit/lms/resources/_js_config/file_picker_config_test.py
@@ -44,7 +44,7 @@ class TestFilePickerConfig:
         if files_enabled:
             expected_config["listFiles"] = {
                 "authUrl": None,
-                "path": "/api/moodle/courses/COURSE_ID/files",
+                "path": "/api/courses/COURSE_ID/files",
             }
         if pages_enabled:
             expected_config["listPages"] = {
@@ -77,7 +77,7 @@ class TestFilePickerConfig:
         if expected:
             expected_config["listFiles"] = {
                 "authUrl": "http://example.com/api/d2l/oauth/authorize",
-                "path": "/api/d2l/courses/COURSE_ID/files",
+                "path": "/api/courses/COURSE_ID/files",
             }
 
         assert config == expected_config

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -13,7 +13,6 @@ from tests import factories
 
 @pytest.mark.usefixtures("aes_service", "canvas_studio_settings", "oauth_http_factory")
 class TestCanvasStudioService:
-
     def test_get_access_token(self, svc, oauth_http_service, client_secret):
         svc.get_access_token("some_code")
 
@@ -75,6 +74,7 @@ class TestCanvasStudioService:
                 "display_name": "More videos",
                 "updated_at": "2024-02-01",
                 "id": "8",
+                "lms_id": "8",
                 "contents": {
                     "path": "http://example.com/api/canvas_studio/collections/8/media"
                 },
@@ -85,6 +85,7 @@ class TestCanvasStudioService:
                 "mime_type": "video",
                 "updated_at": "2024-02-03",
                 "id": "canvas-studio://media/5",
+                "lms_id": "5",
             },
         ]
 
@@ -123,6 +124,7 @@ class TestCanvasStudioService:
                 "mime_type": "video",
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/6",
+                "lms_id": "6",
             }
         ]
 

--- a/tests/unit/lms/views/api/d2l/files_test.py
+++ b/tests/unit/lms/views/api/d2l/files_test.py
@@ -3,16 +3,7 @@ from unittest.mock import sentinel
 import pytest
 
 from lms.services.exceptions import FileNotFoundInCourse
-from lms.views.api.d2l.files import list_files, via_url
-
-
-def test_course_group_sets(pyramid_request, d2l_api_client):
-    pyramid_request.matchdict = {"course_id": "test_course_id"}
-
-    result = list_files(sentinel.context, pyramid_request)
-
-    d2l_api_client.list_files.assert_called_once_with("test_course_id")
-    assert result == d2l_api_client.list_files.return_value
+from lms.views.api.d2l.files import via_url
 
 
 @pytest.mark.parametrize("is_instructor", [True, False])

--- a/tests/unit/lms/views/api/files_test.py
+++ b/tests/unit/lms/views/api/files_test.py
@@ -1,0 +1,14 @@
+from unittest.mock import sentinel
+
+from lms.views.api.files import list_files
+
+
+def test_list_files(pyramid_request):
+    pyramid_request.matchdict = {"course_id": "test_course_id"}
+
+    result = list_files(sentinel.context, pyramid_request)
+
+    pyramid_request.product.api_client.list_files.assert_called_once_with(
+        "test_course_id"
+    )
+    assert result == pyramid_request.product.api_client.list_files.return_value

--- a/tests/unit/lms/views/api/moodle/files_test.py
+++ b/tests/unit/lms/views/api/moodle/files_test.py
@@ -3,16 +3,7 @@ from unittest.mock import Mock, sentinel
 import pytest
 
 from lms.services.exceptions import FileNotFoundInCourse
-from lms.views.api.moodle.files import list_files, via_url
-
-
-def test_list_files(pyramid_request, moodle_api_client):
-    pyramid_request.matchdict = {"course_id": "test_course_id"}
-
-    result = list_files(sentinel.context, pyramid_request)
-
-    moodle_api_client.list_files.assert_called_once_with("test_course_id")
-    assert result == moodle_api_client.list_files.return_value
+from lms.views.api.moodle.files import via_url
 
 
 @pytest.mark.usefixtures("course_copy_plugin")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -181,12 +181,12 @@ def course_service(mock_service):
 
 @pytest.fixture
 def d2l_api_client(mock_service):
-    return mock_service(D2LAPIClient)
+    return mock_service(D2LAPIClient, service_name="d2l")
 
 
 @pytest.fixture
 def moodle_api_client(mock_service):
-    return mock_service(MoodleAPIClient)
+    return mock_service(MoodleAPIClient, service_name="moodle")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR doesn't add a groundbreaking change to the codebase but I reckon it paves the way to better isolate LMS differences without having to invent new mehcaiims (eg. our plugins), just move LMS specific behavior to the LMS specific service.