### PR TITLE
Return Identity | None in security policies

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -177,15 +177,15 @@ class LTIUserSecurityPolicy:
 
         return identity.userid
 
-    def identity(self, request) -> Identity:
+    def identity(self, request) -> Identity | None:
         try:
             lti_user = self._get_lti_user(request)
         except Exception:  # pylint:disable=broad-exception-caught
             # If anything went wrong, no identity
-            return Identity("", [])
+            return None
 
         if lti_user is None:
-            return Identity("", [])
+            return None
 
         permissions = []
         if lti_user.is_learner or lti_user.is_instructor or lti_user.is_admin:
@@ -221,7 +221,7 @@ class LTIUserSecurityPolicy:
 
 
 class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
-    def identity(self, request) -> Identity:
+    def identity(self, request) -> Identity | None:
         userid = self.authenticated_userid(request)
 
         if userid and userid.endswith("@hypothes.is"):
@@ -231,7 +231,7 @@ class LMSGoogleSecurityPolicy(GoogleSecurityPolicy):
 
             return Identity(userid, permissions=permissions)
 
-        return Identity("", [])
+        return None
 
     def permits(self, request, _context, permission):
         return _permits(self.identity(request), permission)

--- a/lms/views/admin/__init__.py
+++ b/lms/views/admin/__init__.py
@@ -6,7 +6,7 @@ from lms.validation._exceptions import ValidationError
 
 @forbidden_view_config(path_info="/admin/*")
 def forbidden(request):
-    if request.identity.userid:
+    if request.identity and request.identity.userid:
         # Logged in but missing permissions, go back to the admin page's index.
         request.session.flash(
             f"You don't have permissions for that: {request.path}", "errors"

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -63,7 +63,7 @@ class TestLMSGoogleSecurityPolicy:
                     permissions=[Permissions.STAFF, Permissions.ADMIN],
                 ),
             ),
-            ("testuser@example.com", Identity(userid="", permissions=[])),
+            ("testuser@example.com", None),
         ],
     )
     def test_identity(self, policy, pyramid_request, userid, expected_identity):
@@ -73,7 +73,7 @@ class TestLMSGoogleSecurityPolicy:
         assert policy.identity(pyramid_request) == expected_identity
 
     def test_identity_when_no_user_is_logged_in(self, policy, pyramid_request):
-        assert policy.identity(pyramid_request) == Identity(userid="", permissions=[])
+        assert not policy.identity(pyramid_request)
 
     def test_authenticated_userid(self, policy, pyramid_request):
         pyramid_request.session["googleauth.userid"] = "testuser@hypothes.is"
@@ -247,9 +247,7 @@ class TestEmailPreferencesSecurityPolicy:
 class TestLTIUserSecurityPolicy:
     def test_it_returns_empty_identity_if_theres_no_lti_user(self, pyramid_request):
         policy = LTIUserSecurityPolicy(create_autospec(get_lti_user, return_value=None))
-        userid = policy.identity(pyramid_request)
-
-        assert userid == Identity(userid="", permissions=[])
+        assert not policy.identity(pyramid_request)
 
     def test_it_returns_empty_identity_if_validation_error(self, pyramid_request):
         get_lti_user_ = create_autospec(
@@ -258,8 +256,7 @@ class TestLTIUserSecurityPolicy:
 
         policy = LTIUserSecurityPolicy(get_lti_user_)
 
-        userid = policy.identity(pyramid_request)
-        assert userid == Identity(userid="", permissions=[])
+        assert not policy.identity(pyramid_request)
 
     @pytest.mark.usefixtures("user_has_no_roles")
     def test_identity_when_theres_an_lti_user_with_no_roles(self, pyramid_request):


### PR DESCRIPTION
This aligns the LTI and Google policies with the EmailPreferences one which already returned None to mean "no identity".

In general views rely on permission to gate access to not often we need to check for the presence of the policy itself in regular view code.

Having all policies behave the same will make changes to the overall delegating policy simpler.