### PR TITLE
Improve TS types used to represent files and folders in cloud storage

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -14,8 +14,21 @@ export type MimeType = 'text/html' | 'application/pdf' | 'video';
 /**
  * Object representing a file or folder in cloud storage.
  */
-export type Document = {
+export type FileBase = {
   type: 'File' | 'Folder';
+
+  /** Identifier for the document within the LMS. */
+  id: string;
+
+  /** Name of the file or folder. */
+  display_name: string;
+
+  /** An ISO 8601 date string. */
+  updated_at?: string;
+};
+
+export type File = FileBase & {
+  type: 'File';
 
   /**
    * MIME type of the file.
@@ -24,29 +37,25 @@ export type Document = {
    * ("text/html").
    */
   mime_type?: MimeType;
-
-  /** Identifier for the document within the LMS. */
-  id: string;
-
-  /** Name of the document to present in the document picker. */
-  display_name: string;
-
-  /** An ISO 8601 date string. */
-  updated_at?: string;
 };
 
-/**
- * Object representing a file or folder in the LMS's file storage.
- */
-export type File = Document & {
-  /** APICallInfo for fetching a folder's content. Only present if `type` is 'Folder'. */
+export type Folder = FileBase & {
+  type: 'Folder';
+
+  /**
+   * Details of an API call to fetch the folder's children.
+   *
+   * Either this property or {@link FileBase.children} will be used to provide
+   * the children, depending on whether the backend decides to require a
+   * separate API call to fetch children or not.
+   */
   contents?: APICallInfo;
 
-  /** Only present if `type` is 'Folder'. A folder may have a parent folder. */
+  /** ID of the parent folder. */
   parent_id?: string | null;
 
-  /** Applies only when `type` is 'Folder'. A folder may contain children (files and folders). */
-  children?: File[];
+  /** Children of this folder. See {@link FileBase.contents}. */
+  children?: Array<File | Folder>;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/ContentSelector.tsx
@@ -179,7 +179,7 @@ export default function ContentSelector({
 
   const selectCanvasFile = (file: File) => {
     cancelDialog();
-    onSelectContent({ type: 'file', file: file as File });
+    onSelectContent({ type: 'file', file });
   };
 
   const selectYouTubeURL = (url: string, title?: string) => {

--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -10,22 +10,22 @@ import {
 import type { ComponentChildren } from 'preact';
 import type { JSX } from 'preact';
 
-import type { Document, MimeType } from '../api-types';
+import type { File, Folder, MimeType } from '../api-types';
 
-export type DocumentListProps<DocumentType extends Document> = {
+export type DocumentListProps = {
   /** List of document objects returned by the API */
-  documents: DocumentType[];
+  documents: Array<File | Folder>;
   /** Whether to show a loading indicator */
   isLoading?: boolean;
   /** The document within `documents` which is currently selected */
-  selectedDocument: DocumentType | null;
+  selectedDocument: File | Folder | null;
   /** Callback invoked when the user clicks on a document */
-  onSelectDocument: (doc: DocumentType | null) => void;
+  onSelectDocument: (doc: File | Folder | null) => void;
   /**
    * Callback invoked when the user double-clicks a document to indicate that
    * they want to use it
    */
-  onUseDocument: (d: DocumentType | null) => void;
+  onUseDocument: (d: File | Folder | null) => void;
   /** Optional message to display if there are no documents */
   noDocumentsMessage?: ComponentChildren;
   /** Component title for accessibility */
@@ -43,7 +43,7 @@ const mimeTypeIcons: Record<MimeType, IconComponent> = {
 /**
  * List of files and folders in a file picker.
  */
-export default function DocumentList<DocumentType extends Document>({
+export default function DocumentList({
   documents,
   isLoading = false,
   selectedDocument,
@@ -51,7 +51,7 @@ export default function DocumentList<DocumentType extends Document>({
   onUseDocument,
   noDocumentsMessage,
   title,
-}: DocumentListProps<DocumentType>) {
+}: DocumentListProps) {
   const formatDate = (isoString: string) =>
     new Date(isoString).toLocaleDateString();
   const columns = [
@@ -66,7 +66,10 @@ export default function DocumentList<DocumentType extends Document>({
     },
   ];
 
-  const renderItem = (document: DocumentType, field: keyof DocumentType) => {
+  const renderItem = (
+    document: File | Folder,
+    field: keyof (File | Folder),
+  ) => {
     switch (field) {
       case 'display_name': {
         let Icon;


### PR DESCRIPTION
Previously there were confusingly two similar-sounding types `File` and `Document`, where `Document` actually had common properties for files and folders, and `File` had the additional properties for folders.

Refactor this so we have:

 - A base type `FileBase` containing common properties for files and folders
 - Sub-types `File` and `Folder` which contain properties exclusive to files and folders respectively

Then refactor various uses of the File/Document types to make it clearer whether that code path expects files, folders or both.

This change only affects type declarations and usage, so there should be no functional changes.