### PR TITLE
Support re-DeepLinking for assignment created without DL.

### DIFF
--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -26,6 +26,20 @@ class MoodleMiscPlugin(MiscPlugin):
             # Get the config from the DL
             return self._assignment_config_from_deep_linked_config(deep_linked_config)
 
+        if (
+            # We found an assignment that corresponds to this launch on the DB
+            assignment
+            # That assignment was not originally DL, is was created before DL was enabled in the school
+            and not assignment.deep_linking_uuid
+            # And now has been deep linked, ie edited using the LMS re-deep-link option.
+            and deep_linked_config.get("deep_linking_uuid")
+        ):
+            # Let's store the UUID so next time we recognize correctly
+            assignment.deep_linking_uuid = deep_linked_config.get("deep_linking_uuid")
+
+            # Use the DL config instead of the one in our DB
+            return self._assignment_config_from_deep_linked_config(deep_linked_config)
+
         if assignment:
             # In other cases, if we have a record of the assignment in our DB, trust that info.
             return self._assignment_config_from_assignment(assignment)

--- a/tests/unit/lms/product/moodle/_plugin/misc_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/misc_test.py
@@ -48,6 +48,30 @@ class TestMoodlePlugin:
             "group_set_id": sentinel.group_set_id,
         }
 
+    def test_get_assignment_configuration_with_assignment_in_db_new_deep_link(
+        self, plugin, pyramid_request, get_deep_linked_assignment_configuration
+    ):
+        assignment = factories.Assignment(
+            document_url=sentinel.document_url,
+            deep_linking_uuid=None,
+            extra={"group_set_id": sentinel.group_set_id},
+        )
+
+        get_deep_linked_assignment_configuration.return_value = {
+            "url": sentinel.dl_document_url,
+            "group_set": sentinel.dl_group_set_id,
+            "deep_linking_uuid": sentinel.new_dl_uuid,
+        }
+
+        result = plugin.get_assignment_configuration(
+            pyramid_request, assignment, sentinel.historical_assignment
+        )
+        assert result == {
+            "document_url": sentinel.dl_document_url,
+            "group_set_id": sentinel.dl_group_set_id,
+        }
+        assert assignment.deep_linking_uuid == sentinel.new_dl_uuid
+
     def test_get_assignment_configuration_deep_linked_fallback(
         self, plugin, get_deep_linked_assignment_configuration
     ):


### PR DESCRIPTION
For: https://github.com/hypothesis/support/issues/108

## Testing:

From the bugreport:

> ### Steps to reproduce
> 1. Create a Hypothesis assignment in Moodle using a non-deep linked H LMS app
> 2. Enable Deep Linking in the H LMS app
> 3. Edit the assignment using the Select Content button in the deep linked H LMS app
> 4. Change the content to a different URL, PDF or Moodle Page
> 5. Accept the changes


Recorded a video going thru that and few more cases at the end

https://github.com/hypothesis/lms/assets/1433832/9131adf7-c2cf-40e5-8cfe-eee423150333


