### PR TITLE
Change dashboard config so that the form can be sent from sidebar's frame

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -365,19 +365,17 @@ class JSConfig:
         self._config["filePicker"]["deepLinkingAPI"] = config
 
     def enable_instructor_dashboard_entry_point(self, assignment):
-        self._config["hypothesisClient"] = self._hypothesis_client
         self._hypothesis_client["dashboard"] = {
             "showEntryPoint": True,
-            "entryPointRPCMethod": "openDashboard",
-        }
-        self._config["dashboard"] = {
-            "dashboardEntryPoint": {
+            "authTokenRPCMethod": "requestAuthToken",
+            "entryPoint": {
                 "path": self._request.route_path(
                     "dashboard.launch.assignment", id_=assignment.id
                 ),
-                "data": {},
             },
+            "authFieldName": "authorization",
         }
+        self._config["hypothesisClient"] = self._hypothesis_client
 
     def enable_toolbar_editing(self):
         toolbar_config = self._get_toolbar_config()

--- a/lms/static/scripts/frontend_apps/services/client-rpc.ts
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.ts
@@ -137,6 +137,9 @@ export class ClientRPC extends TinyEmitter {
       },
     );
 
+    // Expose current auth token via RPC
+    this._server.register('requestAuthToken', () => authToken);
+
     this._resolveGroups = () => {};
     const groups = new Promise(resolve => {
       this._resolveGroups = resolve;

--- a/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
+++ b/lms/static/scripts/frontend_apps/services/test/client-rpc-test.js
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 import { $imports, ClientRPC } from '../client-rpc';
 
 describe('ClientRPC', () => {
@@ -165,6 +167,19 @@ describe('ClientRPC', () => {
           'Unable to fetch Hypothesis login. Please reload the assignment.',
         );
       }
+    });
+  });
+
+  describe('"requestAuthToken" RPC handler', () => {
+    it('returns auth token', async () => {
+      createClientRPC();
+
+      const [, callback] = fakeServerInstance.register.args.find(
+        ([method]) => method === 'requestAuthToken',
+      );
+      const returnedAuthToken = await callback();
+
+      assert.equal(authToken, returnedAuthToken);
     });
   });
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -693,15 +693,13 @@ class TestEnableInstructorDashboardEntryPoint:
         js_config.enable_instructor_dashboard_entry_point(assignment)
         config = js_config.asdict()
 
-        assert config["dashboard"] == {
-            "dashboardEntryPoint": {
-                "path": f"/dashboard/launch/assignment/{assignment.id}",
-                "data": {},
-            },
-        }
         assert config["hypothesisClient"]["dashboard"] == {
             "showEntryPoint": True,
-            "entryPointRPCMethod": "openDashboard",
+            "authTokenRPCMethod": "requestAuthToken",
+            "entryPoint": {
+                "path": f"/dashboard/launch/assignment/{assignment.id}",
+            },
+            "authFieldName": "authorization",
         }
 
 


### PR DESCRIPTION
The initial intention was that the sidebar's menu item was going to send an RPC message to the LMS font-end, and this would be programmatically submitting a form in a new tab.

However, we found a problem in Firefox, where this is not considered part of a user gesture, resulting in the new tab opening to be blocked.

This PR changes the config passed to the client so that it can be the one submitting the form by only requesting the auth token to the LMS front-end via RPC.

The client PR will follow this one.