### PR TITLE
Disable video download controls for Canvas Studio videos

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -81,6 +81,7 @@ def via_video_url(
             urlencode(
                 {
                     **_common_via_params(request),
+                    "allow_download": "0",  # Disable download controls in UI
                     "url": canonical_url,
                     "media_url": download_url,
                     "transcript": transcript_url,

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -95,6 +95,7 @@ class TestViaVideoURL:
         expected_url_params = dict(DEFAULT_OPTIONS)
         expected_url_params.update(
             {
+                "allow_download": "0",
                 "url": canonical_url,
                 "media_url": download_url,
                 "transcript": transcript_url,


### PR DESCRIPTION
This matches the behavior of Canvas Studio's own video player, although that player uses a different mechanism (overlaying a transparent element above the video to intercept clicks).

See also https://github.com/hypothesis/via/pull/1329.

**Testing:**

- Launch the Canvas Studio video assignment at https://hypothesis.instructure.com/courses/125/assignments/6473. The video's context menu and built-in download controls should be removed.