### PR TITLE
Add relationship from assignment to groupings

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -76,6 +77,9 @@ class Assignment(CreatedUpdatedMixin, Base):
 
     deep_linking_uuid: Mapped[str | None] = mapped_column(sa.Unicode, nullable=True)
     """UUID that identifies the deep linking that created this assignment."""
+
+    groupings = association_proxy("assignment_grouping", "grouping")
+    """List of groupings this assigments is related to."""
 
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)

--- a/lms/models/assignment_grouping.py
+++ b/lms/models/assignment_grouping.py
@@ -14,11 +14,15 @@ class AssignmentGrouping(CreatedUpdatedMixin, Base):
         sa.ForeignKey("assignment.id", ondelete="cascade"),
         primary_key=True,
     )
-    assignment = sa.orm.relationship("Assignment", foreign_keys=[assignment_id])
+    assignment = sa.orm.relationship(
+        "Assignment", foreign_keys=[assignment_id], backref="assignment_grouping"
+    )
     """The assignment."""
 
     grouping_id = sa.Column(
         sa.Integer(), sa.ForeignKey("grouping.id", ondelete="cascade"), primary_key=True
     )
-    grouping = sa.orm.relationship("Grouping", foreign_keys=[grouping_id])
+    grouping = sa.orm.relationship(
+        "Grouping", foreign_keys=[grouping_id], backref="groupings"
+    )
     """The grouping the assignment is a part of."""


### PR DESCRIPTION
This allows to do `assignment.groupings` to get the list of groupings a assignment has been seen in.

Without this you have to manually build the query, which is not that complex but it get tiring after a few times.