### PR TITLE
Re-enable caching of JWKs

### DIFF
--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -140,15 +140,15 @@ class JWTService:
         )
 
     @staticmethod
-    @lru_cache
+    @lru_cache(maxsize=256)
     def _get_jwk_client(jwk_url: str):
         """
         Get a PyJWKClient for the given key set URL.
 
-        PyJWKClient maintains a cache of keys it has seen we want to keep
-        the clients around with `lru_cache` in case we can reuse that internal cache
+        PyJWKClient maintains a cache of keys it has seen.
+        We want to keep the clients around with `lru_cache` to reuse that internal cache.
         """
-        return _RequestsPyJWKClient(jwk_url)
+        return _RequestsPyJWKClient(jwk_url, cache_keys=True)
 
 
 class _RequestsPyJWKClient(jwt.PyJWKClient):

--- a/tests/unit/lms/services/jwt_test.py
+++ b/tests/unit/lms/services/jwt_test.py
@@ -96,7 +96,7 @@ class TestJWTService:
         jwt.get_unverified_header.assert_called_once_with(sentinel.id_token)
         lti_registration_service.get.assert_called_once_with("ISS", "AUD")
         _RequestsPyJWKClient.assert_called_once_with(
-            lti_registration_service.get.return_value.key_set_url
+            lti_registration_service.get.return_value.key_set_url, cache_keys=True
         )
         jwt.decode.assert_called_with(
             sentinel.id_token,


### PR DESCRIPTION
The default changed in a pyjwt release, re enable it again.

While we don't have that many registrations (the entities that have different jwt_URLs) it's probably a good practice to limit the size of the lru_cache.

In summary: the lru_cache of the client keeps one client around per jwt_url while the internal client cache keeps indivual keys for that URL identified by their ID (kid).