### PR TITLE
Show all students (and only students) in assignments dashboards

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -23,7 +23,7 @@ from lms.models.json_settings import JSONSettings
 from lms.models.jwt_oauth2_token import JWTOAuth2Token
 from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
-from lms.models.lti_role import LTIRole, LTIRoleOverride
+from lms.models.lti_role import LTIRole, LTIRoleOverride, RoleScope, RoleType
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -81,6 +81,10 @@ class Assignment(CreatedUpdatedMixin, Base):
     groupings = association_proxy("assignment_grouping", "grouping")
     """List of groupings this assigments is related to."""
 
+    membership = sa.orm.relationship(
+        "AssignmentMembership", lazy="dynamic", viewonly=True
+    )
+
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)
 


### PR DESCRIPTION
Join data from H for the dashboard with LMS DB records
Use the LMS DB data to:

- Filter out teachers
- Include students that didn't make an annotation



## Testing

I've been applying a hacky diff like:


```diff
diff --git a/lms/views/dashboard.py b/lms/views/dashboard.py
index b3388208a..fa250873d 100644
--- a/lms/views/dashboard.py
+++ b/lms/views/dashboard.py
@@ -51,7 +51,6 @@ class DashboardViews:
         route_name="api.assignment.stats",
         request_method="GET",
         renderer="json",
-        permission=Permissions.DASHBOARD_VIEW,
     )
     def api_assignment_stats(self):
         """Fetch the stats for one particular assignment."""
@@ -96,6 +95,7 @@ class DashboardViews:
 
     def get_request_assignment(self):
         assignment = self.assignment_service.get_by_id(self.request.matchdict["id_"])
+        return assignment
         if not assignment:
             raise HTTPNotFound()
```



Finding a relevant assignment ID in the DB and accessing the endpoint via: http://localhost:8001/api/assignment/292/stats

