### PR TITLE
Canvas group sets course copy fix

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,5 +1,5 @@
-from typing import TypedDict
 from enum import Enum
+from typing import TypedDict
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,3 +1,4 @@
+from typing import TypedDict
 from enum import Enum
 
 import sqlalchemy as sa
@@ -167,6 +168,17 @@ class MoodleGroup(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.MOODLE_GROUP}
 
 
+class GroupSet(TypedDict):
+    """
+    Group sets are a collection of student groups.
+
+    We store them in Course.extra
+    """
+
+    id: str
+    name: str
+
+
 class Course(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
 
@@ -187,7 +199,7 @@ class Course(Grouping):
         group_sets = [{"id": str(g["id"]), "name": g["name"]} for g in group_sets]
         self.extra["group_sets"] = group_sets
 
-    def get_group_sets(self) -> list[dict]:
+    def get_group_sets(self) -> list[GroupSet]:
         """Get this course's available group sets."""
         return self.extra.get("group_sets", [])
 

--- a/lms/product/canvas/_plugin/course_copy.py
+++ b/lms/product/canvas/_plugin/course_copy.py
@@ -1,4 +1,4 @@
-from lms.product.plugin.course_copy import CourseCopyFilesHelper
+from lms.product.plugin.course_copy import CourseCopyFilesHelper, CourseCopyGroupsHelper
 
 
 class CanvasCourseCopyPlugin:
@@ -7,10 +7,17 @@ class CanvasCourseCopyPlugin:
     file_type = "canvas_file"
     page_type = "canvas_page"
 
-    def __init__(self, api, file_service, files_helper: CourseCopyFilesHelper):
+    def __init__(
+        self,
+        api,
+        file_service,
+        files_helper: CourseCopyFilesHelper,
+        groups_helper: CourseCopyGroupsHelper,
+    ):
         self._api = api
         self._file_service = file_service
         self._files_helper = files_helper
+        self._groups_helper = groups_helper
 
     def is_file_in_course(self, course_id, file_id):
         return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
@@ -44,12 +51,10 @@ class CanvasCourseCopyPlugin:
             self._api.pages.list, self.page_type, original_page_id, new_course_id
         )
 
-    def find_matching_group_set_in_course(self, _course, _group_set_id):
-        # We are not yet handling course copy for groups in Canvas.
-        # Canvas doesn't copy group sets during course copy so the approach taken
-        # in other LMS won't make sense here.
-        # We implement this method so we can call `find_mapped_group_set_id` in all LMS's
-        return None
+    def find_matching_group_set_in_course(self, course, group_set_id):
+        return self._groups_helper.find_matching_group_set_in_course(
+            course, group_set_id
+        )
 
     @classmethod
     def factory(cls, _context, request):
@@ -57,4 +62,5 @@ class CanvasCourseCopyPlugin:
             api=request.find_service(name="canvas_api_client"),
             file_service=request.find_service(name="file"),
             files_helper=request.find_service(CourseCopyFilesHelper),
+            groups_helper=request.find_service(CourseCopyGroupsHelper),
         )

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -102,7 +102,7 @@ class CourseCopyGroupsHelper:
         # We might have a record of this because we just called `grouping_plugin.get_group_sets` as the current user
         # or another user might have done it before for us.
         if new_group_set := self._course_service.find_group_set(
-            name=group_set.name, context_id=course.lms_id
+            name=group_set["name"], context_id=course.lms_id
         ):
             # We found a match, store it to save the search for next time
             course.set_mapped_group_set_id(group_set_id, new_group_set.id)

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -105,8 +105,8 @@ class CourseCopyGroupsHelper:
             name=group_set["name"], context_id=course.lms_id
         ):
             # We found a match, store it to save the search for next time
-            course.set_mapped_group_set_id(group_set_id, new_group_set.id)
-            return new_group_set.id
+            course.set_mapped_group_set_id(group_set_id, new_group_set["id"])
+            return new_group_set["id"]
 
         # No match
         return None

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -95,7 +95,9 @@ class GroupingPlugin:
 class GroupError(Exception):
     """Exceptions raised by plugins."""
 
