### PR TITLE
Include path in cookies and change dashboard endpoints to include the organization ID

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -235,7 +235,7 @@ def includeme(config):  # pylint:disable=too-many-statements
     )
     config.add_route(
         "dashboard.assignment",
-        "/dashboard/assignment/{id_}",
+        "/dashboard/organization/{public_id}/assignment/{id_}",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route("api.assignment.stats", "/api/assignment/{id_}/stats")

--- a/lms/security.py
+++ b/lms/security.py
@@ -104,7 +104,7 @@ class SecurityPolicy:
             # Routes that require the Google auth policy
             return LMSGoogleSecurityPolicy()
 
-        if path.startswith("/dashboard/assignment/") or path.startswith(
+        if path.startswith("/dashboard/organization/") or path.startswith(
             "/api/assignment/"
         ):
             # For certain routes we only use the google policy in case it resulted
@@ -156,7 +156,7 @@ class SecurityPolicy:
                 partial(get_lti_user_from_bearer_token, location="form")
             )
 
-        if path.startswith("/dashboard/assignment/"):
+        if path.startswith("/dashboard/organization/"):
             return LTIUserSecurityPolicy(
                 partial(get_lti_user_from_bearer_token, location="cookies")
             )

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/dashboard/assignment/:assignmentId">
+          <Route path="/dashboard/organization/:organizationId/assignment/:assignmentId">
             <DashboardApp />
           </Route>
           <Route path="/email/preferences">

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -75,7 +75,7 @@ describe('AppRoot', () => {
     {
       config: { mode: 'dashboard' },
       appComponent: 'DashboardApp',
-      route: '/dashboard/assignment/123',
+      route: '/dashboard/organization/ORG_ID/assignment/123',
     },
     {
       config: { mode: 'error-dialog' },

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -51,7 +51,14 @@ class AdminAssignmentViews:
         )
 
         response = HTTPFound(
-            location=self.request.route_url("dashboard.assignment", id_=assignment.id),
+            location=self.request.route_url(
+                "dashboard.assignment",
+                # pylint:disable=protected-access
+                public_id=assignment.groupings[
+                    0
+                ].application_instance.organization._public_id,
+                id_=assignment.id,
+            ),
         )
         return response
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -263,6 +263,7 @@ def application_instance(db_session):
         developer_key="TEST_DEVELOPER_KEY",
         provisioning=True,
         settings=ApplicationSettings({}),
+        organization=factories.Organization(),
     )
 
     application_instance.settings.set("canvas", "sections_enabled", True)
@@ -271,6 +272,11 @@ def application_instance(db_session):
     # Force flush to get a non None application_instance.id
     db_session.flush()
     return application_instance
+
+
+@pytest.fixture
+def organization(application_instance):
+    return application_instance.organization
 
 
 @pytest.fixture

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -409,7 +409,9 @@ class TestSecurityPolicy:
         get_policy.return_value.forget.assert_called_once_with(pyramid_request)
         assert user_id == get_policy.return_value.forget.return_value
 
-    @pytest.mark.parametrize("path", ["/api/assignment/10", "/dashboard/assignment/10"])
+    @pytest.mark.parametrize(
+        "path", ["/api/assignment/10", "/dashboard/organization/ORGID"]
+    )
     def test_get_policy_google_when_available(
         self, pyramid_request, path, LMSGoogleSecurityPolicy
     ):
@@ -488,7 +490,7 @@ class TestSecurityPolicy:
             ("/assignment", "form"),
             ("/assignment/edit", "form"),
             ("/dashboard/launch/assignment/10", "form"),
-            ("/dashboard/assignment/10", "cookies"),
+            ("/dashboard/organization/ORGID/assignment/10", "cookies"),
         ],
     )
     def test_picks_lti_launches_with_bearer_token(


### PR DESCRIPTION
Scope dashboard cookies to the current organization. This is done to
allow multiple cookies to coexists in the same browser allowing
multiple identities from different LMSes.

We include the organization ID in the URL, not the full one (public_id)
but just the last part of the identifier (_public_id).

The full public id contains both the region (us / ca) and the type of object (org) but
those are already part of the URL (region in the host name and org is in the path)


### Testing 

- Open the dashboard from https://hypothesis.instructure.com/courses/125/assignments/873
- Enable the dashboard in the [D2L instance](http://localhost:8001/admin/instance/106/settings)
- Open the dashboard from https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2374/View



- Switch beetween 
  - https://localhost:48001/dashboard/organization/llxvXeSfSCqL0HY2wSgCWQ/assignment/318
  - https://localhost:48001/dashboard/organization/LDtcl7EUTeW2UERPJLAVtA/assignment/292