### PR TITLE
Upgrade postgres to 15.6 in preparation for the production upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest-32-cores
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
         - 5433:5432
         env:
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
         - 5433:5432
         env:
@@ -162,9 +162,17 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
         - 5433:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:11.5-alpine
+    image: postgres:15.6-alpine
     ports:
       - "127.0.0.1:5433:5432"
     healthcheck:


### PR DESCRIPTION
For:

- https://github.com/hypothesis/playbook/issues/1147

## Testing and local env setup

- If you don't have the service running you can just

`make services dev`

and the right postgres version will start.


If you do have a container running it won't start after the upgrade:

- Optionally, backup the contents


```docker exec -it lms-postgres-1 pg_dumpall -U postgres > upgrade_backup.sql```


- Find the the volume ID:

```
docker inspect -f '{{ .Mounts }}' lms-postgres-1
[{volume e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076 /var/lib/docker/volumes/e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076/_data /var/lib/postgresql/data local  true }]
```

- Stop the container

`docker compose down postgres`


- And remove the volume:

`docker volume rm e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076`


- Start the services again

`docker compose up`

- Optionally restore the DB

```cat upgrade_backup.sql | docker exec -i lms-postgres-1 psql -U postgres```


- Start  server do double check everything is ok

`make services dev`
