### PR TITLE
Mark empty methods with "no cover"

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -234,10 +234,10 @@ class LTIUserSecurityPolicy:
 
         return _permits(self.identity(request), permission)
 
-    def remember(self, request, userid, **kw):
+    def remember(self, request, userid, **kw):  # pragma: no cover
         pass
 
-    def forget(self, request):
+    def forget(self, request):  # pragma: no cover
         pass
 
 

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -311,14 +311,6 @@ class TestLTIUserSecurityPolicy:
 
         assert identity.permissions == expected_permissions
 
-    def test_remember(self, pyramid_request):
-        LTIUserSecurityPolicy(sentinel.get_lti_user).remember(
-            pyramid_request, "TEST_USERID", kwarg=sentinel.kwarg
-        )
-
-    def test_forget(self, pyramid_request):
-        LTIUserSecurityPolicy(sentinel.get_lti_user).forget(pyramid_request)
-
     def test_permits_allow(self, pyramid_request, user_is_learner):
         policy = LTIUserSecurityPolicy(
             create_autospec(get_lti_user, return_value=user_is_learner)


### PR DESCRIPTION
Removing the assertion-less test which mask the missing coverage. Make it explicit with the pragma declaration.