### PR TITLE
Fix is_member to support memberships with multiple roles

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -200,7 +200,7 @@ class AssignmentService:
 
     def is_member(self, assignment: Assignment, user: User) -> bool:
         """Check if a user is a member of an assignment."""
-        return bool(assignment.membership.filter_by(user=user).one_or_none())
+        return bool(assignment.membership.filter_by(user=user).first())
 
     def get_members(
         self, assignment, role_type: RoleType, role_scope: RoleScope

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -216,9 +216,13 @@ class TestAssignmentService:
         assignment = factories.Assignment()
         user = factories.User()
         other_user = factories.User()
-        lti_role = factories.LTIRole()
+        lti_role_1 = factories.LTIRole()
+        lti_role_2 = factories.LTIRole()
         factories.AssignmentMembership.create(
-            assignment=assignment, user=user, lti_role=lti_role
+            assignment=assignment, user=user, lti_role=lti_role_1
+        )
+        factories.AssignmentMembership.create(
+            assignment=assignment, user=user, lti_role=lti_role_2
         )
 
         db_session.flush()


### PR DESCRIPTION
Memberships are not unique by assignment/user but by assignment/user/role.