### PR TITLE
Add duration to Canvas Studio media thumbnails

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -44,6 +44,7 @@ class CanvasStudioCollectionMediaSchema(RequestsResponseSchema):
         id = fields.Integer(required=True)
         title = fields.Str(required=True)
         created_at = fields.Str(required=False)
+        duration = fields.Float(required=False)
         thumbnail_url = fields.Str(required=False)
 
     media = fields.List(fields.Nested(MediaSchema), required=True)
@@ -84,6 +85,10 @@ class File(TypedDict):
 
     id: str
     display_name: str
+
+    duration: float | None
+    """Duration of media in seconds."""
+
     updated_at: str
     thumbnail_url: str | None
 
@@ -244,6 +249,7 @@ class CanvasStudioService:
                     "mime_type": "video",
                     "id": f"canvas-studio://media/{media_id}",
                     "display_name": item["title"],
+                    "duration": item.get("duration", None),
                     "updated_at": item["created_at"],
                     # nb. There is a known issue with thumbnails for audio files
                     # where the API returns a thumbnail URL, which redirects to

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -40,6 +40,9 @@ export type File = FileBase & {
 
   /** URL of a thumbnail for this item. */
   thumbnail_url?: string;
+
+  /** Duration of audio or video in seconds. */
+  duration?: number;
 };
 
 export type Folder = FileBase & {

--- a/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DocumentList-test.js
@@ -49,6 +49,22 @@ describe('DocumentList', () => {
       type: 'File',
       mime_type: 'video',
       thumbnail_url: 'https://example.local/thumbnail.jpg',
+      duration: 75.0,
+      formattedDuration: '01:15',
+    },
+    {
+      type: 'File',
+      mime_type: 'video',
+      thumbnail_url: 'https://example.local/thumbnail.jpg',
+      duration: 5.5,
+      formattedDuration: '00:06',
+    },
+    {
+      type: 'File',
+      mime_type: 'video',
+      thumbnail_url: 'https://example.local/thumbnail.jpg',
+      duration: 71 * 60 + 5,
+      formattedDuration: '71:05',
     },
 
     // Files with known mime type
@@ -58,33 +74,43 @@ describe('DocumentList', () => {
 
     // File with unknown mime type
     { type: 'File', icon: 'FileGenericIcon' },
-  ].forEach(({ type, mime_type, icon, thumbnail_url }) => {
-    it('renders documents with an icon, document name and date', () => {
-      const wrapper = renderDocumentList({
-        documents: [{ ...testDocuments[0], type, mime_type, thumbnail_url }],
-      });
-      const formattedDate = new Date(testDocuments[0]).toLocaleDateString();
-      const dataRow = wrapper.find('tbody tr').at(0);
-      assert.equal(
-        dataRow.find('td').at(0).text(),
-        testDocuments[0].display_name,
-      );
+  ].forEach(
+    ({ type, mime_type, icon, thumbnail_url, duration, formattedDuration }) => {
+      it('renders documents with an icon or thumbnail, document name and date', () => {
+        const wrapper = renderDocumentList({
+          documents: [
+            { ...testDocuments[0], type, mime_type, thumbnail_url, duration },
+          ],
+        });
+        const formattedDate = new Date(testDocuments[0]).toLocaleDateString();
+        const dataRow = wrapper.find('tbody tr').at(0);
+        assert.equal(
+          dataRow.find('[data-testid="display-name"]').text(),
+          testDocuments[0].display_name,
+        );
 
-      if (icon) {
-        assert.isTrue(dataRow.exists(icon));
-      } else {
-        assert.isFalse(dataRow.exists('[data-testid="icon"]'));
-      }
+        if (icon) {
+          assert.isTrue(dataRow.exists(icon));
+        } else {
+          assert.isFalse(dataRow.exists('[data-testid="icon"]'));
+        }
 
-      if (thumbnail_url) {
         const thumbnail = dataRow.find('[data-testid="thumbnail"]');
-        assert.isTrue(thumbnail.exists());
-        assert.equal(thumbnail.prop('src'), thumbnail_url);
-      }
+        assert.equal(thumbnail.exists(), !!thumbnail_url);
+        if (thumbnail_url) {
+          assert.equal(thumbnail.prop('src'), thumbnail_url);
+        }
 
-      assert.equal(dataRow.find('td').at(1).text(), formattedDate);
-    });
-  });
+        const durationEl = dataRow.find('[data-testid="duration"]');
+        assert.equal(durationEl.exists(), typeof duration === 'number');
+        if (typeof duration === 'number') {
+          assert.equal(durationEl.text(), formattedDuration);
+        }
+
+        assert.equal(dataRow.find('td').at(1).text(), formattedDate);
+      });
+    },
+  );
 
   it('renders fallback if thumbnail fails to load', () => {
     const wrapper = renderDocumentList({

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -99,6 +99,7 @@ class TestCanvasStudioService:
                 "updated_at": "2024-02-03",
                 "id": "canvas-studio://media/5",
                 "thumbnail_url": None,
+                "duration": 10.5,
             },
         ]
 
@@ -138,6 +139,7 @@ class TestCanvasStudioService:
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/6",
                 "thumbnail_url": "https://videos.cdn.com/thumbnails/6.jpg",
+                "duration": 10.5,
             },
             {
                 "type": "File",
@@ -146,6 +148,7 @@ class TestCanvasStudioService:
                 "updated_at": "2024-02-04",
                 "id": "canvas-studio://media/7",
                 "thumbnail_url": "https://videos.cdn.com/thumbnails/7.jpg",
+                "duration": 10.5,
             },
         ]
 
@@ -327,7 +330,12 @@ class TestCanvasStudioService:
             return {"id": id_, "name": name, "type": type_, "created_at": created_at}
 
         def make_file(id_, title, created_at, with_thumbnail=False):
-            file = {"id": id_, "title": title, "created_at": created_at}
+            file = {
+                "id": id_,
+                "title": title,
+                "created_at": created_at,
+                "duration": 10.5,
+            }
             if with_thumbnail:
                 file["thumbnail_url"] = f"https://videos.cdn.com/thumbnails/{id_}.jpg"
             return file


### PR DESCRIPTION
This can help the user to verify they are using the correct video/audio file. The positioning of the duration roughly matches how it is presented in Canvas Studio's own UI as well as platforms such as YouTube.

There is a known issue with our `DataTable` component where table cells that are elevated to a new stacking context can be drawn on top of the sticky table header. I will fix this separately in the `@hypothesis/frontend-shared` package.

<img width="694" alt="Video duration" src="https://github.com/hypothesis/lms/assets/2458/0c9e59cd-3d81-4abd-8109-949b8ffbd0a9">
