### PR TITLE
Create dashboard miniapp

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -235,12 +235,13 @@ class JSConfig:
         self._config.update(
             {
                 "mode": JSConfig.Mode.DASHBOARD,
-                "assignment": {"title": assignment.title},
-                "assignmentStatsApi": {
-                    "path": self._request.route_path(
-                        "api.assignment.stats", id_=assignment.id
-                    ),
-                    "data": {},
+                "dashboard": {
+                    "assignment": {"title": assignment.title},
+                    "assignmentStatsApi": {
+                        "path": self._request.route_path(
+                            "api.assignment.stats", id_=assignment.id
+                        ),
+                    },
                 },
             }
         )

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -142,3 +142,13 @@ export type YouTubeVideoInfo = {
   image: string;
   restrictions: YouTubeVideoRestriction[];
 };
+
+/**
+ * Individual items in response for `/api/assignment/{assignment_id}/stats` call.
+ */
+export type StudentStats = {
+  display_name: string;
+  last_activity: string;
+  annotations: number;
+  replies: number;
+};

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -11,6 +11,7 @@ import EmailPreferencesApp from './EmailPreferencesApp';
 import ErrorDialogApp from './ErrorDialogApp';
 import FilePickerApp, { loadFilePickerConfig } from './FilePickerApp';
 import OAuth2RedirectErrorApp from './OAuth2RedirectErrorApp';
+import DashboardApp from './dashboard/DashboardApp';
 
 export type AppRootProps = {
   /** Initial route and configuration for the frontend, read from the HTML page. */
@@ -39,6 +40,9 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
             >
               <FilePickerApp />
             </DataLoader>
+          </Route>
+          <Route path="/dashboard/assignment/:assignmentId">
+            <DashboardApp />
           </Route>
           <Route path="/email/preferences">
             <EmailPreferencesApp />

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,0 +1,48 @@
+import classnames from 'classnames';
+import { useParams } from 'wouter-preact';
+
+import type { StudentStats } from '../../api-types';
+import { useConfig } from '../../config';
+import { apiCall } from '../../utils/api';
+import { useFetch } from '../../utils/fetch';
+import StudentsActivityTable from './StudentsActivityTable';
+
+export default function DashboardApp() {
+  const { assignmentId } = useParams<{ assignmentId: string }>();
+  const { dashboard, api } = useConfig(['dashboard', 'api']);
+  const assignment = {
+    title: dashboard.assignment.title,
+    id: assignmentId,
+  };
+  const students = useFetch<StudentStats[]>(`${assignmentId}_students`, () =>
+    apiCall({
+      authToken: api.authToken,
+      method: 'GET',
+      path: dashboard.assignmentStatsApi.path,
+    }),
+  );
+
+  return (
+    <div className="min-h-full bg-grey-2">
+      <div
+        className={classnames(
+          'flex justify-center p-3 mb-5 w-full',
+          'bg-white border-b shadow',
+        )}
+      >
+        <img
+          alt="Hypothesis logo"
+          src="/static/images/email_header.png"
+          className="h-10"
+        />
+      </div>
+      <div className="mx-auto max-w-6xl">
+        <StudentsActivityTable
+          assignment={assignment}
+          students={students.data ?? []}
+          loading={students.isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
@@ -1,0 +1,101 @@
+import { Card, CardContent, DataTable } from '@hypothesis/frontend-shared';
+import type { DataTableProps } from '@hypothesis/frontend-shared';
+import { useMemo, useState } from 'preact/hooks';
+
+import type { StudentStats } from '../../api-types';
+import { formatDateTime } from '../../utils/date';
+
+export type AssignmentInfo = {
+  id: string;
+  title: string;
+};
+
+export type StudentsActivityTableProps = {
+  assignment: AssignmentInfo;
+  students: StudentStats[];
+  loading?: boolean;
+};
+
+type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
+
+function useOrderedRows<T>(rows: T[], order: MandatoryOrder<T>) {
+  return useMemo(
+    () =>
+      [...rows].sort((a, b) => {
+        if (a[order.field] === b[order.field]) {
+          return 0;
+        }
+
+        if (order.direction === 'ascending') {
+          return a[order.field] > b[order.field] ? 1 : -1;
+        }
+
+        return a[order.field] > b[order.field] ? -1 : 1;
+      }),
+    [order, rows],
+  );
+}
+
+export default function StudentsActivityTable({
+  assignment,
+  students,
+  loading,
+}: StudentsActivityTableProps) {
+  const title = `Student activity for assignment "${assignment.title}"`;
+  const [order, setOrder] = useState<MandatoryOrder<StudentStats>>({
+    field: 'display_name',
+    direction: 'ascending',
+  });
+  const orderedStudents = useOrderedRows(students, order);
+
+  return (
+    <Card>
+      <CardContent>
+        <h2 className="text-brand mb-3 text-xl" data-testid="title">
+          {title}
+        </h2>
+        <DataTable
+          emptyMessage="No students found"
+          title={title}
+          columns={[
+            { field: 'display_name', label: 'Name', classes: 'w-[60%]' },
+            {
+              field: 'annotations',
+              label: 'Annotations',
+              classes: 'text-right',
+            },
+            { field: 'replies', label: 'Replies', classes: 'text-right' },
+            {
+              field: 'last_activity',
+              label: 'Last Activity',
+              classes: 'text-right',
+            },
+          ]}
+          rows={orderedStudents}
+          renderItem={(stats, field) => {
+            if (field === 'display_name') {
+              return stats[field];
+            }
+
+            return (
+              <div className="text-right" data-testid={`${field}-col`}>
+                {field === 'last_activity' && stats[field]
+                  ? formatDateTime(new Date(stats[field]))
+                  : stats[field]}
+              </div>
+            );
+          }}
+          loading={loading}
+          orderableColumns={[
+            'display_name',
+            'annotations',
+            'replies',
+            'last_activity',
+          ]}
+          order={order}
+          onOrderChange={setOrder}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardApp-test.js
@@ -1,0 +1,112 @@
+import { mockImportedComponents } from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { Config } from '../../../config';
+import DashboardApp, { $imports } from '../DashboardApp';
+
+describe('DashboardApp', () => {
+  let fakeApiCall;
+  let fakeConfig;
+  let fakeUseParams;
+
+  beforeEach(() => {
+    fakeApiCall = sinon.stub().resolves([]);
+    fakeUseParams = sinon.stub().returns({ assignmentId: '123' });
+    fakeConfig = {
+      dashboard: {
+        assignment: {
+          title: 'The assignment',
+        },
+        assignmentStatsApi: {
+          path: '/api/assignment/123/stats',
+        },
+      },
+      api: { authToken: 'authToken' },
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      'wouter-preact': { useParams: fakeUseParams },
+      '../../utils/api': { apiCall: fakeApiCall },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent() {
+    return mount(
+      <Config.Provider value={fakeConfig}>
+        <DashboardApp />
+      </Config.Provider>,
+    );
+  }
+
+  it('loads assignment stats on mount, via API call', () => {
+    assert.notCalled(fakeApiCall);
+    createComponent();
+    assert.calledWith(fakeApiCall, {
+      authToken: 'authToken',
+      method: 'GET',
+      path: '/api/assignment/123/stats',
+    });
+  });
+
+  it('passes assignment info down to StudentsActivityTable', () => {
+    const wrapper = createComponent();
+    const table = wrapper.find('StudentsActivityTable');
+
+    assert.deepEqual(table.prop('assignment'), {
+      title: 'The assignment',
+      id: '123',
+    });
+  });
+
+  context('when loading students', () => {
+    const configureApiCall = () => {
+      let resolve;
+      const promise = new Promise(r => {
+        resolve = r;
+      });
+      fakeApiCall.returns(promise);
+
+      return async (wrapper, studentsList = []) => {
+        resolve(studentsList);
+        await promise;
+        wrapper.update();
+      };
+    };
+
+    it('passes loading state down to StudentsActivityTable', async () => {
+      const resolveApiCall = configureApiCall();
+      const wrapper = createComponent();
+
+      // Loading is initially true
+      assert.isTrue(wrapper.find('StudentsActivityTable').prop('loading'));
+
+      // Once the API call promise resolves, it transitions to "not loading"
+      await resolveApiCall(wrapper);
+      assert.isFalse(wrapper.find('StudentsActivityTable').prop('loading'));
+    });
+
+    it('passes list of students down to StudentsActivityTable', async () => {
+      const resolveApiCall = configureApiCall();
+      const wrapper = createComponent();
+
+      // Students is an empty list initially
+      assert.deepEqual(
+        wrapper.find('StudentsActivityTable').prop('students'),
+        [],
+      );
+
+      // Once the API call promise resolves, it passes actual data
+      await resolveApiCall(wrapper, [1, 2, 3]);
+      assert.deepEqual(
+        wrapper.find('StudentsActivityTable').prop('students'),
+        [1, 2, 3],
+      );
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivityTable-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivityTable-test.js
@@ -1,0 +1,196 @@
+import { mount } from 'enzyme';
+
+import StudentsActivityTable from '../StudentsActivityTable';
+
+describe('StudentsActivityTable', () => {
+  function createComponent({
+    students = [],
+    title = 'The assignment',
+    loading,
+  } = {}) {
+    return mount(
+      <StudentsActivityTable
+        students={students}
+        assignment={{ id: '123', title }}
+        loading={loading}
+      />,
+    );
+  }
+
+  ['foo', 'Assignment', 'Hello World'].forEach(title => {
+    it('shows expected title', () => {
+      const wrapper = createComponent({ title });
+      const titleElement = wrapper.find('[data-testid="title"]');
+      const tableElement = wrapper.find('DataTable');
+      const expectedTitle = `Student activity for assignment "${title}"`;
+
+      assert.equal(titleElement.text(), expectedTitle);
+      assert.equal(tableElement.prop('title'), expectedTitle);
+    });
+  });
+
+  [true, false].forEach(loading => {
+    it('sets loading state in table', () => {
+      const wrapper = createComponent({ loading });
+      assert.equal(wrapper.find('DataTable').prop('loading'), loading);
+    });
+  });
+
+  [
+    {
+      orderToSet: { field: 'annotations', direction: 'descending' },
+      expectedStudents: [
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'replies', direction: 'ascending' },
+      expectedStudents: [
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'last_activity', direction: 'descending' },
+      expectedStudents: [
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+      ],
+    },
+  ].forEach(({ orderToSet, expectedStudents }) => {
+    it('orders students on order change', () => {
+      const wrapper = createComponent({
+        students: [
+          {
+            display_name: 'b',
+            last_activity: '2020-01-01T00:00:00',
+            annotations: 8,
+            replies: 0,
+          },
+          {
+            display_name: 'a',
+            last_activity: '2020-01-02T00:00:00',
+            annotations: 3,
+            replies: 20,
+          },
+          {
+            display_name: 'c',
+            last_activity: '2020-01-02T00:00:00',
+            annotations: 5,
+            replies: 100,
+          },
+        ],
+      });
+      const getRows = () => wrapper.find('DataTable').prop('rows');
+      const getOrder = () => wrapper.find('DataTable').prop('order');
+      const setOrder = order => {
+        wrapper.find('DataTable').props().onOrderChange(order);
+        wrapper.update();
+      };
+
+      // Initially, students are ordered by name
+      assert.deepEqual(getOrder(), {
+        field: 'display_name',
+        direction: 'ascending',
+      });
+      assert.deepEqual(getRows(), [
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ]);
+
+      setOrder(orderToSet);
+      assert.deepEqual(getOrder(), orderToSet);
+      assert.deepEqual(getRows(), expectedStudents);
+    });
+  });
+
+  [
+    { fieldName: 'display_name', expectedValue: 'Jane Doe' },
+    { fieldName: 'annotations', expectedValue: '37' },
+    { fieldName: 'replies', expectedValue: '25' },
+    { fieldName: 'last_activity', expectedValue: '2024-01-01 10:35' },
+  ].forEach(({ fieldName, expectedValue }) => {
+    it('renders every field as expected', () => {
+      const studentStats = {
+        display_name: 'Jane Doe',
+        last_activity: '2024-01-01T10:35:18',
+        annotations: 37,
+        replies: 25,
+      };
+      const wrapper = createComponent();
+
+      const item = wrapper
+        .find('DataTable')
+        .props()
+        .renderItem(studentStats, fieldName);
+      const value = typeof item === 'string' ? item : mount(item).text();
+
+      assert.equal(value, expectedValue);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -73,6 +73,11 @@ describe('AppRoot', () => {
       route: '/email/preferences',
     },
     {
+      config: { mode: 'dashboard' },
+      appComponent: 'DashboardApp',
+      route: '/dashboard/assignment/123',
+    },
+    {
       config: { mode: 'error-dialog' },
       appComponent: 'ErrorDialogApp',
     },

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -29,6 +29,7 @@ export type APICallInfo = {
 export type AppMode =
   | 'basic-lti-launch'
   | 'content-item-selection'
+  | 'dashboard'
   | 'email-preferences'
   | 'error-dialog'
   | 'oauth2-redirect-error';
@@ -239,6 +240,13 @@ export type EmailPreferences = {
   flashMessage: string | null;
 };
 
+export type DashboardConfig = {
+  assignment: {
+    title: string;
+  };
+  assignmentStatsApi: APICallInfo;
+};
+
 /**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
@@ -293,6 +301,9 @@ export type ConfigObject = {
 
   // Only present in "email-preferences" mode.
   emailPreferences?: EmailPreferences;
+
+  // Only present in "dashboard" mode
+  dashboard?: DashboardConfig;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -22,11 +22,10 @@ import type { ServiceMap } from './services';
  * those routes and reloading the page results in a 404.
  */
 function routeForAppMode(mode: AppMode): string {
-  if (mode === 'email-preferences') {
-    // For the email-preferences mode, since this app is not designed to be
-    // opened in an iframe, but as the main window frame, we want to use a route
-    // that matches the server-side one.
-    return '/email/preferences';
+  // For apps not designed to be opened in an iframe, but as the main window
+  // frame, we want to keep the server-side route.
+  if (['dashboard', 'email-preferences'].includes(mode)) {
+    return location.pathname;
   }
 
   return `/app/${mode}`;

--- a/lms/static/scripts/frontend_apps/utils/date.ts
+++ b/lms/static/scripts/frontend_apps/utils/date.ts
@@ -1,0 +1,12 @@
+/**
+ * Formats a date as `YYYY-MM-DD hh:mm`, using 24h and system timezone.
+ */
+export function formatDateTime(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}

--- a/lms/static/scripts/frontend_apps/utils/test/date-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/date-test.js
@@ -1,0 +1,13 @@
+import { formatDateTime } from '../date';
+
+describe('formatDateTime', () => {
+  [
+    new Date(Date.UTC(2023, 11, 20, 3, 5, 38)),
+    new Date('2020-05-04T23:02:01+05:00'),
+  ].forEach(date => {
+    it('returns right format for provided date', () => {
+      const expectedDateRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+      assert.match(formatDateTime(date), expectedDateRegex);
+    });
+  });
+});

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -680,10 +680,11 @@ class TestEnableDashboardMode:
         config = js_config.asdict()
 
         assert config["mode"] == JSConfig.Mode.DASHBOARD
-        assert config["assignment"] == {"title": assignment.title}
-        assert config["assignmentStatsApi"] == {
-            "path": f"/api/assignment/{assignment.id}/stats",
-            "data": {},
+        assert config["dashboard"] == {
+            "assignment": {"title": assignment.title},
+            "assignmentStatsApi": {
+                "path": f"/api/assignment/{assignment.id}/stats",
+            },
         }
 
 


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/135/views/1?pane=issue&itemId=53493112

This PR adds a new client mini-app responsible of rendering the instructor dashboard.

The client-side mini-app matches the same route generated by the server, as we did with the email preferences.

https://github.com/hypothesis/lms/assets/2719332/e928da84-2631-495d-ace7-a7d5372ec416

### Out of scope

This PR does not implement everything as it was designed, and has some open questions that we'll have to handle later.

* The list of students is not paginated.
* The table can be ordered, but ordering happens client-side. If server-side pagination is added, we would need to add server-side ordering as well.
* The design ~is not exactly as in~ is currently very different than https://www.figma.com/file/rugQ2tONStRF3RL9UXZaGW/Search-Explorations?type=design&node-id=1280-38&mode=design&t=WrfvX0Y0BjqW2iuf-0. For now, we use our standard components.

### Testing steps

1. Go to http://localhost:8001/admin/instance/8/settings and check "Enable instructor dashboard".
2. Go to https://hypothesis.instructure.com/courses/125/assignments/873 and log in as an instructor user.
3. Click the user menu in the sidebar, and then select "Open dashboard". You should be redirected to the assignment dashboard in a new tab.
4. Reloading the page should still work.
5. The page should show a table with the list of students which launched the assignment at least once. For those who annotated, we should also show amount of annotations, replies, and the last time they did something.
6. If you open the same URL in an incognito window or a different browser, you should see an authorization error.