### PR TITLE
Display better error if Canvas Studio video cannot be used with Via

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -320,6 +320,42 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'canvas_studio_download_unavailable':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Unable to fetch Canvas Studio video"
+        >
+          <p>
+            Only videos uploaded directly to Canvas Studio can be used. Videos
+            hosted on YouTube or Vimeo cannot be used.
+          </p>
+        </ErrorModal>
+      );
+
+    case 'canvas_studio_media_not_found':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Canvas Studio media not found"
+        />
+      );
+
+    case 'canvas_studio_transcript_unavailable':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Video does not have a published transcript"
+        >
+          <p>
+            To use a video with Hypothesis, you must upload or generate captions
+            in Canvas Studio <i>and</i> publish them.
+          </p>
+        </ErrorModal>
+      );
     case 'blackboard_group_set_not_found':
       return (
         <ErrorModal

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -83,6 +83,29 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'canvas_studio_download_unavailable',
+      expectedText:
+        'Only videos uploaded directly to Canvas Studio can be used. Videos hosted on YouTube or Vimeo cannot be used.',
+      expectedTitle: 'Unable to fetch Canvas Studio video',
+      hasRetry: false,
+      withError: true,
+    },
+    {
+      errorState: 'canvas_studio_media_not_found',
+      expectedText: '',
+      expectedTitle: 'Canvas Studio media not found',
+      hasRetry: false,
+      withError: true,
+    },
+    {
+      errorState: 'canvas_studio_transcript_unavailable',
+      expectedText:
+        'To use a video with Hypothesis, you must upload or generate captions in Canvas Studio and publish them.',
+      expectedTitle: 'Video does not have a published transcript',
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'd2l_file_not_found_in_course_instructor',
       expectedText:
         'To fix the issue, recreate this assignment and select a different file.',

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -18,6 +18,9 @@ export type LTILaunchServerErrorCode =
   | 'canvas_group_set_not_found'
   | 'canvas_page_not_found_in_course'
   | 'canvas_student_not_in_group'
+  | 'canvas_studio_download_unavailable'
+  | 'canvas_studio_transcript_unavailable'
+  | 'canvas_studio_media_not_found'
   | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_file_not_found_in_course_student'
   | 'd2l_group_set_empty'
@@ -162,6 +165,9 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_group_set_not_found',
       'canvas_group_set_empty',
       'canvas_student_not_in_group',
+      'canvas_studio_download_unavailable',
+      'canvas_studio_transcript_unavailable',
+      'canvas_studio_media_not_found',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
       'moodle_page_not_found_in_course',

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -191,6 +191,9 @@ class TestCanvasStudioService:
             svc.get_video_download_url("456")
         assert Any.instance_of(exc_info.value.response).with_attrs({"status_code": 404})
 
+    def test_get_video_download_url_returns_None_if_video_not_available(self, svc):
+        assert svc.get_video_download_url("800") is None
+
     def test_get_video_download_url_fails_if_admin_email_not_set(
         self, svc, pyramid_request
     ):
@@ -411,6 +414,11 @@ class TestCanvasStudioService:
                     json_data = {}
                 case "media/456/download":
                     status_code = 404
+                    json_data = {}
+                case "media/800/download":
+                    # Simulate response in case where video is hosted on
+                    # YouTube or Vimeo, so not available for download.
+                    status_code = 422
                     json_data = {}
 
                 case _:  # pragma: nocover


### PR DESCRIPTION
Display a more helpful error in the case where a download URL cannot be obtained for a Canvas Studio video because it is hosted in YouTube or Vimeo. At the same time, also improve the presentation of the error when the video doesn't have a transcript.

The errors look like this:

<img width="609" alt="Canvas Studio video fetch error" src="https://github.com/hypothesis/lms/assets/2458/d82076f7-cc6d-44b0-91ca-5ec77cfe7a65">

<img width="604" alt="Canvas Studio no transcript error" src="https://github.com/hypothesis/lms/assets/2458/31531250-8d99-4001-8468-80dc866643d9">


Fixes https://github.com/hypothesis/lms/issues/6231

[1] See https://hypothes-is.slack.com/archives/C1MA4E9B9/p1714472977336609