### PR TITLE
Use SelectNext for groups config selector

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, Link, Select } from '@hypothesis/frontend-shared';
+import { Checkbox, Link, SelectNext } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import type { GroupSet } from '../api-types';
 import { useConfig } from '../config';
@@ -46,6 +46,10 @@ function GroupSelect({
   selectedGroupSetId,
 }: GroupSelectProps) {
   const selectId = useUniqueId('GroupSetSelector__select');
+  const selectedGroupSet = useMemo(
+    () => groupSets?.find(({ id }) => id === selectedGroupSetId),
+    [groupSets, selectedGroupSetId],
+  );
 
   return (
     <div
@@ -60,33 +64,23 @@ function GroupSelect({
       >
         Group set
       </label>
-      <Select
+      <SelectNext
+        value={selectedGroupSet}
+        onChange={newGroupSet => onInput(newGroupSet?.id ?? null)}
+        buttonId={selectId}
         disabled={loading}
-        id={selectId}
-        onInput={(e: Event) =>
-          onInput((e.target as HTMLSelectElement | null)?.value || null)
+        buttonContent={
+          loading
+            ? 'Fetching group sets…'
+            : selectedGroupSet?.name ?? 'Select group set'
         }
       >
-        {loading && <option>Fetching group sets…</option>}
-        {groupSets && (
-          <>
-            <option disabled selected={selectedGroupSetId === null}>
-              Select group set
-            </option>
-            <hr />
-            {groupSets.map(gs => (
-              <option
-                key={gs.id}
-                value={gs.id}
-                selected={gs.id === selectedGroupSetId}
-                data-testid="groupset-option"
-              >
-                {gs.name}
-              </option>
-            ))}
-          </>
-        )}
-      </Select>
+        {groupSets?.map(gs => (
+          <SelectNext.Option value={gs} key={gs.id}>
+            {gs.name}
+          </SelectNext.Option>
+        ))}
+      </SelectNext>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -21,6 +21,7 @@ describe('GroupConfigSelector', () => {
   let fakeConfig;
   let fakeGroupSets;
   let fakeIsAuthorizationError;
+  let wrappers;
 
   beforeEach(() => {
     fakeGroupSets = [
@@ -33,6 +34,7 @@ describe('GroupConfigSelector', () => {
         name: 'Group Set 2',
       },
     ];
+    wrappers = [];
 
     fakeAPICall = sinon.stub();
     fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
@@ -66,6 +68,7 @@ describe('GroupConfigSelector', () => {
 
   afterEach(() => {
     $imports.$restore();
+    wrappers.forEach(w => w.unmount());
   });
 
   // Helper that simulates GroupConfigSelector's containing component.
@@ -83,7 +86,10 @@ describe('GroupConfigSelector', () => {
   }
 
   function createComponent(props = {}) {
-    return mount(<Container {...props} />);
+    const wrapper = mount(<Container {...props} />);
+    wrappers.push(wrapper);
+
+    return wrapper;
   }
 
   function toggleCheckbox(wrapper) {

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -1,3 +1,4 @@
+import { SelectNext } from '@hypothesis/frontend-shared';
 import {
   mockImportedComponents,
   waitForElement,
@@ -124,24 +125,20 @@ describe('GroupConfigSelector', () => {
       groupConfig: { useGroupSet: true, groupConfig: null },
     });
 
-    // While groups are being fetched, the `<select>` should be visible but disabled
-    // and display a fetching status.
-    const groupSetSelect = wrapper.find('select');
+    // While groups are being fetched, the `<SelectNext>` should be visible but
+    // disabled, and display a fetching status.
+    const groupSetSelect = wrapper.find('SelectNext');
     assert.isTrue(groupSetSelect.exists());
     assert.isTrue(groupSetSelect.prop('disabled'));
-    assert.equal(groupSetSelect.find('option').length, 1);
-    assert.equal(groupSetSelect.find('option').text(), 'Fetching group sets…');
+    assert.equal(groupSetSelect.prop('buttonContent'), 'Fetching group sets…');
 
-    // Once group sets are fetched, they should be rendered as `<option>`s.
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]',
-    );
+    // Once group sets are fetched, they should be rendered as options.
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
 
     fakeGroupSets.forEach((gs, i) => {
       assert.equal(options.at(i).text(), gs.name);
-      assert.equal(options.at(i).prop('value'), gs.id);
+      assert.equal(options.at(i).prop('value'), gs);
     });
   });
 
@@ -152,20 +149,16 @@ describe('GroupConfigSelector', () => {
       onChangeGroupConfig,
     });
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]',
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
     assert.notCalled(onChangeGroupConfig);
 
-    const select = wrapper.find('select').getDOMNode();
+    const select = wrapper.find('SelectNext');
 
     options.forEach((option, i) => {
       onChangeGroupConfig.resetHistory();
 
-      select.value = option.prop('value');
-      select.dispatchEvent(new Event('input'));
+      select.props().onChange(option.prop('value'));
 
       assert.calledWith(onChangeGroupConfig, {
         useGroupSet: true,
@@ -192,10 +185,7 @@ describe('GroupConfigSelector', () => {
     fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
     authModal.prop('onAuthComplete')();
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]',
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 
@@ -227,10 +217,7 @@ describe('GroupConfigSelector', () => {
       authModal.prop('onRetry')();
     });
 
-    const options = await waitForElement(
-      wrapper,
-      'option[data-testid="groupset-option"]',
-    );
+    const options = await waitForElement(wrapper, SelectNext.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -8,12 +8,13 @@ import StudentSelector, { $imports } from '../StudentSelector';
 
 describe('StudentSelector', () => {
   let fakeStudents;
+  let wrappers;
 
   const renderSelector = (props = {}) => {
     const fakeOnSelectStudent = sinon.stub();
     const fakeSelectedStudentIndex = 0;
 
-    return mount(
+    const wrapper = mount(
       <StudentSelector
         onSelectStudent={fakeOnSelectStudent}
         selectedStudentIndex={fakeSelectedStudentIndex}
@@ -21,6 +22,9 @@ describe('StudentSelector', () => {
         {...props}
       />,
     );
+    wrappers.push(wrapper);
+
+    return wrapper;
   };
 
   beforeEach(() => {
@@ -33,10 +37,12 @@ describe('StudentSelector', () => {
         displayName: 'Student 2',
       },
     ];
+    wrappers = [];
   });
 
   afterEach(() => {
     $imports.$restore();
+    wrappers.forEach(w => w.unmount());
   });
 
   it('shall have "All Students" as the default option', () => {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.8.0",
+    "@hypothesis/frontend-shared": "^7.9.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,15 +2137,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.8.0":
-  version: 7.8.0
-  resolution: "@hypothesis/frontend-shared@npm:7.8.0"
+"@hypothesis/frontend-shared@npm:^7.9.0":
+  version: 7.9.0
+  resolution: "@hypothesis/frontend-shared@npm:7.9.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 16eb6e730f5990a2af4c0d2cbe12b89ba8274435d97392aa6bbb59c36adc9467b1435e5a3a9053dec1c7273deaf8825d0a31e19a968824abc1815ae213248198
+  checksum: 2c0a71f57436859e0b3f4fb617c13e7385b660d2676743f2008accd6460cd29f3e1b5ee7fa61b7540e64440610a5950dd41d22ec902dde31c0438c5ddb351224
   languageName: node
   linkType: hard
 
@@ -7346,7 +7346,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@babel/preset-typescript": ^7.24.1
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.8.0
+    "@hypothesis/frontend-shared": ^7.9.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1540

Replace the last instance of `<Select />`, in the group config selector, with `<SelectNext />`.

https://github.com/hypothesis/lms/assets/2719332/bc4438a6-8f21-4941-9634-11776b337a94
