### PR TITLE
Split `type` property for file API responses into `type`/`mime_type` and add an icon for videos

### DIFF
--- a/lms/services/canvas_api/client.py
+++ b/lms/services/canvas_api/client.py
@@ -246,6 +246,13 @@ class CanvasAPIClient:
             params={"content_types[]": "application/pdf", "sort": sort},
             schema=self._ListFilesSchema,
         )
+
+        # Set the mime type. We currently only list PDF files, so we know it
+        # is always application/pdf. We could use the `content-type` property
+        # from the API response if we supported other content types.
+        for file in files:
+            file["mime_type"] = "application/pdf"
+
         # Canvas' pagination is broken as it sorts by fields that allows duplicates.
         # This can lead to objects being skipped or duplicated across pages.
         # We can't detected objects that are not returned but we can detect the duplicates,

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,4 +1,4 @@
-from typing import Literal, Type, TypedDict
+from typing import Literal, NotRequired, Type, TypedDict
 from urllib.parse import urlencode, urljoin, urlparse, urlunparse
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
@@ -74,6 +74,7 @@ class File(TypedDict):
     """Represents a file or folder in an LMS's file storage."""
 
     type: Literal["File", "Folder"]
+    mime_type: NotRequired[Literal["text/html", "application/pdf", "video"]]
 
     id: str
     display_name: str
