### PR TITLE
Use a grid table for the students list in the dashboard

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivityTable.tsx
@@ -1,6 +1,11 @@
-import { Card, CardContent, DataTable } from '@hypothesis/frontend-shared';
+import {
+  Card,
+  CardContent,
+  DataTable,
+  useOrderedRows,
+} from '@hypothesis/frontend-shared';
 import type { DataTableProps } from '@hypothesis/frontend-shared';
-import { useMemo, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 
 import type { StudentStats } from '../../api-types';
 import { formatDateTime } from '../../utils/date';
@@ -16,24 +21,6 @@ export type StudentsActivityTableProps = {
 };
 
 type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
-
-function useOrderedRows<T>(rows: T[], order: MandatoryOrder<T>) {
-  return useMemo(
-    () =>
-      [...rows].sort((a, b) => {
-        if (a[order.field] === b[order.field]) {
-          return 0;
-        }
-
-        if (order.direction === 'ascending') {
-          return a[order.field] > b[order.field] ? 1 : -1;
-        }
-
-        return a[order.field] > b[order.field] ? -1 : 1;
-      }),
-    [order, rows],
-  );
-}
 
 export default function StudentsActivityTable({
   assignment,
@@ -54,6 +41,8 @@ export default function StudentsActivityTable({
           {title}
         </h2>
         <DataTable
+          grid
+          striped={false}
           emptyMessage="No students found"
           title={title}
           columns={[
@@ -72,17 +61,13 @@ export default function StudentsActivityTable({
           ]}
           rows={orderedStudents}
           renderItem={(stats, field) => {
-            if (field === 'display_name') {
-              return stats[field];
+            if (['annotations', 'replies'].includes(field)) {
+              return <div className="text-right">{stats[field]}</div>;
             }
 
-            return (
-              <div className="text-right" data-testid={`${field}-col`}>
-                {field === 'last_activity' && stats[field]
-                  ? formatDateTime(new Date(stats[field]))
-                  : stats[field]}
-              </div>
-            );
+            return field === 'last_activity' && stats[field]
+              ? formatDateTime(new Date(stats[field]))
+              : stats[field];
           }}
           loading={loading}
           orderableColumns={[

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^v7.6.1",
+    "@hypothesis/frontend-shared": "^7.7.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,15 +2018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^v7.6.1":
-  version: 7.6.1
-  resolution: "@hypothesis/frontend-shared@npm:7.6.1"
+"@hypothesis/frontend-shared@npm:^7.7.0":
+  version: 7.7.0
+  resolution: "@hypothesis/frontend-shared@npm:7.7.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 920cf3512052044b4c81235288d388351b328f474456a492efbbfde72226fae59d0c5a37cbc0a2edecd2869fc3db6d9dbe514307384d2c836e6f591a1799b038
+  checksum: 99234f59f02659052c222eef65e0f7d3706ce9ea49f4d3b53ec29c7a7cd4eb43d0e68dd9c0ce4fd39152a24a3757851b579d33caa7a1983d59122177c16ca8f1
   languageName: node
   linkType: hard
 
@@ -7220,7 +7220,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@babel/preset-typescript": ^7.24.1
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^v7.6.1
+    "@hypothesis/frontend-shared": ^7.7.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7


### PR DESCRIPTION
Apply changes introduced in https://github.com/hypothesis/frontend-shared/pull/1525 to make the students list look closer to the designs:

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/a4190749-3a67-4c4d-bf00-662933f19a42)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/7b08a397-580c-4874-8f42-ae8207e82ece)

I took the opportunity to use the `useOrderedRows` hook from `frontend-shared` and drop local one.