### PR TITLE
Don't update assignment details while on a SpeedGrader launch

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -50,6 +50,12 @@ class AssignmentService:
 
     def update_assignment(self, request, assignment, document_url, group_set_id):
         """Update an existing assignment."""
+        if request.GET.get("learner_canvas_user_id"):
+            # SpeedGrader has a number of issues regarding the information it sends about the assignment
+            # Don't update our DB with that nonsense.
+            # See:
+            #   https://github.com/instructure/canvas-lms/issues/1952
+            return assignment
 
         assignment.document_url = document_url
         assignment.extra["group_set_id"] = group_set_id


### PR DESCRIPTION
SpeedGrader launches lie to us in a at least two ways related to the information we store in the DB:

- The assignment title we get tis the course's not the groups
- All SpeedGrader launches are identified as is_gradable=False



## Testing

- In `main` launch: [localhost (make devdata) HTML Assignment](https://hypothesis.instructure.com/courses/125/assignments/873)


- Check the DB status:
```
docker compose exec postgres psql -U postgres -c "select title, is_gradable from assignment where resource_link_id = 'f330509e8ee8e465a55c4c88a4fcc9ef1ee992bd';"
                  title                   | is_gradable 
------------------------------------------+-------------
 localhost (make devdata) HTML Assignment | t
(1 row)
````

- Launch [localhost (make devdata) HTML Assignment in SpeedGrader mode](https://hypothesis.instructure.com/courses/125/gradebook/speed_grader?assignment_id=873&student_id=2742)



```docker compose exec postgres psql -U postgres -c "select title, is_gradable from assignment where resource_link_id = 'f330509e8ee8e465a55c4c88a4fcc9ef1ee992bd';"
                     title                      | is_gradable 
------------------------------------------------+-------------
 localhost (make devdata) with Sections Enabled | f
(1 row)
```

Note that title and is_gradable have changed :scream: 


- Repeat the process in this branch. No wierd changes now in the DB.