### PR TITLE
Underline links in error dialog

### DIFF
--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -128,7 +128,7 @@ export default function ErrorDisplay({
           <Link
             href={supportURL(message, error)}
             target="_blank"
-            underline="none"
+            underline="always"
           >
             open a support ticket
           </Link>{' '}
@@ -136,7 +136,7 @@ export default function ErrorDisplay({
           <Link
             href="https://web.hypothes.is/help/"
             target="_blank"
-            underline="none"
+            underline="always"
           >
             help documents
           </Link>


### PR DESCRIPTION
Links which appear in the middle of a sentence or paragraph should always be underlined, unless there is another strong link-ness cue, for the benefit of users who can't distinguish the color difference.

**Preview:**

<img width="609" alt="Error dialog links" src="https://github.com/hypothesis/lms/assets/2458/92e38802-2de6-4c7d-8b27-134b0da621ed">
