### PR TITLE
Fix type annotations in security.py

### DIFF
--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -58,7 +58,7 @@ class LTIUser:  # pylint: disable=too-many-instance-attributes
     request.lti_session or similar with contains the user and any other relevant values.
     """
 
-    application_instance: ApplicationInstance | None = None
+    application_instance: ApplicationInstance
     """Application instance this user belongs to"""
 
     email: str = ""

--- a/lms/security.py
+++ b/lms/security.py
@@ -29,12 +29,6 @@ class DeniedWithException(Denied):
         self.exception = exception
 
 
-class Identity(NamedTuple):
-    userid: str
-    permissions: list[str]
-    lti_user: LTIUser | None = None
-
-
 class Permissions(Enum):
     LTI_LAUNCH_ASSIGNMENT = "lti_launch_assignment"
     LTI_CONFIGURE_ASSIGNMENT = "lti_configure_assignment"
@@ -44,6 +38,12 @@ class Permissions(Enum):
     GRADE_ASSIGNMENT = "grade_assignment"
     EMAIL_PREFERENCES = "email.preferences"
     DASHBOARD_VIEW = "dashboard.view"
+
+
+class Identity(NamedTuple):
+    userid: str
+    permissions: list[Permissions]
+    lti_user: LTIUser | None = None
 
 
 class UnautheticatedSecurityPolicy:  # pragma: no cover
@@ -177,7 +177,7 @@ class LTIUserSecurityPolicy:
 
         return identity.userid
 
-    def identity(self, request):
+    def identity(self, request) -> Identity:
         try:
             lti_user = self._get_lti_user(request)
         except Exception:  # pylint:disable=broad-exception-caught
@@ -221,7 +221,7 @@ class LTIUserSecurityPolicy:
 
 
 class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
-    def identity(self, request):
+    def identity(self, request) -> Identity:
         userid = self.authenticated_userid(request)
 
         if userid and userid.endswith("@hypothes.is"):

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -1,6 +1,7 @@
-from factory import Faker, fuzzy, make_factory
+from factory import Faker, SubFactory, fuzzy, make_factory
 
 from lms.models.lti_user import LTI, LTIUser
+from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID, USER_ID
 
 LTIUser = make_factory(
@@ -13,4 +14,5 @@ LTIUser = make_factory(
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
     lti=LTI(course_id=Faker("hexify", text="^" * 40), product_family="UNKNOWN"),
+    application_instance=SubFactory(ApplicationInstance),
 )

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -347,21 +347,26 @@ class TestLTIUserSecurityPolicy:
         assert is_allowed == DeniedWithException(validation_error)
 
     @pytest.mark.parametrize(
-        "lti_user,expected_userid",
+        "user_id,application_instance_id,expected_userid",
         [
-            (None, None),
-            (
-                factories.LTIUser(
-                    user_id="sam",
-                    application_instance_id=100,
-                ),
-                "c2Ft:100",
-            ),
+            (None, None, None),
+            ("sam", 100, "c2Ft:100"),
         ],
     )
-    def test_authenticated_userid(self, lti_user, expected_userid, pyramid_request):
+    def test_authenticated_userid(
+        self, user_id, application_instance_id, expected_userid, pyramid_request
+    ):
         policy = LTIUserSecurityPolicy(
-            create_autospec(get_lti_user, return_value=lti_user)
+            create_autospec(
+                get_lti_user,
+                return_value=(
+                    factories.LTIUser(
+                        user_id=user_id, application_instance_id=application_instance_id
+                    )
+                    if user_id
+                    else None
+                ),
+            )
         )
 
         assert policy.authenticated_userid(pyramid_request) == expected_userid


### PR DESCRIPTION
Fix type declaration for LTIUser.application_instance 

- Remove the default None, it must always be not None
- Include application_instance on the factory
- Refactor test that build LTIUser as fixtures. Factory boy didn't have
  access to subfactories in that setup.
- Add type annotations in security.py