### PR TITLE
Launch Canvas Studio assignments using an admin account

### DIFF
--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from lms.models import OAuth2Token
 from lms.models.oauth2_token import Service
-from lms.services import OAuth2TokenError
+from lms.services.exceptions import OAuth2TokenError
 
 
 class OAuth2TokenService:
@@ -69,7 +69,9 @@ class OAuth2TokenService:
             ) from err
 
 
-def oauth2_token_service_factory(_context, request):
+def oauth2_token_service_factory(_context, request, user_id: str | None = None):
     return OAuth2TokenService(
-        request.db, request.lti_user.application_instance, request.lti_user.user_id
+        request.db,
+        request.lti_user.application_instance,
+        user_id or request.lti_user.user_id,
     )

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -268,9 +268,29 @@ class TestFactory:
         )
         assert service == OAuthHTTPService.return_value
 
+    def test_with_custom_user_id(
+        self,
+        OAuthHTTPService,
+        pyramid_request,
+        http_service,
+        oauth2_token_service_factory,
+    ):
+        service = factory(sentinel.context, pyramid_request, user_id="custom_user_id")
+        oauth2_token_service_factory.assert_called_once_with(
+            sentinel.context, pyramid_request, "custom_user_id"
+        )
+        OAuthHTTPService.assert_called_once_with(
+            http_service, oauth2_token_service_factory.return_value, Service.LMS
+        )
+        assert service == OAuthHTTPService.return_value
+
     @pytest.fixture
     def OAuthHTTPService(self, patch):
         return patch("lms.services.oauth_http.OAuthHTTPService")
+
+    @pytest.fixture
+    def oauth2_token_service_factory(self, patch):
+        return patch("lms.services.oauth_http.oauth2_token_service_factory")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The Canvas Studio API has a constraint that only the owner of a video or an admin can use the APIs for getting a video download/playback URL or the transcript. Before this PR, only the instructor who uploaded a video could actually launch the assignment.

In https://github.com/hypothesis/lms/pull/6160 a new application instance setting `canvas_studio.admin_email` was added, which specifies the email address of a user with admin permissions in Canvas Studio. In this PR, when an assignment is launched, an API token belonging to this user is used to fetch the video and transcript. In order for this to work, the admin user must authenticate Canvas Studio once by configuring or launching an assignment. The user does not have to be an administrator within Canvas itself, they just need to have the necessary permissions with Canvas Studio.

This solution is not ideal because it requires extra work for end-users to set up, and if the admin user ever revokes API access in Canvas Studio, launching assignments will break for everyone, until the admin user re-authenticates.

Summary of changes:

- Add the ability to construct instances of `OAuthHTTPService` which use a specified user ID, instead of the user ID associated with the current request
- Change `CanvasStudioService` to create two instances of `OAuthHTTPService`, one for the current user and one for the admin user
- Change the requests in `CanvasStudioService` which fetch the transcript and video to use the admin user instance of `OAuthHTTPService`, _if the current user is *not* the admin user_

**Testing:**

1. Create a Canvas Studio assignment locally
2. Attempt to launch it. This should fail with an error that no admin account is configured
3. Go into the settings for the application instance and add credentials for a user under "Canvas Studio admin account email". For testing purposes this user doesn't have to be an admin - the email of the "teacher" account you are using (who owns the video) will work
4. Launch the assignment using whichever account you have configured as the admin account
5. In a different browser, launch the assignment as a student. This should now work.

There are a variety of error scenarios that we need to handle:

- The `canvas_studio.admin_email` setting is not configured
- The current user is not an admin, and the admin user has never launched Hypothesis, so we can't look up their LTI user ID
- The current user is not an admin, the the admin user has never authenticated Canvas Studio, so we don't have a token we can use
- The current user is not an admin, and the admin user token refresh fails

See test cases for `CanvasStudioService` for the messages that each of these should generate.