### PR TITLE
Frontend changes for the new API-driven dashboard

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -152,3 +152,11 @@ export type StudentStats = {
   annotations: number;
   replies: number;
 };
+
+/**
+ * Response for `/api/assignment/{assignment_id}` call.
+ */
+export type Assignment = {
+  id: number;
+  title: string;
+};

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/dashboard/organization/:organizationId/assignment/:assignmentId">
+          <Route path="/dashboard/organization/:organizationId" nest>
             <DashboardApp />
           </Route>
           <Route path="/email/preferences">

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,16 +1,10 @@
 import classnames from 'classnames';
+import { Route } from 'wouter-preact';
 
-import type { StudentStats } from '../../api-types';
-import { useConfig } from '../../config';
-import { useAPIFetch } from '../../utils/api';
 import DashboardFooter from './DashboardFooter';
-import StudentsActivityTable from './StudentsActivityTable';
+import StudentsActivity from './StudentsActivity';
 
 export default function DashboardApp() {
-  const { dashboard } = useConfig(['dashboard']);
-  const { assignment, assignmentStatsApi } = dashboard;
-  const students = useAPIFetch<StudentStats[]>(assignmentStatsApi.path);
-
   return (
     <div className="flex flex-col min-h-screen gap-5 bg-grey-2">
       <div
@@ -27,11 +21,9 @@ export default function DashboardApp() {
       </div>
       <div className="flex-grow px-3">
         <div className="mx-auto max-w-6xl">
-          <StudentsActivityTable
-            assignment={assignment}
-            students={students.data ?? []}
-            loading={students.isLoading}
-          />
+          <Route path="/assignment/:assignmentId">
+            <StudentsActivity />
+          </Route>
         </div>
       </div>
       <DashboardFooter />

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
@@ -6,45 +6,48 @@ import {
 } from '@hypothesis/frontend-shared';
 import type { DataTableProps } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
+import { useParams } from 'wouter-preact';
 
-import type { StudentStats } from '../../api-types';
+import type { Assignment, StudentStats } from '../../api-types';
+import { useConfig } from '../../config';
+import { useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
-
-export type AssignmentInfo = {
-  title: string;
-};
-
-export type StudentsActivityTableProps = {
-  assignment: AssignmentInfo;
-  students: StudentStats[];
-  loading?: boolean;
-};
 
 type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
 
-export default function StudentsActivityTable({
-  assignment,
-  students,
-  loading,
-}: StudentsActivityTableProps) {
-  const title = `Assignment: ${assignment.title}`;
+export default function StudentsActivity() {
+  const { dashboard } = useConfig(['dashboard']);
+  const { routes } = dashboard;
+  const { assignmentId } = useParams<{ assignmentId: string }>();
+  const assignment = useAPIFetch<Assignment>(
+    routes.assignment.replace(':assignment_id', assignmentId),
+  );
+  const students = useAPIFetch<StudentStats[]>(
+    routes.assignment_stats.replace(':assignment_id', assignmentId),
+  );
+
+  const title = `Assignment: ${assignment.data?.title}`;
   const [order, setOrder] = useState<MandatoryOrder<StudentStats>>({
     field: 'display_name',
     direction: 'ascending',
   });
-  const orderedStudents = useOrderedRows(students, order);
+  const orderedStudents = useOrderedRows(students.data ?? [], order);
 
   return (
     <Card>
       <CardContent>
         <h2 className="text-brand mb-3 text-xl" data-testid="title">
-          {title}
+          {assignment.isLoading && 'Loading...'}
+          {assignment.error && 'Could not load assignment title'}
+          {assignment.data && title}
         </h2>
         <DataTable
           grid
           striped={false}
-          emptyMessage="No students found"
-          title={title}
+          emptyMessage={
+            students.error ? 'Could not load students' : 'No students found'
+          }
+          title={assignment.isLoading ? 'Loading...' : title}
           columns={[
             { field: 'display_name', label: 'Name', classes: 'w-[60%]' },
             { field: 'annotations', label: 'Annotations' },
@@ -61,7 +64,7 @@ export default function StudentsActivityTable({
               ? formatDateTime(new Date(stats[field]))
               : stats[field];
           }}
-          loading={loading}
+          loading={students.isLoading}
           orderableColumns={[
             'display_name',
             'annotations',

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardApp-test.js
@@ -3,33 +3,12 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
-import sinon from 'sinon';
 
-import { Config } from '../../../config';
 import DashboardApp, { $imports } from '../DashboardApp';
 
 describe('DashboardApp', () => {
-  let fakeUseAPIFetch;
-  let fakeConfig;
-
   beforeEach(() => {
-    fakeUseAPIFetch = sinon.stub().returns({ data: [], isLoading: false });
-    fakeConfig = {
-      dashboard: {
-        assignment: {
-          title: 'The assignment',
-        },
-        assignmentStatsApi: {
-          path: '/api/assignment/123/stats',
-        },
-      },
-      api: { authToken: 'authToken' },
-    };
-
     $imports.$mock(mockImportedComponents());
-    $imports.$mock({
-      '../../utils/api': { useAPIFetch: fakeUseAPIFetch },
-    });
   });
 
   afterEach(() => {
@@ -37,53 +16,8 @@ describe('DashboardApp', () => {
   });
 
   function createComponent() {
-    return mount(
-      <Config.Provider value={fakeConfig}>
-        <DashboardApp />
-      </Config.Provider>,
-    );
+    return mount(<DashboardApp />);
   }
-
-  it('loads assignment stats on mount, via API call', () => {
-    assert.notCalled(fakeUseAPIFetch);
-    createComponent();
-    assert.calledWith(fakeUseAPIFetch, '/api/assignment/123/stats');
-  });
-
-  it('passes assignment info down to StudentsActivityTable', () => {
-    const wrapper = createComponent();
-    const table = wrapper.find('StudentsActivityTable');
-
-    assert.deepEqual(table.prop('assignment'), {
-      title: 'The assignment',
-    });
-  });
-
-  context('when loading students', () => {
-    [true, false].forEach(isLoading => {
-      it('passes loading state down to StudentsActivityTable', () => {
-        fakeUseAPIFetch.returns({ isLoading });
-        const wrapper = createComponent();
-
-        assert.equal(
-          wrapper.find('StudentsActivityTable').prop('loading'),
-          isLoading,
-        );
-      });
-    });
-
-    [undefined, [1, 2, 3]].forEach(students => {
-      it('passes list of students down to StudentsActivityTable', () => {
-        fakeUseAPIFetch.returns({ isLoading: false, data: students });
-        const wrapper = createComponent();
-
-        assert.deepEqual(
-          wrapper.find('StudentsActivityTable').prop('students'),
-          students ?? [],
-        );
-      });
-    });
-  });
 
   it(
     'should pass a11y checks',

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -240,11 +240,13 @@ export type EmailPreferences = {
   flashMessage: string | null;
 };
 
+export type DashboardRoutes = {
+  assignment: string;
+  assignment_stats: string;
+};
+
 export type DashboardConfig = {
-  assignment: {
-    title: string;
-  };
-  assignmentStatsApi: APICallInfo;
+  routes: DashboardRoutes;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sass": "^1.76.0",
     "tailwindcss": "^3.3.3",
     "tiny-emitter": "^2.1.0",
-    "wouter-preact": "^3.0.0"
+    "wouter-preact": "^3.1.3"
   },
   "devDependencies": {
     "@hypothesis/frontend-testing": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7396,7 +7396,7 @@ __metadata:
     tailwindcss: ^3.3.3
     tiny-emitter: ^2.1.0
     typescript: ^5.2.2
-    wouter-preact: ^3.0.0
+    wouter-preact: ^3.1.3
   languageName: unknown
   linkType: soft
 
@@ -10778,6 +10778,18 @@ __metadata:
   peerDependencies:
     preact: ^10.0.0
   checksum: 253927b4dbf0906220f71f103f3934e649debc4a5f2c94c84e3097a9072c3c2d967b559421b626acb555437ab3aa416ed0faabedd2cf95fb3c61fdbb83370bca
+  languageName: node
+  linkType: hard
+
+"wouter-preact@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "wouter-preact@npm:3.1.3"
+  dependencies:
+    mitt: ^3.0.1
+    regexparam: ^3.0.0
+  peerDependencies:
+    preact: ^10.0.0
+  checksum: 82784b2710088cd122323c8d061697941723bf30e9cc051fff9c05ea0ef91465ae8d0b5008339fc02dbfb7eb822adbea119fb6f71730dcc476d215c7e55bb182
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!NOTE]  
> This PR depends on https://github.com/hypothesis/lms/pull/6257, with the intention to merge it there first, to then merge both together into `main`, but with the ability to review them independently.

This PR starts preparing the Dashboard FE for the [BE changes](https://github.com/hypothesis/lms/pull/6257) around making the app more API-centric.

Main changes introduced here:

* Update to latest version of wouter-preact, which supports nested routes (according to the docs, v3.0 should also support them, but I couldn't make it work until I updated to v3.1)
* Create nested wouter routes, with the intention to dynamically render different pieces/children in the dashboard based on the route.
* Move student-specific async state handling from `<DashboardApp />` to `<StudentsActivity />` (formerly `<StudentsActivityTable />`) so that only the required information is fetched depending on the route.
* Due to the point above, the main `DashboardApp` component becomes dumber now, and will only take care of rendering the overall layout and the nested routes.

### Testing steps

There should be no visual changes here, but data is loaded differently now, so a bit of sanity check.

* Open an assignment in any LMS, for example https://hypothesis.instructure.com/courses/125
* Make sure the dashboard is enabled for the organization. For the assignment above go to http://localhost:8001/admin/instance/8/settings and check "Enable instructor dashboard"
* Relaunch the assignment. In the sidebar's user menu, click "Open dashboard" -> You should see the students activity list with no errors in the console.