### PR TITLE
Adjust dashboard entry point config

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -368,11 +368,9 @@ class JSConfig:
         self._hypothesis_client["dashboard"] = {
             "showEntryPoint": True,
             "authTokenRPCMethod": "requestAuthToken",
-            "entryPoint": {
-                "path": self._request.route_path(
-                    "dashboard.launch.assignment", id_=assignment.id
-                ),
-            },
+            "entryPointURL": self._request.route_url(
+                "dashboard.launch.assignment", id_=assignment.id
+            ),
             "authFieldName": "authorization",
         }
         self._config["hypothesisClient"] = self._hypothesis_client

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -696,9 +696,7 @@ class TestEnableInstructorDashboardEntryPoint:
         assert config["hypothesisClient"]["dashboard"] == {
             "showEntryPoint": True,
             "authTokenRPCMethod": "requestAuthToken",
-            "entryPoint": {
-                "path": f"/dashboard/launch/assignment/{assignment.id}",
-            },
+            "entryPointURL": f"http://example.com/dashboard/launch/assignment/{assignment.id}",
             "authFieldName": "authorization",
         }
 


### PR DESCRIPTION
This PR adjusts the dashboard config to accommodate to what was suggested in [this comment](https://github.com/hypothesis/client/pull/6323#discussion_r1561125001)

* We don't return a `entryPoint` object with a nested `path` string, but just a plain string named `entryPointURL`
* `entryPointURL` is no longer just a path, but a fully qualified URL including the schema and authority.