### PR TITLE
Use ruff to replace black,  isort, pydocstyle & pycodestyle

### DIFF
--- a/lms/extensions/feature_flags/__init__.py
+++ b/lms/extensions/feature_flags/__init__.py
@@ -145,10 +145,12 @@ set by that source. For example::
 
 from ._exceptions import SettingError
 from ._feature_flags import FeatureFlags
-from ._providers import config_file_provider  # noqa
-from ._providers import cookie_provider  # noqa
-from ._providers import envvar_provider  # noqa
-from ._providers import query_string_provider  # noqa
+from ._providers import (
+    config_file_provider,  # noqa
+    cookie_provider,  # noqa
+    envvar_provider,  # noqa
+    query_string_provider,  # noqa
+)
 from .views._predicates import FeatureFlagViewPredicate
 
 __all__ = ["SettingError"]

--- a/lms/models/_mixins/public_id.py
+++ b/lms/models/_mixins/public_id.py
@@ -12,9 +12,7 @@ def _get_current_region():
     return Region(code=environ["REGION_CODE"], authority=environ["H_AUTHORITY"])
 
 
-class _PublicIdComparator(
-    Comparator
-):  # pylint: disable=abstract-method, too-many-ancestors
+class _PublicIdComparator(Comparator):  # pylint: disable=abstract-method, too-many-ancestors
     """A comparator for covering over details of comparing public ids."""
 
     def __eq__(self, other):

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -616,9 +616,9 @@ class JSConfig:
         else:
             # If not using the default COURSE grouping point the FE
             # to the sync API to dynamically get the relevant groupings.
-            self._config["hypothesisClient"]["services"][0][
-                "groups"
-            ] = "$rpc:requestGroups"
+            self._config["hypothesisClient"]["services"][0]["groups"] = (
+                "$rpc:requestGroups"
+            )
 
             req = self._request
             self._config["api"]["sync"] = {

--- a/lms/scripts/init_db.py
+++ b/lms/scripts/init_db.py
@@ -8,6 +8,7 @@ Usage:
     python3 -m lms.scripts.init_db --help
 
 """
+
 # pylint:disable=import-outside-toplevel,unused-import
 import argparse
 import logging

--- a/lms/services/canvas_api/_authenticated.py
+++ b/lms/services/canvas_api/_authenticated.py
@@ -41,9 +41,7 @@ class AuthenticatedClient:
         self._client_secret = client_secret
         self._redirect_uri = redirect_uri
 
-    def send(
-        self, method, path, schema, timeout=DEFAULT_TIMEOUT, params=None
-    ):  # pylint:disable=too-many-arguments
+    def send(self, method, path, schema, timeout=DEFAULT_TIMEOUT, params=None):  # pylint:disable=too-many-arguments
         """
         Send a Canvas API request, and retry it if there are OAuth problems.
 

--- a/lms/services/d2l_api/client.py
+++ b/lms/services/d2l_api/client.py
@@ -208,7 +208,8 @@ class D2LAPIClient:
                     "updated_at": topic["updated_at"],
                 }
                 for topic in module.get("topics", [])
-                if topic.get("type") == "File" and not topic.get("is_broken", False)
+                if topic.get("type") == "File"
+                and not topic.get("is_broken", False)
                 # Filter out non-pdfs using the file's name.
                 # Other LMS offer the content type of the file at this level
                 # but will have to rely on the extension for D2L.

--- a/lms/services/file.py
+++ b/lms/services/file.py
@@ -20,7 +20,8 @@ class FileService:
             )
             # We might have recorded the same file twice in different ApplicationInstances
             # as we query by GUID we might get more than once row, in that case we prefer the newest
-            .order_by(File.id.desc()).first()
+            .order_by(File.id.desc())
+            .first()
         )
 
     def find_copied_file(self, new_course_id, original_file: File):
