### PR TITLE
Trust information from the launch instead of the DB for is_gradable

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -75,7 +75,14 @@ def _apply_canvas_quirks(lti_params, request):
     # We add the correct resource_link_id as a query param on the launch
     # URL that we submit to Canvas and use that instead of the incorrect
     # resource_link_id that Canvas puts in the request's body.
-    is_speedgrader = request.GET.get("learner_canvas_user_id")
+
+    # This is canvas only, call the right plugin directly
+    # Importing the plugin here to avoid a circular dependency hell
+    from lms.product.canvas._plugin.misc import (  # pylint:disable=import-outside-toplevel, cyclic-import
+        CanvasMiscPlugin,
+    )
+
+    is_speedgrader = CanvasMiscPlugin().is_speed_grader_launch(request)
 
     if is_speedgrader and (resource_link_id := request.GET.get("resource_link_id")):
         lti_params["resource_link_id"] = resource_link_id

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -161,6 +161,17 @@ class CanvasMiscPlugin(MiscPlugin):
             .geturl()
         )
 
+    def is_speed_grader_launch(self, request) -> bool:
+        """Check whether the current launch is a SpeedGrader one.
+
+        SpeedGrader launches contain additional parameters that we send to canvas on student submissions.
+
+        Those URLs are launched when:
+            - An instructor selects a student in SpeedGrader itself (launched as the instructor)
+            - A students selects the "submission details" option (launched as the learner)
+        """
+        return bool(request.GET.get("learner_canvas_user_id"))
+
     @classmethod
     def factory(cls, _context, _request):
         return cls()

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -24,7 +24,7 @@ class CanvasMiscPlugin(MiscPlugin):
         # `lis_result_sourcedid` associates a specific user with an
         # assignment.
         if (
-            assignment.is_gradable
+            self.is_assignment_gradable(lti_params)
             and lti_user.is_learner
             and lti_params.get("lis_result_sourcedid")
         ):

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -100,6 +100,10 @@ class MiscPlugin:
 
         return params
 
+    def is_speed_grader_launch(self, _request) -> bool:  # pragma: nocover
+        # SpeedGrader is a Canvas only concept
+        return False
+
     @staticmethod
     def _assignment_config_from_assignment(assignment: Assignment) -> AssignmentConfig:
         return {

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -50,7 +50,7 @@ class AssignmentService:
 
     def update_assignment(self, request, assignment, document_url, group_set_id):
         """Update an existing assignment."""
-        if request.GET.get("learner_canvas_user_id"):
+        if self._misc_plugin.is_speed_grader_launch(request):
             # SpeedGrader has a number of issues regarding the information it sends about the assignment
             # Don't update our DB with that nonsense.
             # See:

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -26,10 +26,10 @@ class TestAssignmentService:
         assert assignment in db_session.new
 
     @pytest.mark.parametrize("is_speed_grader", [False, True])
-    def test_update_assignment(self, svc, pyramid_request, is_speed_grader):
-        pyramid_request.GET = {}
-        if is_speed_grader:
-            pyramid_request.GET = {"learner_canvas_user_id": sentinel.speed_grader}
+    def test_update_assignment(
+        self, svc, pyramid_request, is_speed_grader, misc_plugin
+    ):
+        misc_plugin.is_speed_grader_launch.return_value = is_speed_grader
 
         assignment = svc.update_assignment(
             pyramid_request,

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -380,4 +380,6 @@ def grouping_plugin(mock_service):
 
 @pytest.fixture
 def misc_plugin(mock_service):
-    return mock_service(MiscPlugin)
+    plugin = mock_service(MiscPlugin)
+    plugin.is_speed_grader_launch.return_value = False
+    return plugin


### PR DESCRIPTION
We use assignment.is_gradable for record keeping but ultimately the
source of truth should be the current launch. If we don't have the
necessary parameters to call the grading APIs, it's not a gradable launch.

The discrepancy of both method for `is_gradable` comes (as far as we know) from SpeedGrader launches
which are always not gradable (!?) and confuse the course and assignment
parameters.

After 387ec0a we stopped recording that
bogus data in the DB. As a result of that assignment are correctly
marked as gradable in the DB but launches by students in the "submission
details" view (which used SpeedGrader launches) fail because they are in
fact, not gradable launches.


## Testing
- Launch https://hypothesis.instructure.com/courses/319/assignments/3336/submissions/35

- You'll get a `KeyError` in the console in `main`, nothing in this branch

