### PR TITLE
Display video thumbnails in Canvas Studio picker

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -44,6 +44,7 @@ class CanvasStudioCollectionMediaSchema(RequestsResponseSchema):
         id = fields.Integer(required=True)
         title = fields.Str(required=True)
         created_at = fields.Str(required=False)
+        thumbnail_url = fields.Str(required=False)
 
     media = fields.List(fields.Nested(MediaSchema), required=True)
 
@@ -84,6 +85,7 @@ class File(TypedDict):
     id: str
     display_name: str
     updated_at: str
+    thumbnail_url: str | None
 
     contents: NotRequired[APICallInfo]
     """API call to use to fetch contents of a folder."""
@@ -240,6 +242,14 @@ class CanvasStudioService:
                     "id": f"canvas-studio://media/{media_id}",
                     "display_name": item["title"],
                     "updated_at": item["created_at"],
+                    # nb. There is a known issue with thumbnails for audio files
+                    # where the API returns a thumbnail URL, which redirects to
+                    # a `default_thumbnail` image when requested, but that URL
+                    # fails to load with a 403.
+                    #
+                    # We handle this on the frontend by rendering fallback
+                    # content if the thumbnail fails to load for any reason.
+                    "thumbnail_url": item.get("thumbnail_url", None),
                 }
             )
 

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -37,6 +37,9 @@ export type File = FileBase & {
    * ("text/html").
    */
   mime_type?: MimeType;
+
+  /** URL of a thumbnail for this item. */
+  thumbnail_url?: string;
 };
 
 export type Folder = FileBase & {

--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -49,6 +49,11 @@ type FileThumbnailProps = {
 
 /**
  * Display a media thumbnail with a fallback if the content fails to load.
+ *
+ * The fallback exists because the thumbnail URLs may refer to images hosted
+ * on third-party servers, so we can't be sure they will return valid images.
+ * The alternative would be to proxy all thumbnails through the LMS's server,
+ * which could serve a fallback if upstream fails to load.
  */
 function FileThumbnail({ src, fallback }: FileThumbnailProps) {
   const [useFallback, setUseFallback] = useState(false);

--- a/lms/static/scripts/frontend_apps/components/DocumentList.tsx
+++ b/lms/static/scripts/frontend_apps/components/DocumentList.tsx
@@ -10,6 +10,7 @@ import {
 import type { DataTableProps } from '@hypothesis/frontend-shared';
 import type { ComponentChildren } from 'preact';
 import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 
 import type { File, Folder, MimeType } from '../api-types';
 
@@ -40,6 +41,38 @@ const mimeTypeIcons: Record<MimeType, IconComponent> = {
   'text/html': FileGenericIcon,
   video: PreviewIcon,
 };
+
+type FileThumbnailProps = {
+  src: string;
+  fallback: ComponentChildren;
+};
+
+/**
+ * Display a media thumbnail with a fallback if the content fails to load.
+ */
+function FileThumbnail({ src, fallback }: FileThumbnailProps) {
+  const [useFallback, setUseFallback] = useState(false);
+  if (useFallback) {
+    return (
+      <div
+        data-testid="thumbnail-fallback"
+        className="w-[96px] flex justify-center"
+      >
+        {fallback}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      className="w-[96px] rounded"
+      data-testid="thumbnail"
+      alt=""
+      onError={() => setUseFallback(true)}
+      src={src}
+    />
+  );
+}
 
 /**
  * List of files and folders in a file picker.
@@ -81,9 +114,18 @@ export default function DocumentList({
         } else {
           Icon = FileGenericIcon;
         }
+        const icon = <Icon data-testid="icon" className="w-5 h-5" />;
+
+        let thumbnail;
+        if (document.type === 'File' && document.thumbnail_url) {
+          thumbnail = (
+            <FileThumbnail src={document.thumbnail_url} fallback={icon} />
+          );
+        }
+
         return (
           <div className="flex flex-row items-center gap-x-2">
-            <Icon className="w-5 h-5" />
+            {thumbnail ?? icon}
             {document.display_name}
           </div>
         );

--- a/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
@@ -44,6 +44,13 @@ describe('DocumentList', () => {
     // Folder
     { type: 'Folder', icon: 'FolderIcon' },
 
+    // Files with a thumbnail
+    {
+      type: 'File',
+      mime_type: 'video',
+      thumbnail_url: 'https://example.local/thumbnail.jpg',
+    },
+
     // Files with known mime type
     { type: 'File', mime_type: 'application/pdf', icon: 'FilePdfFilledIcon' },
     { type: 'File', mime_type: 'text/html', icon: 'FileGenericIcon' },
@@ -51,20 +58,53 @@ describe('DocumentList', () => {
 
     // File with unknown mime type
     { type: 'File', icon: 'FileGenericIcon' },
-  ].forEach(({ type, mime_type, icon }) => {
+  ].forEach(({ type, mime_type, icon, thumbnail_url }) => {
     it('renders documents with an icon, document name and date', () => {
       const wrapper = renderDocumentList({
-        documents: [{ ...testDocuments[0], type, mime_type }],
+        documents: [{ ...testDocuments[0], type, mime_type, thumbnail_url }],
       });
       const formattedDate = new Date(testDocuments[0]).toLocaleDateString();
       const dataRow = wrapper.find('tbody tr').at(0);
-      assert.isTrue(dataRow.find(icon).exists());
       assert.equal(
         dataRow.find('td').at(0).text(),
         testDocuments[0].display_name,
       );
+
+      if (icon) {
+        assert.isTrue(dataRow.exists(icon));
+      } else {
+        assert.isFalse(dataRow.exists('[data-testid="icon"]'));
+      }
+
+      if (thumbnail_url) {
+        const thumbnail = dataRow.find('[data-testid="thumbnail"]');
+        assert.isTrue(thumbnail.exists());
+        assert.equal(thumbnail.prop('src'), thumbnail_url);
+      }
+
       assert.equal(dataRow.find('td').at(1).text(), formattedDate);
     });
+  });
+
+  it('renders fallback if thumbnail fails to load', () => {
+    const wrapper = renderDocumentList({
+      documents: [
+        {
+          ...testDocuments[0],
+          type: 'File',
+          mime_type: 'video',
+          thumbnail_url: 'https://example.local/thumbnail.jpg',
+        },
+      ],
+    });
+    const thumbnail = wrapper.find('img[data-testid="thumbnail"]');
+    assert.isTrue(thumbnail.exists());
+
+    thumbnail.simulate('error');
+    wrapper.update();
+
+    const fallback = wrapper.find('[data-testid="thumbnail-fallback"]');
+    assert.isTrue(fallback.exists());
   });
 
   it('renders a explanatory message when there are no documents', () => {

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -89,6 +89,7 @@ class TestCanvasStudioService:
                 "mime_type": "video",
                 "updated_at": "2024-02-03",
                 "id": "canvas-studio://media/5",
+                "thumbnail_url": None,
             },
         ]
 
@@ -127,6 +128,7 @@ class TestCanvasStudioService:
                 "mime_type": "video",
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/6",
+                "thumbnail_url": "https://videos.cdn.com/thumbnails/6.jpg",
             }
         ]
 
@@ -307,8 +309,11 @@ class TestCanvasStudioService:
         def make_collection(id_, name, type_, created_at):
             return {"id": id_, "name": name, "type": type_, "created_at": created_at}
 
-        def make_file(id_, title, created_at):
-            return {"id": id_, "title": title, "created_at": created_at}
+        def make_file(id_, title, created_at, with_thumbnail=False):
+            file = {"id": id_, "title": title, "created_at": created_at}
+            if with_thumbnail:
+                file["thumbnail_url"] = f"https://videos.cdn.com/thumbnails/{id_}.jpg"
+            return file
 
         if collections is None:
             # Add default collections
@@ -339,7 +344,9 @@ class TestCanvasStudioService:
                 case "collections/8/media":
                     json_data = {
                         "media": [
-                            make_file(6, "Another video", "2024-02-04"),
+                            make_file(
+                                6, "Another video", "2024-02-04", with_thumbnail=True
+                            ),
                         ]
                     }
                 case "media/42/caption_files":


### PR DESCRIPTION
This PR adds support for displaying media thumbnails in the file picker, instead of just the generic mime-type icons, and uses this to display thumbnails for Canvas Studio videos.

For audio files, the image that Canvas Studio uses is not available (see notes in code), so we continue to render the generic media "play" icon as a fallback.

<img width="700" alt="Video thumbnails" src="https://github.com/hypothesis/lms/assets/2458/70100cdc-7c79-4121-ad6b-30aa3d8186f9">
