### PR TITLE
Change approach to display acquired license message for VS

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -58,16 +58,16 @@ class BasicLaunchViews:
     def lti_launch(self):
         """Handle regular LTI launches."""
 
+        assignment = self.assignment_service.get_assignment_for_launch(self.request)
+
         if error_code := self.request.find_service(VitalSourceService).check_h_license(
-            self.request.lti_user, self.request.lti_params
+            self.request.lti_user, self.request.lti_params, assignment
         ):
             self.request.override_renderer = "lms:templates/error_dialog.html.jinja2"
             self.context.js_config.enable_error_dialog_mode(error_code)
             return {}
 
-        if assignment := self.assignment_service.get_assignment_for_launch(
-            self.request
-        ):
+        if assignment:
             self.request.override_renderer = (
                 "lms:templates/lti/basic_launch/basic_launch.html.jinja2"
             )

--- a/tests/unit/lms/services/vitalsource/service_test.py
+++ b/tests/unit/lms/services/vitalsource/service_test.py
@@ -104,7 +104,7 @@ class TestVitalSourceService:
         svc._student_pay_enabled = False  # pylint:disable=protected-access
 
         assert not svc.check_h_license(
-            pyramid_request.lti_user, pyramid_request.lti_params
+            pyramid_request.lti_user, pyramid_request.lti_params, sentinel.assignment
         )
 
     @pytest.mark.parametrize(
@@ -121,12 +121,12 @@ class TestVitalSourceService:
         self, request, svc, pyramid_request, user_fixture, code
     ):
         svc._student_pay_enabled = True  # pylint:disable=protected-access
-        pyramid_request.lti_params["context_id"] = "COURSE_ID"
-        pyramid_request.lti_params["resource_link_id"] = "COURSE_ID"
         _ = request.getfixturevalue(user_fixture)
 
         assert (
-            svc.check_h_license(pyramid_request.lti_user, pyramid_request.lti_params)
+            svc.check_h_license(
+                pyramid_request.lti_user, pyramid_request.lti_params, None
+            )
             == code
         )
 
@@ -136,7 +136,11 @@ class TestVitalSourceService:
         customer_client.get_user_book_license.return_value = None
 
         assert (
-            svc.check_h_license(pyramid_request.lti_user, pyramid_request.lti_params)
+            svc.check_h_license(
+                pyramid_request.lti_user,
+                pyramid_request.lti_params,
+                sentinel.assignment,
+            )
             == ErrorCode.VITALSOURCE_STUDENT_PAY_NO_LICENSE
         )
 
@@ -150,7 +154,11 @@ class TestVitalSourceService:
         customer_client.get_user_book_license.return_value = sentinel.license
 
         assert not (
-            svc.check_h_license(pyramid_request.lti_user, pyramid_request.lti_params)
+            svc.check_h_license(
+                pyramid_request.lti_user,
+                pyramid_request.lti_params,
+                sentinel.assignment,
+            )
         )
 
     @pytest.mark.usefixtures("user_is_instructor")
@@ -160,7 +168,11 @@ class TestVitalSourceService:
         svc._student_pay_enabled = True  # pylint:disable=protected-access
 
         assert not (
-            svc.check_h_license(pyramid_request.lti_user, pyramid_request.lti_params)
+            svc.check_h_license(
+                pyramid_request.lti_user,
+                pyramid_request.lti_params,
+                sentinel.assignment,
+            )
         )
         customer_client.get_user_book_license.assert_not_called()
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -163,14 +163,16 @@ class TestBasicLaunchViews:
         assert not response
 
     def test_lti_launch_check_h_license_fails(
-        self, context, pyramid_request, vitalsource_service
+        self, context, pyramid_request, vitalsource_service, assignment_service
     ):
         vitalsource_service.check_h_license.return_value = sentinel.error_code
 
         response = BasicLaunchViews(context, pyramid_request).lti_launch()
 
         vitalsource_service.check_h_license.assert_called_once_with(
-            pyramid_request.lti_user, pyramid_request.lti_params
+            pyramid_request.lti_user,
+            pyramid_request.lti_params,
+            assignment_service.get_assignment_for_launch.return_value,
         )
 
         assert (


### PR DESCRIPTION
Instead of trying to guess the launch from the VitalSource course materials via LTI parameters that will be different from each LMS show the message in all cases for:

- Non DL launches
- No configured assignment

In the VS integration we don't use our non-DL filepicker because it will required teachers selecting the H sku in *every* launch. We'll always use DL to configure assignments.

That means that every non configured launch must be from the course materials section.