### PR TITLE
Refactor how events are built

### DIFF
--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -11,13 +11,10 @@ from lms.models import EventType
 class BaseEvent:  # pylint:disable=too-many-instance-attributes
     """Base class for generic events."""
 
-    Type = EventType.Type
-    """Expose the type here for the callers convenience"""
-
     type: EventType.Type
     """Type of the event"""
 
-    request: Request | None = None
+    request: Request
     """Reference to the current request"""
 
     user_id: int | None = None
@@ -34,60 +31,52 @@ class BaseEvent:  # pylint:disable=too-many-instance-attributes
     data: dict | None = None
     """Extra data to associate with this event"""
 
-    def __post_init__(self):
-        for event_field in fields(self):
-            getter_name = f"_get_{event_field.name}"
-
-            # If we don't have a value for `field` and we have implemented
-            # a _get_`field.name` method, use that to get a default
-            if not getattr(self, event_field.name) and hasattr(self, getter_name):
-                setattr(self, event_field.name, getattr(self, getter_name)())
+    Type = EventType.Type
+    """Expose the type here for the callers convenience"""
 
     def serialize(self) -> dict:
         return {
             field.name: getattr(self, field.name)
             for field in fields(self)
             # Excluded non-serializable fields
-            if field.name not in ["request"]
+            if field.name not in ["request", "Type"]
         }
 
 
 @dataclass
 class LTIEvent(BaseEvent):
-    """
-    Class to represent LTI-related events.
+    """Class to represent LTI-related events."""
 
-    All the _get_`field`  method are used by the base class to
-    fill up any missing fields
-    """
+    @classmethod
+    def from_request(
+        cls, request: Request, type_: EventType.Type, data: dict | None = None
+    ):
+        if not request.lti_user:
+            return cls(request=request, type=type_, data=data)
 
