### PR TITLE
Sync yarn.lock by running yarn install

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,13 +3762,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001603
-  resolution: "caniuse-lite@npm:1.0.30001603"
-  checksum: e66e0d24b899c2ed3fdcc2dd44df29c4fc06d74fa8f43abe81fc7cff4a72b092d438e0fb5b7daeb252ee267519f32c6c7d229a15e7a4f4263afef6ea3832b661
-  languageName: node
-  linkType: hard
-
 "chai@npm:^4.3.10":
   version: 4.3.10
   resolution: "chai@npm:4.3.10"


### PR DESCRIPTION
This fixes execution of `yarn install` in CI envs, where the yarn.lock file is not expected to change.

I run `yarn install` and commited the changes applied to the yarn.lock file.

This sometimes happens after merging a few dependabot pull requests.