### PR TITLE
Store known error codes as events on the DB

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -15,8 +15,10 @@ from pyramid.view import (
     view_defaults,
 )
 
+from lms.events import LTIEvent
 from lms.services import (
     CanvasAPIPermissionError,
+    EventService,
     ExternalAsyncRequestError,
     ExternalRequestError,
     OAuth2TokenError,
@@ -200,6 +202,14 @@ class APIExceptionViews:
         """
 
         if hasattr(self.context, "error_code"):
+            EventService.queue_event(
+                LTIEvent(
+                    request=self.request,
+                    type=LTIEvent.Type.ERROR_CODE,
+                    data={"code": self.context.error_code},
+                )
+            )
+
             return ErrorBody(
                 error_code=self.context.error_code,
                 message=getattr(self.context, "message", None),


### PR DESCRIPTION
Extend the mechanism we already use for `canvas_invalid_scope` to other error codes.



## Testing

- Launch a few assignment that produce error codes:

https://hypothesis.instructure.com/courses/125/assignments/1370
https://hypothesis.instructure.com/courses/125/assignments/1683

- Check the events in the DB:

```
select timestamp, type, course_id, assignment_id, extra->'code' from event join event_data on event_data.event_id = event.id  join event_type on type_id = event_type.id where type = 'error_code';



         timestamp          |    type    | course_id | assignment_id |             ?column?              
----------------------------+------------+-----------+---------------+-----------------------------------
 2024-03-22 11:15:58.536867 | error_code |      1288 |           297 | "canvas_group_set_not_found"
 2024-03-22 11:16:02.081535 | error_code |      1288 |           295 | "canvas_file_not_found_in_course"
(2 rows)
```