@@ -39,8 +40,7 @@ class FileService:
             )
             .filter(
                 # We don't want to find the same file we are looking for
-                File.id
-                != original_file.id,
+                File.id != original_file.id,
             )
             # We might find more than one matching file, prefer the newest
             .order_by(File.id.desc())

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -70,7 +70,8 @@ class OrganizationService:
         # Get all the objects in the hierarchy, to ensure they are cached by
         # SQLAlchemy, and should be fast to access.
         hierarchy = (
-            self._db_session.query(Organization).filter(
+            self._db_session.query(Organization)
+            .filter(
                 Organization.id.in_(self.get_hierarchy_ids(id_, include_parents=True))
             )
             # Order by parent id, this will cause the root (if any) to be last.
@@ -362,7 +363,8 @@ class OrganizationService:
         # https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE
         cols = [Organization.id, Organization.parent_id]
         base_case = (
-            self._db_session.query(*cols).filter(Organization.id == id_)
+            self._db_session.query(*cols)
+            .filter(Organization.id == id_)
             # The name of the CTE is arbitrary, but must be present
             .cte("organizations", recursive=True)
         )

--- a/lms/validation/_exceptions.py
+++ b/lms/validation/_exceptions.py
@@ -8,9 +8,7 @@ from pyramid.httpexceptions import HTTPFound
 __all__ = ["ValidationError", "LTIToolRedirect"]
 
 
-class ValidationError(
-    httpexceptions.HTTPUnprocessableEntity
-):  # pylint: disable=too-many-ancestors
+class ValidationError(httpexceptions.HTTPUnprocessableEntity):  # pylint: disable=too-many-ancestors
     """
     A schema validation failure.
 

--- a/lms/views/dashboard.py
+++ b/lms/views/dashboard.py
@@ -133,7 +133,8 @@ class DashboardViews:
             # An LTIUser might not exists if accessing from the admin pages.
             return response
         auth_token = (
-            BearerTokenSchema(self.request).authorization_param(lti_user)
+            BearerTokenSchema(self.request)
+            .authorization_param(lti_user)
             # White space is not allowed as a cookie character, remove the leading part
             .replace("Bearer ", "")
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,15 +59,6 @@ precision = 2
 fail_under = 100.00
 skip_covered = true
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-default_section = "THIRDPARTY"
-known_first_party = ["lms", "tests"]
-
 [tool.pylint.main]
 jobs = 0 # Use one process for CPU.
 
@@ -79,6 +70,7 @@ load-plugins = [
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.redefined_variable_type",
 ]
+
 
 # Fail if there are *any* messages from PyLint.
 # The letters refer to PyLint's message categories, see
@@ -137,6 +129,11 @@ good-names = [
 [tool.pylint.reports]
 output-format = "colorized"
 score = "no"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
 
 [tool.hdev]
 project_name = "lms"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,33 +10,6 @@ filterwarnings = [
     "ignore:^'cgi' is deprecated and slated for removal in Python 3\\.13$:DeprecationWarning:webob",
 ]
 
-[tool.pydocstyle]
-ignore = [
-    # Missing docstrings.
-    "D100","D101","D102","D103","D104","D105","D106","D107",
-
-    # "No blank lines allowed after function docstring" conflicts with the
-    # Black code formatter which insists on inserting blank lines after
-    # function docstrings.
-    "D202",
-
-    # "1 blank line required before class docstring" conflicts with another
-    # pydocstyle rule D211 "No blank lines allowed before class docstring".
-    "D203",
-
-    # "Multi-line docstring summary should start at the first line"
-    # and "Multi-line docstring summary should start at the second line".
-    # These two rules conflict with each other so you have to disable one of them.
-    # How about we disable them both? PEP 257 says either approach is okay:
-    #
-    # > The summary line may be on the same line as the opening quotes or on
-    # > the next line.
-    # >
-    # > https://peps.python.org/pep-0257/#multi-line-docstrings
-    "D212",
-    "D213",
-]
-
 [tool.coverage.run]
 branch = true
 parallel = true
@@ -134,6 +107,53 @@ score = "no"
 target-version = "py311"
 line-length = 88
 
+[tool.ruff.lint]
+select = [
+  "E", "W", #  https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+  "D", # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+]
+
+ignore = [
+    # Missing docstrings.
+    "D100","D101","D102","D103","D104","D105","D106","D107",
+
+    # "No blank lines allowed after function docstring" conflicts with the
+    # Black code formatter which insists on inserting blank lines after
+    # function docstrings.
+    "D202",
+
+    # "1 blank line required before class docstring" conflicts with another
+    # pydocstyle rule D211 "No blank lines allowed before class docstring".
+    "D203",
+
+    # "Multi-line docstring summary should start at the first line"
+    # and "Multi-line docstring summary should start at the second line".
+    # These two rules conflict with each other so you have to disable one of them.
+    # How about we disable them both? PEP 257 says either approach is okay:
+    #
+    # > The summary line may be on the same line as the opening quotes or on
+    # > the next line.
+    # >
+    # > https://peps.python.org/pep-0257/#multi-line-docstrings
+    "D212",
+    "D213",
+
+    # We use Black to format our code automatically, so we don't need PyLint to
+    # check formatting for us.
+    "E501", # line-too-long
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    # Just disable name style checking for the tests, because we
+    # frequently use lots of argument names that don't conform.
+    # For example we frequently create pytest fixtures that aren't named in
+    # snake_case, such as a fixture that returns a mock of the FooBar class would
+    # be named FooBar in CamelCase.
+    "N",
+    # We are more lax about  comment formatting in the tests
+    "D",
+] 
 
 [tool.hdev]
 project_name = "lms"

--- a/requirements/checkformatting.in
+++ b/requirements/checkformatting.in
@@ -1,4 +1,3 @@
 pip-tools
 pip-sync-faster
-black
-isort
+ruff

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -4,38 +4,26 @@
 #
 #    pip-compile --allow-unsafe requirements/checkformatting.in
 #
-black==24.3.0
-    # via -r requirements/checkformatting.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 importlib-metadata==7.0.1
     # via pip-sync-faster
-isort==5.13.2
-    # via -r requirements/checkformatting.in
-mypy-extensions==1.0.0
-    # via black
 packaging==23.2
-    # via
-    #   black
-    #   build
-pathspec==0.12.1
-    # via black
+    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/checkformatting.in
 pip-tools==7.4.1
     # via
     #   -r requirements/checkformatting.in
     #   pip-sync-faster
-platformdirs==4.1.0
-    # via black
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
+ruff==0.4.3
+    # via -r requirements/checkformatting.in
 wheel==0.42.0
     # via pip-tools
 zipp==3.17.0

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -13,17 +13,17 @@ importlib-metadata==7.0.1
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/checkformatting.in
+    # via -r checkformatting.in
 pip-tools==7.4.1
     # via
-    #   -r requirements/checkformatting.in
+    #   -r checkformatting.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
 ruff==0.4.3
-    # via -r requirements/checkformatting.in
+    # via -r checkformatting.in
 wheel==0.42.0
     # via pip-tools
 zipp==3.17.0

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -9,16 +9,16 @@ build==1.0.3
 click==8.1.7
     # via pip-tools
 coverage[toml]==7.4.4
-    # via -r requirements/coverage.in
+    # via -r coverage.in
 importlib-metadata==7.0.1
     # via pip-sync-faster
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/coverage.in
+    # via -r coverage.in
 pip-tools==7.4.1
     # via
-    #   -r requirements/coverage.in
+    #   -r coverage.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via

--- a/requirements/format.in
+++ b/requirements/format.in
@@ -1,4 +1,3 @@
 pip-tools
 pip-sync-faster
-black
-isort
+ruff

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -13,17 +13,17 @@ importlib-metadata==7.0.1
 packaging==23.2
     # via build
 pip-sync-faster==0.0.3
-    # via -r requirements/format.in
+    # via -r format.in
 pip-tools==7.4.1
     # via
-    #   -r requirements/format.in
+    #   -r format.in
     #   pip-sync-faster
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
 ruff==0.4.3
-    # via -r requirements/format.in
+    # via -r format.in
 wheel==0.42.0
     # via pip-tools
 zipp==3.17.0

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -4,38 +4,26 @@
 #
 #    pip-compile --allow-unsafe requirements/format.in
 #
-black==24.3.0
-    # via -r requirements/format.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 importlib-metadata==7.0.1
     # via pip-sync-faster
-isort==5.13.2
-    # via -r requirements/format.in
-mypy-extensions==1.0.0
-    # via black
 packaging==23.2
-    # via
-    #   black
-    #   build
-pathspec==0.12.1
-    # via black
+    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/format.in
 pip-tools==7.4.1
     # via
     #   -r requirements/format.in
     #   pip-sync-faster
-platformdirs==4.1.0
-    # via black
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
+ruff==0.4.3
+    # via -r requirements/format.in
 wheel==0.42.0
     # via pip-tools
 zipp==3.17.0

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -2,8 +2,6 @@ pip-tools
 pip-sync-faster
 -r tests.txt
 -r functests.txt
-toml # Needed for pydocstyle to support pyproject.toml.
 pylint>=3.0.0
-pydocstyle
-pycodestyle
+ruff
 -r bddtests.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -426,8 +426,6 @@ pyasn1-modules==0.3.0
     #   -r functests.txt
     #   -r tests.txt
     #   google-auth
-pycodestyle==2.11.1
-    # via -r lint.in
 pycparser==2.21
     # via
     #   -r bddtests.txt
@@ -439,8 +437,6 @@ pycryptodomex==3.19.1
     #   -r bddtests.txt
     #   -r functests.txt
     #   -r tests.txt
-pydocstyle==6.3.0
-    # via -r lint.in
 pyjwt[crypto]==2.8.0
     # via
     #   -r bddtests.txt
@@ -558,6 +554,8 @@ rsa==4.9
     #   -r functests.txt
     #   -r tests.txt
     #   google-auth
+ruff==0.4.3
+    # via -r lint.in
 sentry-sdk==2.0.1
     # via
     #   -r bddtests.txt
@@ -573,8 +571,6 @@ six==1.16.0
     #   mailchimp-transactional
     #   parse-type
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 soupsieve==2.5
     # via
     #   -r bddtests.txt
@@ -600,8 +596,6 @@ tabulate==0.9.0
     #   -r functests.txt
     #   -r tests.txt
     #   data-tasks
-toml==0.10.2
-    # via -r lint.in
 tomlkit==0.12.3
     # via pylint
 transaction==4.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -118,7 +118,8 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     pyramid_request = testing.DummyRequest(db=db_session)
     pyramid_request.POST.update(lti_v11_params)
     pyramid_request.feature = mock.create_autospec(
-        lambda feature: False, return_value=False  # pragma: no cover
+        lambda feature: False,
+        return_value=False,  # pragma: no cover
     )
     pyramid_request.lti_user = factories.LTIUser(
         application_instance_id=application_instance.id,

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -17,7 +17,6 @@ from tests import factories
     "aes_service", "canvas_studio_settings", "oauth_http_factory", "admin_user"
 )
 class TestCanvasStudioService:
-
     def test_get_access_token(self, svc, oauth_http_service, client_secret):
         svc.get_access_token("some_code")
 

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -258,7 +258,6 @@ class TestFactory:
     def test_with_custom_service(
         self, http_service, oauth2_token_service, pyramid_request, OAuthHTTPService
     ):
-
         api_service = Service.CANVAS_STUDIO
 
         service = factory(sentinel.context, pyramid_request, api_service)

--- a/tests/unit/lms/views/api/canvas/pages_test.py
+++ b/tests/unit/lms/views/api/canvas/pages_test.py
@@ -92,9 +92,7 @@ class TestPageAPIViews:
         course_service.get_by_context_id.return_value.extra = {
             "canvas": {"custom_canvas_course_id": "OTHER_COURSE_ID"}
         }
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            "OTHER_PAGE_ID"
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = "OTHER_PAGE_ID"
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 
         response = PagesAPIViews(pyramid_request).via_url()
@@ -125,9 +123,7 @@ class TestPageAPIViews:
         course_service.get_by_context_id.return_value.extra = {
             "canvas": {"custom_canvas_course_id": "OTHER_COURSE_ID"}
         }
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            None
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = None
         course_copy_plugin.find_matching_page_in_course.return_value = None
 
         with pytest.raises(PageNotFoundInCourse):
@@ -152,9 +148,7 @@ class TestPageAPIViews:
         course_service.get_by_context_id.return_value.extra = {
             "canvas": {"custom_canvas_course_id": "OTHER_COURSE_ID"}
         }
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            None
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = None
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 
         course_copy_plugin.find_matching_page_in_course.return_value = Mock(
@@ -193,9 +187,7 @@ class TestPageAPIViews:
         course_service.get_by_context_id.return_value.extra = {
             "canvas": {"custom_canvas_course_id": "OTHER_COURSE_ID"}
         }
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            "OTHER_PAGE_ID"
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = "OTHER_PAGE_ID"
         canvas_service.api.pages.page.side_effect = CanvasAPIError
 
         with pytest.raises(PageNotFoundInCourse):

--- a/tests/unit/lms/views/api/moodle/pages_test.py
+++ b/tests/unit/lms/views/api/moodle/pages_test.py
@@ -97,9 +97,7 @@ class TestPageAPIViews:
         lti_user.lti.course_id = (
             course_service.get_by_context_id.return_value.lms_id
         ) = "OTHER_COURSE_ID"
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            "OTHER_PAGE_ID"
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = "OTHER_PAGE_ID"
         assignment_service.get_assignment.return_value.document_url = (
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
@@ -134,9 +132,7 @@ class TestPageAPIViews:
         assignment_service.get_assignment.return_value.document_url = (
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            "PAGE_ID"
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = "PAGE_ID"
         course_copy_plugin.find_matching_page_in_course.return_value = None
 
         with pytest.raises(PageNotFoundInCourse):
@@ -162,9 +158,7 @@ class TestPageAPIViews:
         assignment_service.get_assignment.return_value.document_url = (
             "moodle://page/course/COURSE_ID/page_id/PAGE_ID"
         )
-        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = (
-            "PAGE_ID"
-        )
+        course_service.get_by_context_id.return_value.get_mapped_page_id.return_value = "PAGE_ID"
         BearerTokenSchema.return_value.authorization_param.return_value = "TOKEN"
 
         course_copy_plugin.find_matching_page_in_course.return_value = Mock(

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -82,7 +82,6 @@ class TestViaURL:
 
 
 class TestViaVideoURL:
-
     def test_it(self, pyramid_request):
         canonical_url = "https://media.com/videos/abc"
         download_url = "https://cdn.media.com/videos/abc.mp4"

--- a/tox.ini
+++ b/tox.ini
@@ -89,10 +89,10 @@ commands =
     tests: sh bin/create-db lms_tests
     functests: sh bin/create-db lms_functests
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
-    format: black lms tests bin
-    format: isort --atomic lms tests bin
-    checkformatting: black --check lms tests bin
-    checkformatting: isort --quiet --check-only lms tests bin
+    format: ruff check --select I --fix lms tests bin
+    format: ruff format lms tests bin
+    checkformatting: ruff check --select I lms tests bin
+    checkformatting: ruff format --check lms tests bin
     lint: pylint lms bin
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle lms tests bin

--- a/tox.ini
+++ b/tox.ini
@@ -93,10 +93,9 @@ commands =
     format: ruff format lms tests bin
     checkformatting: ruff check --select I lms tests bin
     checkformatting: ruff format --check lms tests bin
+    lint: ruff check -q lms tests bin
     lint: pylint lms bin
     lint: pylint --rcfile=tests/pyproject.toml tests
-    lint: pydocstyle lms tests bin
-    lint: pycodestyle lms tests bin
     {tests,functests}: python3 -m lms.scripts.init_db --delete --create
     tests: python -m pytest --cov --cov-report= --cov-fail-under=0 --numprocesses logical --dist loadgroup --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}


### PR DESCRIPTION
A slight change of plans, as this generates a relatively big diff let's do it first and tackle linting afterwards. 

This change doesn't take much effort and reverting is also very easy, just switch the dependencies and run black/isort again.


https://docs.astral.sh/ruff/formatter/
https://docs.astral.sh/ruff/formatter/#intentional-deviations