-    def __init__(self, error_code: Enum, group_set):
+    def __init__(
+        self, error_code: Enum, group_set: str, group_set_name: str | None = None
+    ):
         self.error_code = error_code
-        self.details = {"group_set": group_set}
+        self.details = {"group_set_id": group_set, "group_set_name": group_set_name}
         super().__init__(self.details)

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -193,7 +193,9 @@ class CourseService:
             query = query.filter(group_set.c.id == group_set_id)
 
         if name:
-            query = query.filter(group_set.c.name == name)
+            query = query.filter(
+                func.lower(func.trim(group_set.c.name)) == func.lower(func.trim(name))
+            )
 
         return query.first()
 

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -197,7 +197,10 @@ class CourseService:
                 func.lower(func.trim(group_set.c.name)) == func.lower(func.trim(name))
             )
 
-        return query.first()
+        if group_set := query.first():
+            return {"id": group_set.id, "name": group_set.name}
+
+        return None
 
     def _get_authority_provided_id(self, context_id):
         return self._grouping_service.get_authority_provided_id(

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -287,24 +287,36 @@ export default function LaunchErrorDialog({
           title="Group set not found"
         >
           <p>
-            Hypothesis couldn&apos;t find this assignment&apos;s group set. This
+            This Hypothesis assignment was set up to use Canvas{"'"} Group Sets,
+            and we can no longer find the Group Set for this assignment. This
             could be because:
           </p>
 
           <ul className="px-4 list-disc">
             <li>The group set has been deleted from Canvas.</li>
-            <li>
-              This course was created by copying another course (Canvas
-              doesn&apos;t copy the group sets over when you copy a course).
-            </li>
+            <li>This course was created by copying another course.</li>
           </ul>
+          <p>
+            If the group set has been <b>deleted</b> from this course, an
+            instructor needs to edit the assignment settings and select a group
+            set.
+          </p>
 
           <p>
-            <b>
-              To fix this problem, an instructor needs to edit the assignment
-              settings and select a new group set.
-            </b>
+            If this is a <b>copied course</b> the instructor needs to create a
+            new group set in this course that matches the name of the group set
+            in the old course.
           </p>
+          {error?.details &&
+            typeof error.details === 'object' &&
+            'group_set_name' in error.details &&
+            typeof error.details.group_set_name === 'string' && (
+              <p>
+                {' '}
+                The group set name in the old course was:{' '}
+                <b>{error.details.group_set_name}</b>
+              </p>
+            )}
         </ErrorModal>
       );
 

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -116,7 +116,7 @@ describe('LaunchErrorDialog', () => {
     {
       errorState: 'canvas_group_set_not_found',
       expectedText:
-        "Hypothesis couldn't find this assignment's group set. This could be because:The group set has been deleted from Canvas.This course was created by copying another course (Canvas doesn't copy the group sets over when you copy a course).",
+        "This Hypothesis assignment was set up to use Canvas' Group Sets, and we can no longer find the Group Set for this assignment.",
       expectedTitle: 'Group set not found',
       hasRetry: false,
       withError: true,

--- a/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/course_copy_test.py
@@ -7,9 +7,18 @@ from tests import factories
 
 
 class TestCanvasCourseCopyPlugin:
-    def test_find_matching_group_set_in_course(self, plugin):
-        assert not plugin.find_matching_group_set_in_course(
+    def test_find_matching_group_set_in_course(self, plugin, course_copy_groups_helper):
+        result = plugin.find_matching_group_set_in_course(
             sentinel.course, sentinel.group_set_id
+        )
+
+        course_copy_groups_helper.find_matching_group_set_in_course.assert_called_once_with(
+            sentinel.course, sentinel.group_set_id
+        )
+
+        assert (
+            result
+            == course_copy_groups_helper.find_matching_group_set_in_course.return_value
         )
 
     def test_is_file_in_course(self, plugin, course_copy_files_helper):
@@ -113,7 +122,10 @@ class TestCanvasCourseCopyPlugin:
         )
 
     @pytest.mark.usefixtures(
-        "canvas_api_client", "file_service", "course_copy_files_helper"
+        "canvas_api_client",
+        "file_service",
+        "course_copy_files_helper",
+        "course_copy_groups_helper",
     )
     def test_factory(self, pyramid_request):
         plugin = CanvasCourseCopyPlugin.factory(sentinel.context, pyramid_request)
@@ -121,9 +133,16 @@ class TestCanvasCourseCopyPlugin:
         assert isinstance(plugin, CanvasCourseCopyPlugin)
 
     @pytest.fixture
-    def plugin(self, canvas_api_client, file_service, course_copy_files_helper):
+    def plugin(
+        self,
+        canvas_api_client,
+        file_service,
+        course_copy_files_helper,
+        course_copy_groups_helper,
+    ):
         return CanvasCourseCopyPlugin(
             api=canvas_api_client,
             file_service=file_service,
             files_helper=course_copy_files_helper,
+            groups_helper=course_copy_groups_helper,
         )

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -110,8 +110,9 @@ class TestCanvasGroupingPlugin:
         assert canvas_api_client.group_category_groups.return_value == api_groups
 
     def test_get_groups_for_instructor_group_set_not_found(
-        self, grouping_service, canvas_api_client, course, plugin
+        self, grouping_service, canvas_api_client, course, plugin, course_service
     ):
+        course_service.find_group_set.return_value = None
         canvas_api_client.group_category_groups.side_effect = CanvasAPIError()
 
         with pytest.raises(GroupError) as err:
@@ -119,7 +120,34 @@ class TestCanvasGroupingPlugin:
                 grouping_service, course, sentinel.group_set_id
             )
 
+        course_service.find_group_set.assert_called_once_with(
+            group_set_id=sentinel.group_set_id
+        )
         assert err.value.error_code == ErrorCodes.GROUP_SET_NOT_FOUND
+        assert err.value.details == {
+            "group_set_id": sentinel.group_set_id,
+            "group_set_name": None,
+        }
+
+    def test_get_groups_for_instructor_group_set_not_found_with_original_name(
+        self, grouping_service, canvas_api_client, course, plugin, course_service
+    ):
+        course_service.find_group_set.return_value = {"name": sentinel.name}
+        canvas_api_client.group_category_groups.side_effect = CanvasAPIError()
+
+        with pytest.raises(GroupError) as err:
+            plugin.get_groups_for_instructor(
+                grouping_service, course, sentinel.group_set_id
+            )
+
+        course_service.find_group_set.assert_called_once_with(
+            group_set_id=sentinel.group_set_id
+        )
+        assert err.value.error_code == ErrorCodes.GROUP_SET_NOT_FOUND
+        assert err.value.details == {
+            "group_set_name": sentinel.name,
+            "group_set_id": sentinel.group_set_id,
+        }
 
     def test_get_groups_for_instructor_group_set_empty(
         self, grouping_service, canvas_api_client, course, plugin
@@ -204,5 +232,7 @@ class TestCanvasGroupingPlugin:
         )
 
     @pytest.fixture
-    def plugin(self, canvas_api_client):
-        return CanvasGroupingPlugin(canvas_api_client, strict_section_membership=False)
+    def plugin(self, canvas_api_client, pyramid_request):
+        return CanvasGroupingPlugin(
+            canvas_api_client, strict_section_membership=False, request=pyramid_request
+        )

--- a/tests/unit/lms/product/plugin/course_copy_test.py
+++ b/tests/unit/lms/product/plugin/course_copy_test.py
@@ -140,9 +140,9 @@ class TestCourseCopyGroupsHelper:
             context_id=course.lms_id,
         )
         course.set_mapped_group_set_id(
-            sentinel.group_set_id, course_service.find_group_set.return_value.id
+            sentinel.group_set_id, course_service.find_group_set.return_value["id"]
         )
-        assert new_group_set_id == course_service.find_group_set.return_value.id
+        assert new_group_set_id == course_service.find_group_set.return_value["id"]
 
     def test_find_matching_file_raises_OAuth2TokenError(self, helper, grouping_plugin):
         grouping_plugin.get_group_sets.side_effect = OAuth2TokenError

--- a/tests/unit/lms/product/plugin/course_copy_test.py
+++ b/tests/unit/lms/product/plugin/course_copy_test.py
@@ -121,7 +121,7 @@ class TestCourseCopyFilesHelper:
 
 class TestCourseCopyGroupsHelper:
     @pytest.mark.parametrize("raising", [True, False])
-    def test_find_matching_file_in_course(
+    def test_find_matching_group_in_course(
         self, helper, grouping_plugin, raising, course_service, course
     ):
         if raising:
@@ -136,7 +136,7 @@ class TestCourseCopyGroupsHelper:
             group_set_id=sentinel.group_set_id
         )
         course_service.find_group_set.assert_called_with(
-            name=course_service.find_group_set.return_value.name,
+            name=course_service.find_group_set.return_value["name"],
             context_id=course.lms_id,
         )
         course.set_mapped_group_set_id(
@@ -152,7 +152,7 @@ class TestCourseCopyGroupsHelper:
                 sentinel.course, sentinel.group_set_id
             )
 
-    def test_find_matching_file_in_course_no_stored_group_from_original_course(
+    def test_find_matching_group_in_course_no_stored_group_from_original_course(
         self, helper, grouping_plugin, course_service, course
     ):
         course_service.find_group_set.return_value = None
@@ -167,7 +167,7 @@ class TestCourseCopyGroupsHelper:
         )
         assert not new_group_set_id
 
-    def test_find_matching_file_in_course_no_stored_group_from_new_course(
+    def test_find_matching_group_in_course_no_stored_group_from_new_course(
         self, helper, grouping_plugin, course_service, course
     ):
         course_service.find_group_set.side_effect = [
@@ -184,7 +184,7 @@ class TestCourseCopyGroupsHelper:
             group_set_id=sentinel.group_set_id
         )
         course_service.find_group_set.assert_called_with(
-            name=course_service.find_group_set.return_value.name,
+            name=course_service.find_group_set.return_value["name"],
             context_id=course.lms_id,
         )
         assert not new_group_set_id

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -253,8 +253,8 @@ class TestCourseService:
     def test_find_group_set(self, svc, params):
         group_set = svc.find_group_set(**params)
 
-        assert group_set.id == "ID"
-        assert group_set.name == "NAME"
+        assert group_set["id"] == "ID"
+        assert group_set["name"] == "NAME"
 
     @pytest.mark.usefixtures("course_with_group_sets")
     @pytest.mark.parametrize(

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -245,6 +245,8 @@ class TestCourseService:
         (
             {"context_id": "context_id", "group_set_id": "ID", "name": "NAME"},
             {"context_id": "context_id", "name": "NAME"},
+            {"context_id": "context_id", "name": "name"},
+            {"context_id": "context_id", "name": "NAME    "},
             {"context_id": "context_id", "group_set_id": "ID"},
         ),
     )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1219


## Testing

- Edit [an assignment](https://hypothesis.instructure.com/courses/125/assignments/873/edit?return_to=https%3A%2F%2Fhypothesis.instructure.com%2Fcourses%2F125%2Fassignments%2F873) in the original course. Don't save it, just arrive to the stage that list the group sets available.


We do this to simulate the original assignment configuration that, a side effect, stored the existing group sets in the DB.



- Launch [a groups assignment in the copied course](https://hypothesis.instructure.com/courses/607/assignments/5818) 


- [Change the name of the group](https://hypothesis.instructure.com/courses/607/groups#) set to match/not match the name of the old one: `Test group set` (Three dots menu on the right)


- Reset the mapping in the new course: ```delete from grouping where lms_id = '095247085b9091079de17a873cf5b9214f38c670' ; ```


- Change back to a not matching name to see the modal again.

--- 
Screenshot of the modal:

![Screenshot from 2024-04-24 15-55-11](https://github.com/hypothesis/lms/assets/1433832/5a9a4cad-3319-4428-8b90-dd47cf634a3d)

