### PR TITLE
Remove `document_url` param from `canvas_studio_api.via_url` route

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -84,9 +84,7 @@ class JSConfig:
         elif document_url.startswith("canvas-studio://media"):
             self._config["api"]["viaUrl"] = {
                 "authUrl": self._request.route_url("canvas_studio_api.oauth.authorize"),
-                "path": self._request.route_path(
-                    "canvas_studio_api.via_url", _query={"document_url": document_url}
-                ),
+                "path": self._request.route_path("canvas_studio_api.via_url"),
             }
 
         elif document_url.startswith("d2l://"):

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -281,7 +281,12 @@ class CanvasStudioService:
         return self._api_url(f"v1/media/{media_id}")
 
     def get_video_download_url(self, media_id: str) -> str:
-        """Return temporary download URL for a video."""
+        """
+        Return temporary download URL for a video.
+
+        Security: This method does not check whether the current user should
+        have access to this video. See `_admin_api_request`.
+        """
 
         download_rsp = self._bare_api_request(
             f"v1/media/{media_id}/download", as_admin=True, allow_redirects=False
@@ -301,6 +306,9 @@ class CanvasStudioService:
         Return URL of transcript for a video, in SRT (SubRip) format.
 
         May return `None` if no transcript has been generated for the video.
+
+        Security: This method does not check whether the current user should
+        have access to this video. See `_admin_api_request`.
         """
 
         captions = self._api_request(
@@ -336,6 +344,12 @@ class CanvasStudioService:
         This method should not be used if the current user _is_ the admin user.
         In that case we want to follow the normal steps for making a request
         using the current identity, and the corresponding error handling.
+
+        Security: Since this method makes requests as an admin user it does not
+        take account of whether the current user _should_ have access to a
+        particular video. Be sure to only make requests for videos where this
+        has been established some other way (eg. by its association with the
+        assignment being launched).
         """
 
         url = self._api_url(path)

--- a/lms/views/api/canvas_studio.py
+++ b/lms/views/api/canvas_studio.py
@@ -128,14 +128,16 @@ def list_collection(request):
     permission=Permissions.API,
 )
 def via_url(request):
-    svc = request.find_service(CanvasStudioService)
-    document_url = request.params.get("document_url")
-    media_id = (
-        CanvasStudioService.media_id_from_url(document_url) if document_url else None
+    assignment = request.find_service(name="assignment").get_assignment(
+        request.lti_user.application_instance.tool_consumer_instance_guid,
+        request.lti_user.lti.assignment_id,
     )
+    document_url = assignment.document_url
+    media_id = CanvasStudioService.media_id_from_url(document_url)
     if not media_id:
-        raise HTTPBadRequest("Missing or invalid `document_url` param")
+        raise HTTPBadRequest("Unable to get Canvas Studio media ID")
 
+    svc = request.find_service(CanvasStudioService)
     canonical_url = svc.get_canonical_video_url(media_id)
     download_url = svc.get_video_download_url(media_id)
     transcript_url = svc.get_transcript_url(media_id)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -268,7 +268,7 @@ class TestAddDocumentURL:
                 "canvas-studio://media/media_id",
                 {
                     "authUrl": "http://example.com/api/canvas_studio/oauth/authorize",
-                    "path": "/api/canvas_studio/via_url?document_url=canvas-studio%3A%2F%2Fmedia%2Fmedia_id",
+                    "path": "/api/canvas_studio/via_url",
                 },
             ),
             (


### PR DESCRIPTION
Get the document URL from the DB instead of passing it via a query param. This prevents users from replacing it with one that is different than used when configuring the assignment. The new code matches how the `canvas_api.pages.via_url` route works.

Fixes https://github.com/hypothesis/private-issues/issues/173