-    def _get_user_id(self):
-        return self.request.user.id
-
-    # These methods provide defaults for each field and are used in
-    # `BaseEvent.__post_init__` above.
-    def _get_role_ids(self):
-        return [role.id for role in self.request.lti_user.lti_roles]
-
-    def _get_application_instance_id(self):
-        return self.request.lti_user.application_instance_id
-
-    def _get_course_id(self):
-        if course := self.request.find_service(name="course").get_by_context_id(
-            self.request.lti_user.lti.course_id
+        course_id = None
+        assignment_id = None
+        if course := request.find_service(name="course").get_by_context_id(
+            request.lti_user.lti.course_id
         ):
-            return course.id
+            course_id = course.id
 
-        return None
-
-    def _get_assignment_id(self):
-        if assignment := self.request.find_service(name="assignment").get_assignment(
-            self.request.lti_user.tool_consumer_instance_guid,
-            self.request.lti_user.lti.assignment_id,
+        if assignment := request.find_service(name="assignment").get_assignment(
+            request.lti_user.tool_consumer_instance_guid,
+            request.lti_user.lti.assignment_id,
         ):
-            return assignment.id
+            assignment_id = assignment.id
 
-        return None
+        return cls(
+            request=request,
+            type=type_,
+            user_id=request.user.id,
+            role_ids=[role.id for role in request.lti_user.lti_roles],
+            application_instance_id=request.lti_user.application_instance_id,
+            course_id=course_id,
+            assignment_id=assignment_id,
+            data=data,
+        )
 
 
 @dataclass
@@ -126,44 +115,33 @@ class AuditTrailEvent(BaseEvent):
                 **kwargs,
             )
 
-    type: EventType.Type = EventType.Type.AUDIT_TRAIL
-    change: ModelChange | None = None
-
-    def _get_data(self):
-        """
-        Fill the event's data value.
-
-        This is called on BaseEvent.__post_init__
-        """
-        return asdict(self.change)
-
     @staticmethod
     def notify(request: Request, instance: Base, source="admin_pages"):
         db = request.db
+        model_changes = None
         if db.is_modified(instance):
-            request.registry.notify(
-                AuditTrailEvent(
-                    request=request,
-                    change=AuditTrailEvent.ModelChange.from_instance(
-                        instance,
-                        action="insert" if instance in db.new else "update",
-                        source=source,
-                        userid=request.identity.userid,
-                    ),
-                )
+            model_changes = AuditTrailEvent.ModelChange.from_instance(
+                instance,
+                action="insert" if instance in db.new else "update",
+                source=source,
+                userid=request.identity.userid,
             )
         elif instance in db.deleted:
+            model_changes = AuditTrailEvent.ModelChange(
+                model=instance.__class__.__name__,
+                id=instance.id,
+                action="delete",
+                source=source,
+                userid=request.identity.userid,
+                changes={},
+            )
+
+        if model_changes:
             request.registry.notify(
                 AuditTrailEvent(
+                    type=EventType.Type.AUDIT_TRAIL,
                     request=request,
-                    change=AuditTrailEvent.ModelChange(
-                        model=instance.__class__.__name__,
-                        id=instance.id,
-                        action="delete",
-                        source=source,
-                        userid=request.identity.userid,
-                        changes={},
-                    ),
+                    data=asdict(model_changes),
                 )
             )
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -227,10 +227,10 @@ class JSConfig:
             self._config["errorDialog"]["errorMessage"] = message
 
         EventService.queue_event(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=self._request,
-                type=LTIEvent.Type.ERROR_CODE,
-                data={"code": error_code},
+                type_=LTIEvent.Type.ERROR_CODE,
+                data={"code": error_code} | (error_details or {}),
             )
         )
 

--- a/lms/security.py
+++ b/lms/security.py
@@ -10,7 +10,7 @@ from pyramid.request import Request
 from pyramid.security import Allowed, Denied
 from pyramid_googleauth import GoogleSecurityPolicy
 
-from lms.models import LTIUser
+from lms.models import LTIUser, User
 from lms.services import EmailPreferencesService, UserService
 from lms.services.email_preferences import InvalidTokenError, UnrecognisedURLError
 from lms.validation.authentication import (
@@ -334,7 +334,7 @@ def get_lti_user(request) -> LTIUser | None:
     return lti_user
 
 
-def _get_user(request):
+def _get_user(request) -> User | None:
     return request.find_service(UserService).get(
         request.lti_user.application_instance, request.lti_user.user_id
     )

--- a/lms/tasks/event.py
+++ b/lms/tasks/event.py
@@ -9,4 +9,6 @@ def insert_event(event: dict) -> None:
             # pylint:disable=import-outside-toplevel,cyclic-import
             from lms.services.event import EventService
 
-            request.find_service(EventService).insert_event(BaseEvent(**event))
+            request.find_service(EventService).insert_event(
+                BaseEvent(request=request, **event)
+            )

--- a/lms/views/api/canvas/authorize.py
+++ b/lms/views/api/canvas/authorize.py
@@ -144,9 +144,9 @@ def oauth2_redirect_error(request):
         kwargs["error_code"] = error_code
 
         EventService.queue_event(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=request,
-                type=LTIEvent.Type.ERROR_CODE,
+                type_=LTIEvent.Type.ERROR_CODE,
                 data={"code": error_code},
             )
         )

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -203,9 +203,9 @@ class APIExceptionViews:
 
         if hasattr(self.context, "error_code"):
             EventService.queue_event(
-                LTIEvent(
+                LTIEvent.from_request(
                     request=self.request,
-                    type=LTIEvent.Type.ERROR_CODE,
+                    type_=LTIEvent.Type.ERROR_CODE,
                     data={"code": self.context.error_code},
                 )
             )

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -44,9 +44,9 @@ class GradingViews:
             comment=self.parsed_params.get("comment"),
         )
         self.request.registry.notify(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=self.request,
-                type=LTIEvent.Type.GRADE,
+                type_=LTIEvent.Type.GRADE,
                 data={
                     "student_user_id": self.parsed_params["student_user_id"],
                     "score": score,
@@ -114,7 +114,7 @@ class GradingViews:
             lis_result_sourcedid, pre_record_hook=CanvasPreRecordHook(self.request)
         )
         self.request.registry.notify(
-            LTIEvent(request=self.request, type=LTIEvent.Type.SUBMISSION)
+            LTIEvent.from_request(request=self.request, type_=LTIEvent.Type.SUBMISSION)
         )
         return {}
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -76,7 +76,9 @@ class BasicLaunchViews:
             )
             self._show_document(assignment)
             self.request.registry.notify(
-                LTIEvent(request=self.request, type=LTIEvent.Type.CONFIGURED_LAUNCH)
+                LTIEvent.from_request(
+                    request=self.request, type_=LTIEvent.Type.CONFIGURED_LAUNCH
+                )
             )
             return {}
 
@@ -141,9 +143,9 @@ class BasicLaunchViews:
             resource_link_id=self._resource_link_id,
         )
         self.request.registry.notify(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=self.request,
-                type=LTIEvent.Type.EDITED_ASSIGNMENT,
+                type_=LTIEvent.Type.EDITED_ASSIGNMENT,
                 data={
                     "old_url": assignment.document_url,
                     "old_group_set_id": assignment.extra.get("group_set_id"),

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -166,9 +166,9 @@ class DeepLinkingFieldsViews:
             message["https://purl.imsglobal.org/spec/lti-dl/claim/data"] = data
 
         self.request.registry.notify(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=self.request,
-                type=LTIEvent.Type.DEEP_LINKING,
+                type_=LTIEvent.Type.DEEP_LINKING,
                 data=assignment_configuration,
             )
         )
@@ -192,9 +192,9 @@ class DeepLinkingFieldsViews:
         """
         assignment_configuration = self._get_assignment_configuration(self.request)
         self.request.registry.notify(
-            LTIEvent(
+            LTIEvent.from_request(
                 request=self.request,
-                type=LTIEvent.Type.DEEP_LINKING,
+                type_=LTIEvent.Type.DEEP_LINKING,
                 data=assignment_configuration,
             )
         )

--- a/tests/unit/lms/events/event_test.py
+++ b/tests/unit/lms/events/event_test.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest.mock import sentinel
 
 import pytest
@@ -32,6 +33,17 @@ class TestBaseEvent:
 
 
 class TestLTIEvent:
+    def test_lti_event_no_lti_user(self, pyramid_request):
+        pyramid_request.lti_user = None
+
+        event = LTIEvent.from_request(request=pyramid_request, type_=sentinel.type)
+
+        assert not event.user_id
+        assert not event.role_ids
+        assert not event.application_instance_id
+        assert not event.course_id
+        assert not event.assignment_id
+
     def test_lti_event(
         self,
         pyramid_request,
@@ -41,7 +53,9 @@ class TestLTIEvent:
         lti_user,
     ):
         lti_user.lti_roles = [sentinel]
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
+        event = LTIEvent.from_request(
+            request=pyramid_request, type_=sentinel.type, data=sentinel.data
+        )
 
         assert event.user_id == pyramid_request.user.id
         assert event.role_ids == [sentinel.id]
@@ -54,6 +68,7 @@ class TestLTIEvent:
             lti_user.tool_consumer_instance_guid, lti_user.lti.assignment_id
         )
         assert event.assignment_id == assignment_service.get_assignment.return_value.id
+        assert event.data == sentinel.data
 
     @pytest.mark.usefixtures(
         "lti_role_service", "application_instance_service", "assignment_service"
@@ -61,7 +76,7 @@ class TestLTIEvent:
     def test_lti_event_when_no_course(self, pyramid_request, course_service):
         course_service.get_by_context_id.return_value = None
 
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
+        event = LTIEvent.from_request(request=pyramid_request, type_=sentinel.type)
         assert not event.course_id
 
     @pytest.mark.usefixtures(
@@ -70,25 +85,8 @@ class TestLTIEvent:
     def test_lti_event_when_no_assignment(self, pyramid_request, assignment_service):
         assignment_service.get_assignment.return_value = None
 
-        event = LTIEvent(request=pyramid_request, type=sentinel.type)
+        event = LTIEvent.from_request(request=pyramid_request, type_=sentinel.type)
         assert not event.assignment_id
-
-    def test_lti_event_with_values(self, pyramid_request):
-        event = LTIEvent(
-            request=pyramid_request,
-            type=sentinel.type,
-            user_id=sentinel.user_id,
-            role_ids=sentinel.role_ids,
-            application_instance_id=sentinel.application_instance_id,
-            course_id=sentinel.course_id,
-            assignment_id=sentinel.assignment_id,
-        )
-
-        assert event.user_id == sentinel.user_id
-        assert event.role_ids == sentinel.role_ids
-        assert event.application_instance_id == sentinel.application_instance_id
-        assert event.course_id == sentinel.course_id
-        assert event.assignment_id == sentinel.assignment_id
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
@@ -127,23 +125,7 @@ class TestAuditTrailEvent:
             },
         )
 
-    def test__get_data(self, pyramid_request):
-        kwargs = {
-            "id": sentinel.id,
-            "model": sentinel.model,
-            "source": sentinel.source,
-            "action": sentinel.action,
-            "userid": sentinel.userid,
-            "changes": sentinel.changes,
-        }
-
-        event = AuditTrailEvent(
-            request=pyramid_request, change=AuditTrailEvent.ModelChange(**kwargs)
-        )
-
-        assert event.data == kwargs
-
-    def test_notify_update_with_changes(self, pyramid_request, db_session):
+    def test_notify_update_with_data(self, pyramid_request, db_session):
         org = factories.Organization(name="OLD_NAME", enabled=True)
         db_session.flush()
         org.name = "NEW_NAME"
@@ -153,13 +135,16 @@ class TestAuditTrailEvent:
         pyramid_request.registry.notify.assert_called_once_with(
             AuditTrailEvent(
                 request=pyramid_request,
-                change=AuditTrailEvent.ModelChange(
-                    id=org.id,
-                    model="Organization",
-                    action="update",
-                    source=sentinel.source,
-                    userid=pyramid_request.identity.userid,
-                    changes={"name": ("OLD_NAME", "NEW_NAME")},
+                type=AuditTrailEvent.Type.AUDIT_TRAIL,
+                data=asdict(
+                    AuditTrailEvent.ModelChange(
+                        id=org.id,
+                        model="Organization",
+                        action="update",
+                        source=sentinel.source,
+                        userid=pyramid_request.identity.userid,
+                        changes={"name": ("OLD_NAME", "NEW_NAME")},
+                    )
                 ),
             )
         )
@@ -173,19 +158,22 @@ class TestAuditTrailEvent:
 
         pyramid_request.registry.notify.assert_called_once_with(
             AuditTrailEvent(
+                type=AuditTrailEvent.Type.AUDIT_TRAIL,
                 request=pyramid_request,
-                change=AuditTrailEvent.ModelChange(
-                    id=org.id,
-                    model="Organization",
-                    action="delete",
-                    source=sentinel.source,
-                    userid=pyramid_request.identity.userid,
-                    changes={},
+                data=asdict(
+                    AuditTrailEvent.ModelChange(
+                        id=org.id,
+                        model="Organization",
+                        action="delete",
+                        source=sentinel.source,
+                        userid=pyramid_request.identity.userid,
+                        changes={},
+                    )
                 ),
             )
         )
 
-    def test_notify_no_changes(self, pyramid_request, db_session):
+    def test_notify_no_data(self, pyramid_request, db_session):
         org = factories.Organization(name="OLD_NAME", enabled=True)
         db_session.flush()
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -630,7 +630,7 @@ class TestEnableErrorDialogMode:
     def test_it(self, js_config, LTIEvent, EventService, pyramid_request):
         js_config.enable_error_dialog_mode(
             error_code=sentinel.error_code,
-            error_details=sentinel.error_details,
+            error_details={"more": "details"},
             message=sentinel.message,
         )
         config = js_config.asdict()
@@ -638,15 +638,17 @@ class TestEnableErrorDialogMode:
         assert config["mode"] == JSConfig.Mode.ERROR_DIALOG
         assert config["errorDialog"] == {
             "errorCode": sentinel.error_code,
-            "errorDetails": sentinel.error_details,
+            "errorDetails": {"more": "details"},
             "errorMessage": sentinel.message,
         }
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.ERROR_CODE,
-            data={"code": sentinel.error_code},
+            type_=LTIEvent.Type.ERROR_CODE,
+            data={"code": sentinel.error_code, "more": "details"},
         )
-        EventService.queue_event.assert_called_once_with(LTIEvent.return_value)
+        EventService.queue_event.assert_called_once_with(
+            LTIEvent.from_request.return_value
+        )
 
     def test_it_omits_errorDetails_if_no_error_details_argument_is_given(
         self, js_config

--- a/tests/unit/lms/tasks/event_test.py
+++ b/tests/unit/lms/tasks/event_test.py
@@ -5,10 +5,10 @@ import pytest
 from lms.tasks.event import insert_event
 
 
-def test_insert_event(event_service, BaseEvent):
+def test_insert_event(event_service, BaseEvent, pyramid_request):
     insert_event({"type": "value"})
 
-    BaseEvent.assert_called_once_with(type="value")
+    BaseEvent.assert_called_once_with(request=pyramid_request, type="value")
     event_service.insert_event.assert_called_once_with(BaseEvent.return_value)
 
 

--- a/tests/unit/lms/views/api/canvas/authorize_test.py
+++ b/tests/unit/lms/views/api/canvas/authorize_test.py
@@ -176,12 +176,14 @@ class TestOAuth2RedirectError:
         enable_oauth2_redirect_error_mode = js_config.enable_oauth2_redirect_error_mode
         error_code = enable_oauth2_redirect_error_mode.call_args[1].get("error_code")
         assert error_code == JSConfig.ErrorCode.CANVAS_INVALID_SCOPE
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.ERROR_CODE,
+            type_=LTIEvent.Type.ERROR_CODE,
             data={"code": JSConfig.ErrorCode.CANVAS_INVALID_SCOPE},
         )
-        EventService.queue_event.assert_called_once_with(LTIEvent.return_value)
+        EventService.queue_event.assert_called_once_with(
+            LTIEvent.from_request.return_value
+        )
 
     def test_it_sets_the_error_details_if_theres_an_error_description(
         self, pyramid_request

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -156,12 +156,14 @@ class TestAPIError:
             message=sentinel.message,
             details=sentinel.details,
         )
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.ERROR_CODE,
+            type_=LTIEvent.Type.ERROR_CODE,
             data={"code": sentinel.error_code},
         )
-        EventService.queue_event.assert_called_once_with(LTIEvent.return_value)
+        EventService.queue_event.assert_called_once_with(
+            LTIEvent.from_request.return_value
+        )
 
     def test_it_with_a_minimal_viable_error(self, pyramid_request, views):
         class MinimalError:

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -47,8 +47,8 @@ class TestRecordCanvasSpeedgraderSubmission:
             # lti_launch_url=expected_launch_url,
             # submitted_at=datetime.datetime(2001, 1, 1, tzinfo=timezone.utc),
         )
-        LTIEvent.assert_called_once_with(
-            request=pyramid_request, type=LTIEvent.Type.SUBMISSION
+        LTIEvent.from_request.assert_called_once_with(
+            request=pyramid_request, type_=LTIEvent.Type.SUBMISSION
         )
 
     @pytest.fixture
@@ -200,9 +200,9 @@ class TestRecordResult:
         lti_grading_service.record_result.assert_called_once_with(
             "modelstudent-assignment1", score=expected, comment=comment
         )
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.GRADE,
+            type_=LTIEvent.Type.GRADE,
             data={"student_user_id": sentinel.student_user_id, "score": expected},
         )
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -93,9 +93,9 @@ class TestBasicLaunchViews:
             resource_link_id="TEST_RESOURCE_LINK_ID",
         )
         assignment = assignment_service.get_assignment.return_value
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.EDITED_ASSIGNMENT,
+            type_=LTIEvent.Type.EDITED_ASSIGNMENT,
             data={
                 "old_url": assignment.document_url,
                 "old_group_set_id": assignment.extra.get.return_value,
@@ -123,9 +123,9 @@ class TestBasicLaunchViews:
         _show_document.assert_called_once_with(
             assignment_service.get_assignment_for_launch.return_value
         )
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.CONFIGURED_LAUNCH,
+            type_=LTIEvent.Type.CONFIGURED_LAUNCH,
         )
         pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
 

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -105,12 +105,14 @@ class TestDeepLinkingFieldsView:
             ] = title
 
         jwt_service.encode_with_private_key.assert_called_once_with(message)
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.DEEP_LINKING,
+            type_=LTIEvent.Type.DEEP_LINKING,
             data=_get_assignment_configuration.return_value,
         )
-        pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
+        pyramid_request.registry.notify.has_call_with(
+            LTIEvent.from_request.return_value
+        )
         assert fields["JWT"] == jwt_service.encode_with_private_key.return_value
 
     @pytest.mark.usefixtures("LTIEvent")
@@ -151,12 +153,14 @@ class TestDeepLinkingFieldsView:
 
         fields = views.file_picker_to_form_fields_v11()
 
-        LTIEvent.assert_called_once_with(
+        LTIEvent.from_request.assert_called_once_with(
             request=pyramid_request,
-            type=LTIEvent.Type.DEEP_LINKING,
+            type_=LTIEvent.Type.DEEP_LINKING,
             data=_get_assignment_configuration.return_value,
         )
-        pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
+        pyramid_request.registry.notify.has_call_with(
+            LTIEvent.from_request.return_value
+        )
 
         content_items = {
             "@context": "http://purl.imsglobal.org/ctx/lti/v1/ContentItem",


### PR DESCRIPTION
Instead of a one method per field called using getattr use a more
explicit approach.

Using the new approach is easier to support event for which we don't have an user.


## Testing

- Clean local events:

In `make sql`

```truncate event cascade;```


- Launch https://hypothesis.instructure.com/courses/121/assignments/850 for the missing scopes event

- Launch [any assignment](https://hypothesis.instructure.com/courses/125/assignments/873)t for the launch event

- [Re-configure this assignment](https://hypothesis.instructure.com/courses/125/assignments/5115/edit?name=Hypothesis+assignment&due_at=null&points_possible=100) to get the deep linking event.

- [Edit the document of an assignment](https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2424/View?ou=6782) for the edit event

- Create/delete an override on the [admin pages](http://localhost:8001/admin/instance/8/role-overrides) for the audit event

- Check the created events:


```
select distinct type from event join event_type on
type_id = event_type.id;       

type        
------------------- 
error_code
deep_linking
configured_launch 
edited_assignment
audit
(5 rows)
```