### PR TITLE
Fix listing groups while configuring assignments

### DIFF
--- a/lms/views/api/groups.py
+++ b/lms/views/api/groups.py
@@ -4,7 +4,7 @@ from lms.security import Permissions
 
 
 @view_config(
-    request_method="POST",
+    request_method=["POST", "GET"],
     permission=Permissions.API,
     renderer="json",
     route_name="api.courses.group_sets.list",


### PR DESCRIPTION
This change:

https://github.com/hypothesis/lms/pull/6088/files#diff-e6f7e7b4990c33f197f354288dc4d39872ffd099166b0897d9cc3a2d7a3195fbL534

removed the need to send any data to the list group sets endpoint. As a side effect of that the FE decides to use "GET" instead of "POST" to call the endpoint.

As the endpoint was registered with "POST" the change is causing a 404 which are not recorded in sentry or otherwise raised any alarms.

Allowing both GET & POST requests for now to this endpoint until a better solutions is found.


## Testing

Go to https://hypothesis.instructure.com/courses/125/assignments/5335/edit?name=Assignment+with+no+grades&due_at=null&points_possible=0 

Select any content source and pick groups. In main you get a "Endpoint not found error". In this branch successfully returns groups.
