### PR TITLE
Remove the need for `useParams` in DashboardApp

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,26 +1,14 @@
 import classnames from 'classnames';
-import { useParams } from 'wouter-preact';
 
 import type { StudentStats } from '../../api-types';
 import { useConfig } from '../../config';
-import { apiCall } from '../../utils/api';
-import { useFetch } from '../../utils/fetch';
+import { useAPIFetch } from '../../utils/api';
 import StudentsActivityTable from './StudentsActivityTable';
 
 export default function DashboardApp() {
-  const { assignmentId } = useParams<{ assignmentId: string }>();
-  const { dashboard, api } = useConfig(['dashboard', 'api']);
-  const assignment = {
-    title: dashboard.assignment.title,
-    id: assignmentId,
-  };
-  const students = useFetch<StudentStats[]>(`${assignmentId}_students`, () =>
-    apiCall({
-      authToken: api.authToken,
-      method: 'GET',
-      path: dashboard.assignmentStatsApi.path,
-    }),
-  );
+  const { dashboard } = useConfig(['dashboard']);
+  const { assignment, assignmentStatsApi } = dashboard;
+  const students = useAPIFetch<StudentStats[]>(assignmentStatsApi.path);
 
   return (
     <div className="min-h-full bg-grey-2">

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
@@ -6,7 +6,6 @@ import type { StudentStats } from '../../api-types';
 import { formatDateTime } from '../../utils/date';
 
 export type AssignmentInfo = {
-  id: string;
   title: string;
 };
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivityTable-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivityTable-test.js
@@ -11,7 +11,7 @@ describe('StudentsActivityTable', () => {
     return mount(
       <StudentsActivityTable
         students={students}
-        assignment={{ id: '123', title }}
+        assignment={{ title }}
         loading={loading}
       />,
     );

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDisplay-test.js
@@ -1,3 +1,4 @@
+import { Link } from '@hypothesis/frontend-shared';
 import {
   checkAccessibility,
   mockImportedComponents,
@@ -35,7 +36,7 @@ describe('ErrorDisplay', () => {
     );
 
     const link = wrapper
-      .find('Link')
+      .find(Link)
       .filterWhere(n => n.text() === 'open a support ticket');
     assert.isTrue(link.exists());
 
@@ -62,7 +63,7 @@ describe('ErrorDisplay', () => {
     );
 
     const link = wrapper
-      .find('Link')
+      .find(Link)
       .filterWhere(n => n.text() === 'open a support ticket');
 
     const url = new URL(link.prop('href'));

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -1,3 +1,4 @@
+import { Link } from '@hypothesis/frontend-shared';
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 
@@ -300,7 +301,9 @@ describe('LaunchErrorDialog', () => {
       },
     };
     const wrapper = renderDialog({}, config);
-    const editLink = wrapper.find('Link[data-testid="edit-link"]');
+    const editLink = wrapper
+      .find(Link)
+      .filterWhere(n => n.prop('data-testid') === 'edit-link');
     assert.isTrue(editLink.exists());
     assert.equal(editLink.prop('href'), '/app/content-item-selection');
   });


### PR DESCRIPTION
This PR removes the need to read the `assignmentId` from the URL via `useParams`, in `DashboardApp`.

As of today, this was actually not needed, and it was there as a residue of some very early implementation of the dashboard.

~Incidentally, this also defines a proper key for the students fetcher, which was previously based on the `assignmentId`, and it is now based on the actual params that can affect the API call.~

Additionally, the use of `useFetch` + `apiCall` is replaced by `useAPIFetch` (see https://github.com/hypothesis/lms/pull/6205#discussion_r1570661221).

And finally, there's a second commit which fixes some tests which have started to break due to `wouter-preact` package being added further up in the test bundle, causing the `frontend-shared` link to be bundled as `Link$1` by Rollup.

That commit changes a few instances of `wrapper.find('Link').filterWhere(...)` with `wrapper.find(Link).filterWhere(...)` with the actual imported `Link` component from `frontend-shared`.