### PR TITLE
Add actual logic to open the dashboard

### DIFF
--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -239,6 +239,10 @@ export type EmailPreferences = {
   flashMessage: string | null;
 };
 
+export type DashboardConfig = {
+  dashboardEntryPoint: APICallInfo;
+};
+
 /**
  * Data/configuration needed for frontend applications in the LMS app.
  * The `mode` property specifies which frontend application should load and
@@ -293,6 +297,9 @@ export type ConfigObject = {
 
   // Only present in "email-preferences" mode.
   emailPreferences?: EmailPreferences;
+
+  // Only present for instructors
+  dashboard?: DashboardConfig;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/index.tsx
+++ b/lms/static/scripts/frontend_apps/index.tsx
@@ -70,7 +70,8 @@ export function init() {
     const clientRPC = new ClientRPC({
       authToken,
       allowedOrigins: config.rpcServer.allowedOrigins,
-      clientConfig: /** @type {ClientConfig} */ config.hypothesisClient,
+      clientConfig: config.hypothesisClient,
+      dashboardConfig: config.dashboard,
     });
     const contentInfoFetcher = new ContentInfoFetcher(authToken, clientRPC);
     const gradingService = new GradingService({

--- a/lms/static/scripts/frontend_apps/utils/dashboard-opening-form-controller.tsx
+++ b/lms/static/scripts/frontend_apps/utils/dashboard-opening-form-controller.tsx
@@ -1,0 +1,48 @@
+import { render } from 'preact';
+
+import type { DashboardConfig } from '../config';
+
+/**
+ * Handles the rendering and submitting of the form which is used to open the
+ * instructor dashboard
+ */
+export class DashboardOpeningFormController {
+  private _dashboardConfig: DashboardConfig;
+  private _authToken: string;
+
+  constructor(dashboardConfig: DashboardConfig, authToken: string) {
+    this._dashboardConfig = dashboardConfig;
+    this._authToken = authToken;
+  }
+
+  render() {
+    const container = document.createElement('div');
+    document.body.append(container);
+
+    const destroy = () => {
+      render(null, container);
+      container.remove();
+    };
+
+    render(
+      <form
+        target="_blank"
+        method="POST"
+        action={this._dashboardConfig.dashboardEntryPoint.path}
+        ref={form => {
+          if (!form) {
+            return;
+          }
+
+          // Immediately submit the form, as soon as it has been mounted
+          form.submit();
+          destroy();
+        }}
+        data-testid="dashboard-opening-form"
+      >
+        <input type="hidden" name="authorization" value={this._authToken} />
+      </form>,
+      container,
+    );
+  }
+}

--- a/lms/static/scripts/frontend_apps/utils/test/dashboard-opening-form-controller-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/dashboard-opening-form-controller-test.js
@@ -1,0 +1,32 @@
+import { DashboardOpeningFormController } from '../dashboard-opening-form-controller';
+
+describe('DashboardOpeningFormController', () => {
+  let controller;
+
+  beforeEach(() => {
+    sinon.stub(window.HTMLFormElement.prototype, 'submit');
+
+    controller = new DashboardOpeningFormController(
+      {
+        dashboardEntryPoint: { path: '/dashboard' },
+      },
+      'token',
+    );
+  });
+
+  afterEach(() => {
+    window.HTMLFormElement.prototype.submit.restore();
+  });
+
+  describe('render', () => {
+    it('submits form and removes it from DOM', () => {
+      assert.notCalled(window.HTMLFormElement.prototype.submit);
+      controller.render();
+
+      assert.called(window.HTMLFormElement.prototype.submit);
+      assert.isNull(
+        document.querySelector('[data-testid="dashboard-opening-form"]'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR is a follow-up of https://github.com/hypothesis/client/pull/6320

In here, we capture the `openDashboard` RPC method, and use it to render a temp form which sends the auth token via POST to the BE, in a new tab.

### Testing steps

1. Go to http://localhost:8001/admin/instance/8/settings and check the "Enable instructor dashboard" setting.
2. Go to https://hypothesis.instructure.com/courses/125/assignments/873 and log-in as a teacher.
3. Click the user icon in the upper-right corner of the sidebar, and then on the "Open dashboard" menu item -> You should get redirected to http://localhost:8001/dashboard/launch/assignment/82 in a new tab, where you'll see an authorization error for now.

There's work in progress to handle this token and use it to create a new cookie in https://github.com/hypothesis/lms/pull/6179.

In parallel, with that cookie you would be redirected to a new route where a FE mini-app would be rendered. That's being worked on in https://github.com/hypothesis/lms/pull/6174