### PR TITLE
Register logic to allow triggering analytics dashboard opening

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -575,7 +575,11 @@ class JSConfig:
                     "enableShareLinks": False,
                     "grantToken": grant_token,
                 }
-            ]
+            ],
+            "dashboard": {
+                "showEntryPoint": True,
+                "entryPointRPCMethod": "openDashboard",
+            },
         }
 
     def _configure_groups(self, course, assignment):

--- a/lms/static/scripts/frontend_apps/services/client-rpc.ts
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.ts
@@ -137,6 +137,10 @@ export class ClientRPC extends TinyEmitter {
       },
     );
 
+    this._server.register('openDashboard', () => {
+      console.log('Open dashboard');
+    });
+
     this._resolveGroups = () => {};
     const groups = new Promise(resolve => {
       this._resolveGroups = resolve;


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/pull/6320

Make JSConfig class register the proper hypothesis client's `dashboard` config, and define the logic to be triggered when the `openDashboard` RPC method is called.