### PR TITLE
Show a message for instructors in VS course launches

### DIFF
--- a/lms/error_code.py
+++ b/lms/error_code.py
@@ -12,4 +12,7 @@ class ErrorCode(str, Enum):
     CANVAS_INVALID_SCOPE = "canvas_invalid_scope"
     VITALSOURCE_STUDENT_PAY_NO_LICENSE = "vitalsource_student_pay_no_license"
     VITALSOURCE_STUDENT_PAY_LICENSE_LAUNCH = "vitalsource_student_pay_license_launch"
+    VITALSOURCE_STUDENT_PAY_LICENSE_LAUNCH_INSTRUCTOR = (
+        "vitalsource_student_pay_license_launch_instructor"
+    )
     REUSED_CONSUMER_KEY = "reused_consumer_key"

--- a/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDialogApp.tsx
@@ -36,6 +36,10 @@ export default function ErrorDialogApp() {
       title = 'Hypothesis license activated';
       displaySupportLink = false;
       break;
+    case 'vitalsource_student_pay_license_launch_instructor':
+      title = 'This button allows students to acquire licenses';
+      displaySupportLink = false;
+      break;
     default:
       description =
         'An error occurred when launching the Hypothesis application';
@@ -102,6 +106,24 @@ export default function ErrorDialogApp() {
             You have now activated your license to use the Hypothesis tool in
             your LMS. You will be able to launch Hypothesis assignments and
             other readings made by your instructor.
+          </p>
+        </>
+      )}
+      {error.errorCode ===
+        'vitalsource_student_pay_license_launch_instructor' && (
+        <>
+          <p>
+            To create a Hypothesis-enabled reading in Canvas, create a new
+            Assignment or Module item.
+          </p>
+          <p>
+            See:{' '}
+            <Link
+              target="_blank"
+              href="https://web.hypothes.is/help/using-the-hypothesis-app-through-vitalsource/"
+            >
+              https://web.hypothes.is/help/using-the-hypothesis-app-through-vitalsource/
+            </Link>
           </p>
         </>
       )}

--- a/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/ErrorDialogApp-test.js
@@ -58,4 +58,13 @@ describe('ErrorDialogApp', () => {
       'You have now activated your license to use the Hypothesis tool in your LMS.',
     );
   });
+  it('shows dialog for vital_source_student_pay_license_launch for instructors', () => {
+    fakeConfig.errorCode = 'vitalsource_student_pay_license_launch_instructor';
+
+    const wrapper = renderApp();
+    assert.include(
+      wrapper.text(),
+      'To create a Hypothesis-enabled reading in Canvas, create a new Assignment or Module item.',
+    );
+  });
 });

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -1,7 +1,8 @@
 export type AppLaunchServerErrorCode =
   | 'reused_consumer_key'
   | 'vitalsource_student_pay_no_license'
-  | 'vitalsource_student_pay_license_launch';
+  | 'vitalsource_student_pay_license_launch'
+  | 'vitalsource_student_pay_license_launch_instructor';
 
 export type OAuthServerErrorCode =
   | 'blackboard_missing_integration'


### PR DESCRIPTION
While VitalSource course launches is something only students should do to acquire a license we'll show a message for instructors pointing them to create assignments instead.


Copy from https://hypothes-is.slack.com/archives/C2C2U40LW/p1714425682592469?thread_ts=1713560092.698679&cid=C2C2U40LW

![Screenshot from 2024-04-30 16-26-04](https://github.com/hypothesis/lms/assets/1433832/60d8ca15-042e-4b8e-8207-ec1261643c2c)

