### PR TITLE
Fix File dict declaration to mark fields as not required

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -86,11 +86,11 @@ class File(TypedDict):
     id: str
     display_name: str
 
-    duration: float | None
+    duration: NotRequired[float]
     """Duration of media in seconds."""
 
     updated_at: str
-    thumbnail_url: str | None
+    thumbnail_url: NotRequired[str]
 
     contents: NotRequired[APICallInfo]
     """API call to use to fetch contents of a folder."""


### PR DESCRIPTION
make typecheck is not part of CI or make sure so this type of thing is easy to miss.

I'll start a slack thread about enabling this in CI.