### PR TITLE
Check unused-argument with ruff

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -11,7 +11,7 @@ def configure_jinja2_assets(config):
     jinja2_env.globals["asset_urls"] = config.registry["assets_env"].urls
 
 
-def create_app(global_config, **settings):  # pylint: disable=unused-argument
+def create_app(global_config, **settings):  # noqa: ARG001
     config = configure(settings=settings)
 
     # Make sure that pyramid_exclog's tween runs under pyramid_tm's tween so

--- a/lms/extensions/feature_flags/views/_predicates.py
+++ b/lms/extensions/feature_flags/views/_predicates.py
@@ -40,7 +40,7 @@ class FeatureFlagViewPredicate:
         """
         return self.text()
 
-    def __call__(self, context, request):
+    def __call__(self, context, request):  # noqa: ARG002
         """
         Return ``True`` if ``request`` matches this view predicate.
 

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -29,7 +29,7 @@ class CanvasGroupingPlugin(GroupingPlugin):
             self._custom_course_id(course)
         )
 
-    def get_sections_for_instructor(self, svc, course):
+    def get_sections_for_instructor(self, svc, course):  # noqa: ARG002
         if self._strict_section_membership:
             # Return only sections the current instructor belongs to
             return self._canvas_api.authenticated_users_sections(

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -41,8 +41,8 @@ class CanvasMiscPlugin(MiscPlugin):
     def get_assignment_configuration(
         self,
         request,
-        assignment: Assignment | None,
-        historical_assignment: Assignment | None,
+        assignment: Assignment | None,  # noqa: ARG002
+        historical_assignment: Assignment | None,  # noqa: ARG002
     ) -> AssignmentConfig:
         document_url = self._get_document_url(request)
 

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -3,11 +3,11 @@ from lms.services.lti_grading.interface import LTIGradingService
 
 
 class D2LMiscPlugin(MiscPlugin):
-    def get_ltia_aud_claim(self, lti_registration):
+    def get_ltia_aud_claim(self, lti_registration):  # noqa: ARG002
         # In D2L this value is always the same and different from
         # `lti_registration.token_url` as in other LMS
         return "https://api.brightspace.com/auth/token"
 
     @classmethod
-    def factory(cls, _context, request):
+    def factory(cls, _context, request):  # noqa: ARG003
         return cls()

--- a/lms/product/moodle/_plugin/grouping.py
+++ b/lms/product/moodle/_plugin/grouping.py
@@ -48,7 +48,11 @@ class MoodleGroupingPlugin(GroupingPlugin):
         raise GroupError(ErrorCodes.STUDENT_NOT_IN_GROUP, group_set=group_set_id)
 
     def get_groups_for_grading(
-        self, svc, course, group_set_id, grading_student_id=None
+        self,
+        svc,  # noqa: ARG002
+        course,
+        group_set_id,
+        grading_student_id=None,  # noqa: ARG002
     ):
         return self._api.groups_for_user(
             course.lms_id, group_set_id, grading_student_id

--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -54,5 +54,5 @@ class MoodleMiscPlugin(MiscPlugin):
         return self._assignment_config_from_deep_linked_config(deep_linked_config)
 
     @classmethod
-    def factory(cls, _context, request):  # pragma: no cover
+    def factory(cls, _context, request):  # pragma: no cover  # noqa: ARG003
         return cls()

--- a/lms/product/plugin/grouping.py
+++ b/lms/product/plugin/grouping.py
@@ -3,7 +3,6 @@ from enum import Enum
 from lms.models import Course, Grouping
 
 
-# pylint: disable=unused-argument
 class GroupingPlugin:
     """
     An abstraction between a specific LMS API and different grouping types.
@@ -24,52 +23,69 @@ class GroupingPlugin:
     """The type of sections this plugin supports. `None` disables support."""
 
     def get_sections_for_learner(
-        self, svc, course: Course
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the sections from context when launched by a normal learner."""
 
         return None
 
     def get_sections_for_instructor(
-        self, svc, course: Course
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the sections from context when launched by an instructor."""
 
         return None
 
     def get_sections_for_grading(
-        self, svc, course: Course, grading_student_id
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
+        grading_student_id,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the sections for a learner when they are being graded."""
 
         return None
 
-    def get_group_sets(self, course) -> list[dict]:  # pragma: nocover
+    def get_group_sets(self, course) -> list[dict]:  # pragma: nocover  # noqa: ARG002
         """Return the list of group sets for the given course."""
         return []
 
     def get_groups_for_learner(
-        self, svc, course: Course, group_set_id
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
+        group_set_id,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the sections from context when launched by a normal learner."""
 
         return None
 
     def get_groups_for_instructor(
-        self, svc, course: Course, group_set_id
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
+        group_set_id,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the groups from context when launched by an instructor."""
 
         return None
 
     def get_groups_for_grading(
-        self, svc, course: Course, group_set_id, grading_student_id
+        self,
+        svc,  # noqa: ARG002
+        course: Course,  # noqa: ARG002
+        group_set_id,  # noqa: ARG002
+        grading_student_id,  # noqa: ARG002
     ) -> list | None:  # pragma: nocover
         """Get the groups for a learner when they are being graded."""
 
         return None
 
-    def sections_enabled(self, request, application_instance, course) -> bool:
+    def sections_enabled(self, request, application_instance, course) -> bool:  # noqa: ARG002
         """Check if sections are enabled for this LMS, instance and course."""
         return bool(self.sections_type)
 

--- a/lms/services/launch_verifier.py
+++ b/lms/services/launch_verifier.py
@@ -108,12 +108,12 @@ class _OAuthRequestValidator(RequestValidator):
 
         self.application_instance_service = application_instance_service
 
-    def check_client_key(self, client_key):
+    def check_client_key(self, client_key):  # noqa: ARG002
         """Check that the client key only contains safe characters."""
 
         return True
 
-    def check_nonce(self, nonce):
+    def check_nonce(self, nonce):  # noqa: ARG002
         """Check that the nonce only contains only safe characters."""
 
         return True
@@ -122,18 +122,18 @@ class _OAuthRequestValidator(RequestValidator):
         # pylint: disable=too-many-arguments
         # Not our design, we have to fit in with this API
         self,
-        client_key,
-        timestamp,
-        nonce,
-        request,
-        request_token=None,
-        access_token=None,
+        client_key,  # noqa: ARG002
+        timestamp,  # noqa: ARG002
+        nonce,  # noqa: ARG002
+        request,  # noqa: ARG002
+        request_token=None,  # noqa: ARG002
+        access_token=None,  # noqa: ARG002
     ):
         """Validate that the nonce has not been used before."""
 
         return True
 
-    def validate_client_key(self, client_key, request):
+    def validate_client_key(self, client_key, request):  # noqa: ARG002
         """Validate that supplied client key is registered and valid."""
 
         # This is slightly incorrect, but we are just going to say the client
@@ -143,7 +143,7 @@ class _OAuthRequestValidator(RequestValidator):
 
         return True
 
-    def get_client_secret(self, client_key, request):
+    def get_client_secret(self, client_key, request):  # noqa: ARG002
         """Retrieve the client secret associated with the client key."""
 
         try:

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -43,7 +43,7 @@ class LTI11GradingService(LTIGradingService):
 
         return result
 
-    def record_result(self, grading_id, score=None, pre_record_hook=None, comment=None):
+    def record_result(self, grading_id, score=None, pre_record_hook=None, comment=None):  # noqa: ARG002
         request = {"resultRecord": {"sourcedGUID": {"sourcedId": grading_id}}}
 
         if score is not None:

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -47,7 +47,7 @@ class LTIGradingService:  # pragma: no cover
         self.line_item_url = line_item_url
         self.line_item_container_url = line_item_container_url
 
-    def get_score_maximum(self, resource_link_id):  # pylint:disable=unused-argument
+    def get_score_maximum(self, resource_link_id):  # noqa: ARG002
         """
         Read the grading configuration of an assignment.
 

--- a/lms/validation/_base.py
+++ b/lms/validation/_base.py
@@ -91,7 +91,7 @@ class PyramidRequestSchema(PlainSchema):
         return parser.parse(self, self.context["request"], *args, **kwargs)
 
     @staticmethod
-    def _handle_error(error, _req, _schema, *, error_status_code, error_headers):
+    def _handle_error(error, _req, _schema, *, error_status_code, error_headers):  # noqa: ARG004
         raise ValidationError(messages=error.messages) from error
 
 

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -149,7 +149,7 @@ class CanvasPreRecordHook:
     def __init__(self, request):
         self.request = request
 
-    def __call__(self, score=None, request_body=None) -> dict:
+    def __call__(self, score=None, request_body=None) -> dict:  # noqa: ARG002
         speedgrader_url = self.get_speedgrader_launch_url()
 
         #  A `datetime.datetime` that indicates when the submission was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ disable = [
 
     # False positives and flaky behaviour
     "unsubscriptable-object",
+
+    # Ported to ruff
+    "unused-argument",
 ]
 
 good-names = [
@@ -115,6 +118,7 @@ line-length = 88
 select = [
   "E", "W", #  https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
   "D", # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+  "ARG", # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
 ]
 
 ignore = [

--- a/tests/bdd/steps/h_api.py
+++ b/tests/bdd/steps/h_api.py
@@ -25,7 +25,7 @@ class HAPIContext(StepContext):
         )
 
         # Catch URLs we aren't expecting or have failed to mock
-        def error_response(request, uri, response_headers):
+        def error_response(request, uri, response_headers):  # noqa: ARG001
             raise NotImplementedError(f"Unexpected call to URL: {request.method} {uri}")
 
         httpretty.register_uri(method=Any(), uri=re.compile(".*"), body=error_response)

--- a/tests/functional/lti_certification/v13/conftest.py
+++ b/tests/functional/lti_certification/v13/conftest.py
@@ -44,7 +44,7 @@ def make_jwt(jwt_headers, jwt_private_key):
 
 
 @pytest.fixture(autouse=True)
-def lti_registration(db_session):  # pylint:disable=unused-argument
+def lti_registration(db_session):  # noqa: ARG001
     return factories.LTIRegistration(
         issuer="https://ltiadvantagevalidator.imsglobal.org",
         client_id="imstester_4ba76ab",

--- a/tests/functional/views/basic_lti_launch_test.py
+++ b/tests/functional/views/basic_lti_launch_test.py
@@ -85,7 +85,7 @@ class TestBasicLTILaunch:
         )
 
     @pytest.fixture(autouse=True)
-    def application_instance(self, db_session):  # pylint:disable=unused-argument
+    def application_instance(self, db_session):  # noqa: ARG002
         return factories.ApplicationInstance(
             tool_consumer_instance_guid="IMS Testing",
             organization=factories.Organization(),

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -69,6 +69,9 @@ disable = [
 
     # Issues to disable this for false positives, disabling it globally in the meantime https://github.com/PyCQA/pylint/issues/214
     "duplicate-code",
+
+    # Ported to ruff
+    "unused-argument",
 ]
 
 # Just disable PyLint's name style checking for the tests, because we

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -118,7 +118,7 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
     pyramid_request = testing.DummyRequest(db=db_session)
     pyramid_request.POST.update(lti_v11_params)
     pyramid_request.feature = mock.create_autospec(
-        lambda feature: False,
+        lambda feature: False,  # noqa: ARG005
         return_value=False,  # pragma: no cover
     )
     pyramid_request.lti_user = factories.LTIUser(
@@ -183,7 +183,7 @@ def configure_jinja2_assets(config):
     jinja2_env = config.get_jinja2_environment()
     jinja2_env.globals["asset_url"] = "http://example.com"
     jinja2_env.globals["asset_urls"] = (
-        lambda bundle: "http://example.com"
+        lambda bundle: "http://example.com"  # noqa: ARG005
     )  # pragma: no cover
     jinja2_env.globals["js_config"] = {}
 

--- a/tests/unit/lms/services/mailchimp_test.py
+++ b/tests/unit/lms/services/mailchimp_test.py
@@ -18,7 +18,7 @@ from lms.services.mailchimp import (
 #: A factory for course dicts as expected by the instructor_email_digest template.
 CourseDict = make_factory(
     dict,
-    title=Sequence(lambda n: "Course {n}"),
+    title=Sequence(lambda n: "Course {n}"),  # noqa: ARG005
     num_annotations=3,
     annotators=[sentinel.student_1, sentinel.student_2],
 )

--- a/tests/unit/lms/tweens_test.py
+++ b/tests/unit/lms/tweens_test.py
@@ -28,7 +28,9 @@ class TestDBRollbackSessionOnExceptionTween:
 
     @pytest.fixture
     def handler(self):
-        return mock.create_autospec(lambda request: None)  # pragma: nocover
+        return mock.create_autospec(
+            lambda request: None  # noqa: ARG005
+        )  # pragma: nocover  # noqa: ARG005
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
Here I'm testing an approach to avoid a huge pylint / ruff PR.

I wouldn't do it one by one and not for every rule, only for the ones that we have now `pylint:disable=` around the code.

The noqa notes are added by ruff with:

```
.tox/lint/bin/ruff check  -q lms tests bin --add-noqa      
```