### PR TITLE
Sort the contents of the Canvas Studio file picker by type (collection vs video) then by title

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -220,6 +220,9 @@ class CanvasStudioService:
                 }
             )
 
+        # Sort folders by name, then list files after.
+        files.sort(key=lambda f: f["display_name"])
+
         if user_collection:
             files += self.list_collection(str(user_collection["id"]))
 
@@ -252,6 +255,8 @@ class CanvasStudioService:
                     "thumbnail_url": item.get("thumbnail_url", None),
                 }
             )
+
+        files.sort(key=lambda f: f["display_name"])
 
         return files
 

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -76,6 +76,15 @@ class TestCanvasStudioService:
         assert files == [
             {
                 "type": "Folder",
+                "display_name": "And more videos",
+                "updated_at": "2024-02-01",
+                "id": "9",
+                "contents": {
+                    "path": "http://example.com/api/canvas_studio/collections/9/media"
+                },
+            },
+            {
+                "type": "Folder",
                 "display_name": "More videos",
                 "updated_at": "2024-02-01",
                 "id": "8",
@@ -129,7 +138,15 @@ class TestCanvasStudioService:
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/6",
                 "thumbnail_url": "https://videos.cdn.com/thumbnails/6.jpg",
-            }
+            },
+            {
+                "type": "File",
+                "display_name": "Some video",
+                "mime_type": "video",
+                "updated_at": "2024-02-04",
+                "id": "canvas-studio://media/7",
+                "thumbnail_url": "https://videos.cdn.com/thumbnails/7.jpg",
+            },
         ]
 
     def test_get_canonical_video_url(self, svc):
@@ -319,6 +336,7 @@ class TestCanvasStudioService:
             # Add default collections
             collections = [
                 make_collection(1, "", "user", "2024-02-01"),
+                make_collection(9, "And more videos", "some_type", "2024-02-01"),
                 make_collection(8, "More videos", "some_type", "2024-02-01"),
             ]
 
@@ -344,6 +362,9 @@ class TestCanvasStudioService:
                 case "collections/8/media":
                     json_data = {
                         "media": [
+                            make_file(
+                                7, "Some video", "2024-02-04", with_thumbnail=True
+                            ),
                             make_file(
                                 6, "Another video", "2024-02-04", with_thumbnail=True
                             ),


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/6180**

This makes the sorting consistent with other pickers.