@@ -229,6 +230,7 @@ class CanvasStudioService:
             files.append(
                 {
                     "type": "File",
+                    "mime_type": "video",
                     "id": f"canvas-studio://media/{media_id}",
                     "display_name": item["title"],
                     "updated_at": item["created_at"],

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -201,6 +201,7 @@ class D2LAPIClient:
             module_files = [
                 {
                     "type": "File",
+                    "mime_type": "application/pdf",
                     "display_name": topic["display_name"],
                     "lms_id": topic["id"],
                     "id": f"d2l://file/course/{course_id}/file_id/{topic['id']}/",

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -173,7 +173,8 @@ class MoodleAPIClient:
                     updated_at = page_index[0]["updated_at"] if page_index else None
 
                     file_node = {
-                        "type": "Page",
+                        "type": "File",
+                        "mime_type": "text/html",
                         "display_name": module["name"],
                         "lms_id": module["id"],
                         "id": f"moodle://page/course/{course_id}/page_id/{module['id']}",
@@ -237,6 +238,7 @@ class MoodleAPIClient:
 
             file_node = {
                 "type": "File",
+                "mime_type": "application/pdf",
                 "display_name": path_components[-1],
                 "id": f"moodle://file/course/{course_id}/url/{file_data['url']}",
                 "lms_id": file_data["url"],

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -5,10 +5,25 @@
 import type { APICallInfo } from './config';
 
 /**
- * Object representing a file, folder or document stored by the LMS
+ * MIME types which are recognized by the frontend.
+ *
+ * These are used to choose appropriate icons to represent the file.
+ */
+export type MimeType = 'text/html' | 'application/pdf' | 'video';
+
+/**
+ * Object representing a file or folder in cloud storage.
  */
 export type Document = {
-  type?: 'File' | 'Folder' | 'Page';
+  type: 'File' | 'Folder';
+
+  /**
+   * MIME type of the file.
+   *
+   * This can either be a top-level type (eg. "video", "text") or a sub-type
+   * ("text/html").
+   */
+  mime_type?: MimeType;
 
   /** Identifier for the document within the LMS. */
   id: string;
@@ -24,9 +39,6 @@ export type Document = {
  * Object representing a file or folder in the LMS's file storage.
  */
 export type File = Document & {
-  // FIXME - This ought to be present on all file objects.
-  type?: 'File' | 'Folder';
-
   /** APICallInfo for fetching a folder's content. Only present if `type` is 'Folder'. */
   contents?: APICallInfo;
 
@@ -35,13 +47,6 @@ export type File = Document & {
 
   /** Applies only when `type` is 'Folder'. A folder may contain children (files and folders). */
   children?: File[];
-};
-
-/**
- * Object representing Canvas pages or similar documents
- */
-export type Page = Document & {
-  type: 'Page';
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -1,7 +1,7 @@
 import { OptionButton, SpinnerOverlay } from '@hypothesis/frontend-shared';
 import { useMemo, useState } from 'preact/hooks';
 
-import type { File, Page } from '../api-types';
+import type { File } from '../api-types';
 import { useConfig } from '../config';
 import { PickerCanceledError } from '../errors';
 import type { Content } from '../utils/content-item';
@@ -170,14 +170,14 @@ export default function ContentSelector({
   };
 
   // file.id is a URL with a `blackboard://`, `d2l://` or `moodle://` prefix.
-  const selectFileAsURL = (file: File | Page) => selectURL(file.id);
+  const selectFileAsURL = (file: File) => selectURL(file.id);
 
-  const selectPageAsURL = (page: File | Page, lms: string) => {
+  const selectPageAsURL = (page: File, lms: string) => {
     const name = `${lms} page: ${page.display_name}`;
     selectURL(page.id, name);
   };
 
-  const selectCanvasFile = (file: File | Page) => {
+  const selectCanvasFile = (file: File) => {
     cancelDialog();
     onSelectContent({ type: 'file', file: file as File });
   };
@@ -187,16 +187,14 @@ export default function ContentSelector({
     selectURL(url, name);
   };
 
-  const selectCanvasPage = (page: File | Page) =>
-    selectPageAsURL(page, 'Canvas');
+  const selectCanvasPage = (page: File) => selectPageAsURL(page, 'Canvas');
 
-  const selectCanvasStudio = (video: File | Page) => {
+  const selectCanvasStudio = (video: File) => {
     const name = `Canvas Studio video: ${video.display_name}`;
     selectURL(video.id, name);
   };
 
-  const selectMoodlePage = (page: File | Page) =>
-    selectPageAsURL(page, 'Moodle');
+  const selectMoodlePage = (page: File) => selectPageAsURL(page, 'Moodle');
 
   const selectVitalSourceBook = async (
     selection: unknown,

--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -3,12 +3,14 @@ import {
   FileGenericIcon,
   FilePdfFilledIcon,
   FolderIcon,
+  PreviewIcon,
   Scroll,
   ScrollContainer,
 } from '@hypothesis/frontend-shared';
 import type { ComponentChildren } from 'preact';
+import type { JSX } from 'preact';
 
-import type { Document } from '../api-types';
+import type { Document, MimeType } from '../api-types';
 
 export type DocumentListProps<DocumentType extends Document> = {
   /** List of document objects returned by the API */
@@ -30,8 +32,16 @@ export type DocumentListProps<DocumentType extends Document> = {
   title: string;
 };
 
+type IconComponent = (props: { className?: string }) => JSX.Element;
+
+const mimeTypeIcons: Record<MimeType, IconComponent> = {
+  'application/pdf': FilePdfFilledIcon,
+  'text/html': FileGenericIcon,
+  video: PreviewIcon,
+};
+
 /**
- * List of the documents
+ * List of files and folders in a file picker.
  */
 export default function DocumentList<DocumentType extends Document>({
   documents,
@@ -58,19 +68,22 @@ export default function DocumentList<DocumentType extends Document>({
 
   const renderItem = (document: DocumentType, field: keyof DocumentType) => {
     switch (field) {
-      case 'display_name':
+      case 'display_name': {
+        let Icon;
+        if (document.type === 'Folder') {
+          Icon = FolderIcon;
+        } else if (document.mime_type) {
+          Icon = mimeTypeIcons[document.mime_type];
+        } else {
+          Icon = FileGenericIcon;
+        }
         return (
           <div className="flex flex-row items-center gap-x-2">
-            {document.type === 'Folder' ? (
-              <FolderIcon className="w-5 h-5" />
-            ) : document.type === 'Page' ? (
-              <FileGenericIcon className="w-5 h-5" />
-            ) : (
-              <FilePdfFilledIcon className="w-5 h-5" />
-            )}
+            <Icon className="w-5 h-5" />
             {document.display_name}
           </div>
         );
+      }
       case 'updated_at':
       default:
         return document.updated_at ? formatDate(document.updated_at) : '';

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -6,7 +6,7 @@ import {
 import classnames from 'classnames';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
-import type { File, Page } from '../api-types';
+import type { File } from '../api-types';
 import type { APICallInfo } from '../config';
 import { isAuthorizationError } from '../errors';
 import { apiCall } from '../utils/api';
@@ -83,7 +83,7 @@ type LMSFilePickerProps = {
   /**
    * Callback invoked with the metadata of the selected document if the user makes a selection
    */
-  onSelectFile: (d: File | Page) => void;
+  onSelectFile: (file: File) => void;
 
   /**
    * A helpful URL to documentation that explains how to upload files to an LMS such as Canvas or Blackboard.

--- a/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
@@ -13,6 +13,7 @@ describe('DocumentList', () => {
       display_name: 'Test.pdf',
       updated_at: '2019-05-09T17:45:21+00:00Z',
       type: 'File',
+      mime_type: 'application/pdf',
     },
   ];
 
@@ -40,17 +41,24 @@ describe('DocumentList', () => {
   });
 
   [
-    ['File', 'FilePdfFilledIcon'],
-    ['Folder', 'FolderIcon'],
-    ['Page', 'FileGenericIcon'],
-  ].forEach(([type, expectedIcon]) => {
+    // Folder
+    { type: 'Folder', icon: 'FolderIcon' },
+
+    // Files with known mime type
+    { type: 'File', mime_type: 'application/pdf', icon: 'FilePdfFilledIcon' },
+    { type: 'File', mime_type: 'text/html', icon: 'FileGenericIcon' },
+    { type: 'File', mime_type: 'video', icon: 'PreviewIcon' },
+
+    // File with unknown mime type
+    { type: 'File', icon: 'FileGenericIcon' },
+  ].forEach(({ type, mime_type, icon }) => {
     it('renders documents with an icon, document name and date', () => {
       const wrapper = renderDocumentList({
-        documents: [{ ...testDocuments[0], type }],
+        documents: [{ ...testDocuments[0], type, mime_type }],
       });
       const formattedDate = new Date(testDocuments[0]).toLocaleDateString();
       const dataRow = wrapper.find('tbody tr').at(0);
-      assert.isTrue(dataRow.find(expectedIcon).exists());
+      assert.isTrue(dataRow.find(icon).exists());
       assert.equal(
         dataRow.find('td').at(0).text(),
         testDocuments[0].display_name,

--- a/lms/views/api/blackboard/files.py
+++ b/lms/views/api/blackboard/files.py
@@ -49,6 +49,7 @@ class BlackboardFilesAPIViews:
 
             if result["type"] == "File" and result.get("mimeType") == "application/pdf":
                 response_result["id"] = f"blackboard://content-resource/{result['id']}/"
+                response_result["mime_type"] = "application/pdf"
                 response_results.append(response_result)
             elif result["type"] == "Folder":
                 response_result["id"] = result["id"]

--- a/lms/views/api/canvas/pages.py
+++ b/lms/views/api/canvas/pages.py
@@ -42,7 +42,8 @@ class PagesAPIViews:
                 "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
                 "lms_id": page.id,
                 "display_name": page.title,
-                "type": "Page",
+                "type": "File",
+                "mime_type": "text/html",
                 "updated_at": page.updated_at,
             }
             for page in self.canvas.api.pages.list(course_id)

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -351,8 +351,11 @@ class TestCanvasAPIClientIntegrated:
         )
 
         response = canvas_api_client.list_files("COURSE_ID")
+        expected_response = [
+            {**file, "mime_type": "application/pdf"} for file in list_files_json
+        ]
 
-        assert response == list_files_json
+        assert response == expected_response
         self.assert_session_send(
             http_session,
             "api/v1/courses/COURSE_ID/files",
@@ -399,7 +402,9 @@ class TestCanvasAPIClientIntegrated:
 
         response = canvas_api_client.list_files("COURSE_ID")
 
-        assert response == [files[0]]
+        expected_file = files[0].copy()
+        expected_file.update({"mime_type": "application/pdf"})
+        assert response == [expected_file]
 
     def test_list_files_with_folders(
         self,
@@ -447,6 +452,7 @@ class TestCanvasAPIClientIntegrated:
                 "folder_id": 100,
                 "updated_at": "updated_at_1",
                 "type": "File",
+                "mime_type": "application/pdf",
             },
             {
                 "id": 200,
@@ -462,6 +468,7 @@ class TestCanvasAPIClientIntegrated:
                         "folder_id": 200,
                         "updated_at": "updated_at_2",
                         "type": "File",
+                        "mime_type": "application/pdf",
                     },
                     {
                         "id": 300,
@@ -477,6 +484,7 @@ class TestCanvasAPIClientIntegrated:
                                 "folder_id": 300,
                                 "updated_at": "updated_at_3",
                                 "type": "File",
+                                "mime_type": "application/pdf",
                             }
                         ],
                     },

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -82,6 +82,7 @@ class TestCanvasStudioService:
             {
                 "type": "File",
                 "display_name": "Test video",
+                "mime_type": "video",
                 "updated_at": "2024-02-03",
                 "id": "canvas-studio://media/5",
             },
@@ -119,6 +120,7 @@ class TestCanvasStudioService:
             {
                 "type": "File",
                 "display_name": "Another video",
+                "mime_type": "video",
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/6",
             }

--- a/tests/unit/lms/services/d2l_api/client_test.py
+++ b/tests/unit/lms/services/d2l_api/client_test.py
@@ -132,6 +132,7 @@ class TestD2LAPIClient:
                                 "lms_id": "FILE 1",
                                 "type": "File",
                                 "updated_at": "DATE 1",
+                                "mime_type": "application/pdf",
                             },
                             {
                                 "display_name": "MODULE 2",
@@ -146,6 +147,7 @@ class TestD2LAPIClient:
                                         "lms_id": "FILE 2",
                                         "type": "File",
                                         "updated_at": "DATE 2",
+                                        "mime_type": "application/pdf",
                                     },
                                 ],
                             },

--- a/tests/unit/lms/services/moodle_test.py
+++ b/tests/unit/lms/services/moodle_test.py
@@ -108,6 +108,7 @@ class TestMoodleAPIClient:
                     {
                         "type": "File",
                         "display_name": "dummy.pdf",
+                        "mime_type": "application/pdf",
                         "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
                         "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1046/mod_resource/content/1/dummy.pdf?forcedownload=1",
                         "updated_at": 1707992547 * 1000,
@@ -121,6 +122,7 @@ class TestMoodleAPIClient:
                             {
                                 "type": "File",
                                 "display_name": "dummy.pdf",
+                                "mime_type": "application/pdf",
                                 "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
                                 "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/dummy.pdf?forcedownload=1",
                                 "updated_at": 1708513742 * 1000,
@@ -134,6 +136,7 @@ class TestMoodleAPIClient:
                                     {
                                         "type": "File",
                                         "display_name": "FILE IN NESTED.pdf",
+                                        "mime_type": "application/pdf",
                                         "id": "moodle://file/course/COURSE_ID/url/https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
                                         "lms_id": "https://hypothesisuniversity.moodlecloud.com/webservice/pluginfile.php/1134/mod_folder/content/3/Nested%20folder/FILE%20IN%20NESTED.pdf?forcedownload=1",
                                         "updated_at": 1708513801 * 1000,
@@ -173,15 +176,17 @@ class TestMoodleAPIClient:
                 "lms_id": "COURSE_ID-General",
                 "children": [
                     {
-                        "type": "Page",
+                        "type": "File",
                         "display_name": "A Page",
+                        "mime_type": "text/html",
                         "lms_id": 860,
                         "id": "moodle://page/course/COURSE_ID/page_id/860",
                         "updated_at": 1708598607 * 1000,
                     },
                     {
-                        "type": "Page",
+                        "type": "File",
                         "display_name": "Another Page",
+                        "mime_type": "text/html",
                         "lms_id": 1860,
                         "id": "moodle://page/course/COURSE_ID/page_id/1860",
                         "updated_at": 1708598607 * 1000,

--- a/tests/unit/lms/views/api/blackboard/files_test.py
+++ b/tests/unit/lms/views/api/blackboard/files_test.py
@@ -20,6 +20,7 @@ class TestListFiles:
                 "updated_at": "2008-05-06T07:26:35.000z",
                 "display_name": "File_1.pdf",
                 "type": "File",
+                "mime_type": "application/pdf",
                 "parent_id": None,
             },
             {

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -26,7 +26,8 @@ class TestPageAPIViews:
                     "id": f"canvas://page/course/{course_id}/page_id/{page.id}",
                     "lms_id": page.id,
                     "display_name": page.title,
-                    "type": "Page",
+                    "mime_type": "text/html",
+                    "type": "File",
                     "updated_at": page.updated_at,
                 }
                 for page in pages


### PR DESCRIPTION
Split the existing `type` field in file API responses, which indicates both whether and item is a file or folder, and also what kind of file it is (page, PDF etc.) into two separate fields: `type` for file vs folder and `mime_type` for the mime type. Then change the Canvas Studio proxy APIs to set `mime_type` to `video` and use that in the frontend to display a different icon.

**Testing:**

Start creating an assignment in Canvas and open:

1) The Canvas Page picker
2) The Canvas File picker
3) The Canvas Studio picker

For each of these pickers, you should see different icons. The video file type icon is just a placeholder to show we can render something different.