### PR TITLE
Add Canvas Studio admin account email setting

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -24,6 +24,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("canvas", "folders_enabled", asbool),
         JSONSetting("canvas", "strict_section_membership", asbool),
         JSONSetting("canvas", "pages_enabled", asbool),
+        JSONSetting("canvas_studio", "admin_email"),
         JSONSetting("canvas_studio", "client_id"),
         JSONSetting("canvas_studio", "client_secret", JSONSetting.AES_SECRET),
         JSONSetting("canvas_studio", "domain"),

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -164,6 +164,7 @@
 
                         <fieldset class="box">
                             <legend class="label has-text-centered">Content integrations</legend>
+                            {{ settings_text_field("Canvas Studio admin account email", "canvas_studio", "admin_email") }}
                             {{ settings_text_field("Canvas Studio domain", "canvas_studio", "domain") }}
                             {{ settings_text_field("Canvas Studio client ID", "canvas_studio", "client_id") }}
                             {{ settings_secret_field("Canvas Studio client secret", "canvas_studio", "client_secret") }}


### PR DESCRIPTION
This identifies the admin account whose API token will be used to fetch videos and transcripts when launching assignments.

This is part of https://github.com/hypothesis/lms/pull/6139.