### PR TITLE
Add assignment and group IDs in debug info

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -17,6 +17,7 @@ import logging
 from pyramid.view import view_config, view_defaults
 
 from lms.events import LTIEvent
+from lms.models import Assignment
 from lms.product.plugin.misc import MiscPlugin
 from lms.security import Permissions
 from lms.services import LTIGradingService, VitalSourceService
@@ -82,7 +83,7 @@ class BasicLaunchViews:
         # Show the file-picker for the user to choose a document.
         # This happens if we cannot resolve a document URL for any reason.
         self.request.override_renderer = "lms:templates/file_picker.html.jinja2"
-        self._configure_js_for_file_picker()
+        self._configure_js_for_file_picker(assignment)
 
         return {}
 
@@ -93,7 +94,7 @@ class BasicLaunchViews:
             tool_consumer_instance_guid=self._guid,
             resource_link_id=self._resource_link_id,
         )
-        config = self._configure_js_for_file_picker(route="edit_assignment")
+        config = self._configure_js_for_file_picker(assignment, route="edit_assignment")
         return {
             # Info about the assignment's current configuration
             "assignment": {
@@ -265,7 +266,7 @@ class BasicLaunchViews:
         )
 
     def _configure_js_for_file_picker(
-        self, route: str = "configure_assignment"
+        self, assignment: Assignment, route: str = "configure_assignment"
     ) -> dict:
         """
         Show the file-picker for the user to choose a document.
@@ -285,4 +286,6 @@ class BasicLaunchViews:
             form_fields=self.request.lti_params.serialize(
                 authorization=self.context.js_config.auth_token
             ),
+            course=self.course,
+            assignment=assignment,
         )

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -77,6 +77,7 @@ def deep_linking_launch(context, request):
             "lti_message_type": "ContentItemSelection",
             "lti_version": request.parsed_params["lti_version"],
         },
+        course=course,
         prompt_for_title=request.product.plugin.misc.deep_linking_prompt_for_title,
     )
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -25,8 +25,10 @@ pytestmark = pytest.mark.usefixtures(
 
 
 class TestFilePickerMode:
-    def test_it(self, js_config):
-        js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
+    def test_it(self, js_config, course):
+        js_config.enable_file_picker_mode(
+            sentinel.form_action, sentinel.form_fields, course
+        )
         config = js_config.asdict()
 
         assert config == Any.dict.containing(
@@ -54,9 +56,11 @@ class TestFilePickerMode:
         ),
     )
     def test_it_adds_picker_config(
-        self, js_config, pyramid_request, FilePickerConfig, config_function, key
+        self, js_config, pyramid_request, FilePickerConfig, config_function, key, course
     ):
-        js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
+        js_config.enable_file_picker_mode(
+            sentinel.form_action, sentinel.form_fields, course
+        )
         config = js_config.asdict()
 
         config_provider = getattr(FilePickerConfig, config_function)
@@ -65,19 +69,23 @@ class TestFilePickerMode:
             pyramid_request, pyramid_request.lti_user.application_instance
         )
 
-    def test_it_adds_product_info(self, js_config):
-        js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
+    def test_it_adds_product_info(self, js_config, course):
+        js_config.enable_file_picker_mode(
+            sentinel.form_action, sentinel.form_fields, course
+        )
 
         assert js_config.asdict()["product"] == {
             "api": {},
             "settings": {"groupsEnabled": False},
         }
 
-    def test_product_with_list_group_sets(self, js_config, pyramid_request):
+    def test_product_with_list_group_sets(self, js_config, pyramid_request, course):
         pyramid_request.product.route = Routes(oauth2_authorize="welcome")
         pyramid_request.product.settings.groups_enabled = True
 
-        js_config.enable_file_picker_mode(sentinel.form_action, sentinel.form_fields)
+        js_config.enable_file_picker_mode(
+            sentinel.form_action, sentinel.form_fields, course
+        )
 
         assert js_config.asdict()["product"] == {
             "api": {
@@ -124,6 +132,8 @@ class TestEnableLTILaunchMode:
                 "values": {
                     "Organization ID": "us.lms.org.PUBLIC_ID",
                     "Application Instance ID": lti_user.application_instance.id,
+                    "Assignment ID": assignment.id,
+                    "Course ID": course.id,
                     "LTI version": "LTI-1p0",
                 },
             },
@@ -495,9 +505,9 @@ class TestSetFocusedUser:
         )
 
     @pytest.fixture
-    def js_config(self, js_config, assignment):
+    def js_config(self, js_config, assignment, course):
         # `set_focused_user` needs the `hypothesisClient` section to exist
-        js_config.enable_lti_launch_mode(sentinel.course, assignment)
+        js_config.enable_lti_launch_mode(course, assignment)
 
         return js_config
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -129,7 +129,7 @@ class TestBasicLaunchViews:
         pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)
 
     def test_lti_launch_unconfigured(
-        self, svc, context, pyramid_request, assignment_service
+        self, svc, context, pyramid_request, assignment_service, course_service
     ):
         assignment_service.get_assignment_for_launch.return_value = None
 
@@ -145,6 +145,8 @@ class TestBasicLaunchViews:
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="http://example.com/assignment",
             form_fields=pyramid_request.lti_params.serialize.return_value,
+            course=course_service.get_from_launch.return_value,
+            assignment=None,
         )
 
     def test_lti_launch_unconfigured_launch_not_authorized(
@@ -183,7 +185,7 @@ class TestBasicLaunchViews:
         assert not response
 
     def test_reconfigure_assignment_config(
-        self, svc, context, pyramid_request, assignment_service
+        self, svc, context, pyramid_request, assignment_service, course_service
     ):
         pyramid_request.lti_params = mock.create_autospec(
             LTIParams, spec_set=True, instance=True
@@ -198,6 +200,8 @@ class TestBasicLaunchViews:
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="http://example.com/assignment/edit",
             form_fields=pyramid_request.lti_params.serialize.return_value,
+            course=course_service.get_from_launch.return_value,
+            assignment=assignment,
         )
         assert response == {
             "assignment": {

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -40,6 +40,7 @@ class TestDeepLinkingLaunch:
                 "lti_message_type": "ContentItemSelection",
                 "lti_version": "TEST_LTI_VERSION",
             },
+            course=course_service.get_from_launch.return_value,
             prompt_for_title=misc_plugin.deep_linking_prompt_for_title,
         )
         context.js_config.add_deep_linking_api.assert_called_once()


### PR DESCRIPTION
When launching an assignment, you should now see something like this in the browser console:

![image](https://github.com/hypothesis/lms/assets/2719332/9c764be5-a77a-490c-bd9c-532241f0c067)

We always use course and assignment information that has already been queried during the request for other purposes, so this should have almost no performance impact.
