### PR TITLE
Expose annotation stats for a course's assignments

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -12,11 +12,6 @@ class APICallInfo(TypedDict):
     authUrl: NotRequired[str]
 
 
-class APIAssignment(TypedDict):
-    id: int
-    title: str
-
-
 class APICourse(TypedDict):
     id: int
     title: str
@@ -26,12 +21,27 @@ class APIStudentStats(TypedDict):
     display_name: str
     annotations: int
     replies: int
-    last_activity: str
+    last_activity: str | None
+
+
+class AssignmentStats(TypedDict):
+    annotations: int
+    replies: int
+    last_activity: str | None
+
+
+class APIAssignment(TypedDict):
+    id: int
+    title: str
+    stats: NotRequired[AssignmentStats]
 
 
 class DashboardRoutes(TypedDict):
     assignment: str
     assignment_stats: str
+
+    course: str
+    course_assignment_stats: str
 
 
 class DashboardConfig(TypedDict):

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
@@ -9,6 +9,9 @@ from sqlalchemy.orm import Mapped, mapped_column
 from lms.db import Base, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.json_settings import JSONSettings
+
+if TYPE_CHECKING:
+    from lms.models import Assignment
 
 MAX_GROUP_NAME_LENGTH = 25
 
@@ -184,7 +187,7 @@ class GroupSet(TypedDict):
 class Course(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
 
-    assignments = sa.orm.relationship(
+    assignments: Mapped[list["Assignment"]] = sa.orm.relationship(
         "Assignment", secondary="assignment_grouping", viewonly=True
     )
     """Assignments that belong to this course."""

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -246,6 +246,9 @@ class JSConfig:
                             "dashboard.api.assignment.stats"
                         ),
                         course=self._to_frontend_template("dashboard.api.course"),
+                        course_assignment_stats=self._to_frontend_template(
+                            "dashboard.api.course.assignments.stats"
+                        ),
                     ),
                 ),
             }

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -247,3 +247,7 @@ def includeme(config):  # pylint:disable=too-many-statements
         "/dashboard/api/assignment/{assignment_id}/stats",
     )
     config.add_route("dashboard.api.course", "/dashboard/api/course/{course_id}")
+    config.add_route(
+        "dashboard.api.course.assignments.stats",
+        "/dashboard/api/course/{course_id}/assignments/stats",
+    )

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -175,7 +175,7 @@ class HAPI:
     ):
         response = self._api_request(
             "POST",
-            path="bulk/stats/assignment",
+            path="bulk/stats/users",
             body=json.dumps(
                 {
                     "filter": {
@@ -184,6 +184,18 @@ class HAPI:
                     }
                 }
             ),
+            headers={
+                "Content-Type": "application/vnd.hypothesis.v1+json",
+            },
+            stream=False,
+        )
+        return response.json()
+
+    def get_course_stats(self, group_authority_ids: list[str]):
+        response = self._api_request(
+            "POST",
+            path="bulk/stats/assignments",
+            body=json.dumps({"filter": {"groups": group_authority_ids}}),
             headers={
                 "Content-Type": "application/vnd.hypothesis.v1+json",
             },

--- a/lms/templates/admin/course/show.html.jinja2
+++ b/lms/templates/admin/course/show.html.jinja2
@@ -23,7 +23,12 @@
 
     <fieldset class="box mt-6">
         <legend class="label has-text-centered">Assignments</legend>
-        {{ macros.assignments_table(request, course.assignments) }}
+        {% if course.assignments %}
+            {{ macros.assignments_table(request, course.assignments) }}
+        {% else %}
+            <legend class="label has-text-centered">No assignments</legend>
+        {% endif %}
+
     </fieldset>
 </div>
 {% endblock %}

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -259,6 +259,5 @@
         fields=[
         {"label": "Name", "name": "lms_name"},
         {"label": "Context ID", "name": "lms_name"},
-        {"label": "Resource link id", "name": "resource_link_id"},
     ]) }}
 {% endmacro %}

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -42,7 +42,7 @@ class AssignmentViews:
 
         # Organize the H stats by userid for quick access
         stats_by_user = {s["userid"]: s for s in stats}
-        student_stats = []
+        student_stats: list[APIStudentStats] = []
 
         # Iterate over all the students we have in the DB
         for user in self.assignment_service.get_members(

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -1,7 +1,12 @@
 from pyramid.view import view_config
 
-from lms.js_config_types import APICourse
+from lms.js_config_types import (
+    APIAssignment,
+    APICourse,
+    AssignmentStats,
+)
 from lms.security import Permissions
+from lms.services.h_api import HAPI
 from lms.views.dashboard.base import get_request_course
 
 
@@ -9,6 +14,7 @@ class CourseViews:
     def __init__(self, request) -> None:
         self.request = request
         self.course_service = request.find_service(name="course")
+        self.h_api = request.find_service(HAPI)
 
     @view_config(
         route_name="dashboard.api.course",
@@ -22,3 +28,42 @@ class CourseViews:
             "id": course.id,
             "title": course.lms_name,
         }
+
+    @view_config(
+        route_name="dashboard.api.course.assignments.stats",
+        request_method="GET",
+        renderer="json",
+        permission=Permissions.DASHBOARD_VIEW,
+    )
+    def course_stats(self) -> list[APIAssignment]:
+        course = get_request_course(self.request, self.course_service)
+
+        stats = self.h_api.get_course_stats(
+            # Annotations in the course group an any children
+            [course.authority_provided_id]
+            + [child.authority_provided_id for child in course.children]
+        )
+        # Organize the H stats by assignment ID for quick access
+        stats_by_assignment = {s["assignment_id"]: s for s in stats}
+        assignment_stats: list[APIAssignment] = []
+
+        for assignment in course.assignments:
+            if h_stats := stats_by_assignment.get(assignment.resource_link_id):
+                stats = AssignmentStats(
+                    annotations=h_stats["annotations"],
+                    replies=h_stats["replies"],
+                    last_activity=h_stats["last_activity"],
+                )
+            else:
+                # Assignment with no annos, zeroing the stats
+                stats = AssignmentStats(annotations=0, replies=0, last_activity=None)
+
+            assignment_stats.append(
+                APIAssignment(
+                    id=assignment.id,
+                    title=assignment.title,
+                    stats=stats,
+                )
+            )
+
+        return assignment_stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ show_missing = true
 precision = 2
 fail_under = 100.00
 skip_covered = true
+exclude_also = [
+    # # TYPE_CHECKING block is only executed while running mypy
+    "if TYPE_CHECKING:"
+]
 
 [tool.pylint.main]
 jobs = 0 # Use one process for CPU.

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -692,6 +692,7 @@ class TestEnableDashboardMode:
                 "assignment": "/dashboard/api/assignment/:assignment_id",
                 "assignment_stats": "/dashboard/api/assignment/:assignment_id/stats",
                 "course": "/dashboard/api/course/:course_id",
+                "course_assignment_stats": "/dashboard/api/course/:course_id/assignments/stats",
             }
         }
 

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -5,7 +5,7 @@ import pytest
 from lms.views.dashboard.api.course import CourseViews
 from tests import factories
 
-pytestmark = pytest.mark.usefixtures("course_service")
+pytestmark = pytest.mark.usefixtures("course_service", "h_api")
 
 
 class TestCourseViews:
@@ -22,6 +22,61 @@ class TestCourseViews:
             "id": course.id,
             "title": course.lms_name,
         }
+
+    def test_course_stats(
+        self, views, pyramid_request, course_service, h_api, db_session
+    ):
+        pyramid_request.matchdict["course_id"] = sentinel.id
+        course = factories.Course()
+        section = factories.CanvasSection(parent=course)
+        course_service.get_by_id.return_value = course
+
+        assignment = factories.Assignment()
+        assignment_with_no_annos = factories.Assignment()
+
+        factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        factories.AssignmentGrouping(
+            assignment=assignment_with_no_annos, grouping=course
+        )
+        db_session.flush()
+
+        stats = [
+            {
+                "assignment_id": assignment.resource_link_id,
+                "annotations": sentinel.annotations,
+                "replies": sentinel.replies,
+                "userid": "TEACHER",
+                "last_activity": sentinel.last_activity,
+            },
+        ]
+
+        h_api.get_course_stats.return_value = stats
+
+        response = views.course_stats()
+
+        h_api.get_course_stats.assert_called_once_with(
+            [course.authority_provided_id, section.authority_provided_id]
+        )
+        assert response == [
+            {
+                "id": assignment.id,
+                "title": assignment.title,
+                "stats": {
+                    "annotations": sentinel.annotations,
+                    "replies": sentinel.replies,
+                    "last_activity": sentinel.last_activity,
+                },
+            },
+            {
+                "id": assignment_with_no_annos.id,
+                "title": assignment_with_no_annos.title,
+                "stats": {
+                    "annotations": 0,
+                    "replies": 0,
+                    "last_activity": None,
+                },
+            },
+        ]
 
     @pytest.fixture
     def views(self, pyramid_request):


### PR DESCRIPTION
/ GET http://localhost:8001/dashboard/api/course/1826/assignments/stats

```
[
  {
    "id": 350,
    "title": "localhost (make devdata) HTML Assignment",
    "stats": {
      "annotations": 6,
      "replies": 0,
      "last_activity": "2024-05-15T07:22:26.472842"
    }
  },
  {
    "id": 351,
    "title": "Link selection placement text",
    "stats": {
      "annotations": 0,
      "replies": 0,
      "last_activity": null
    }
  },
  {
    "id": 352,
    "title": "",
    "stats": {
      "annotations": 0,
      "replies": 0,
      "last_activity": null
    }
  },
  {
    "id": 353,
    "title": "localhost (make devdata) Groups assignment ",
    "stats": {
      "annotations": 1,
      "replies": 0,
      "last_activity": "2024-05-15T07:23:34.823135"
    }
  }
]
```


## Testing 

- Checkout https://github.com/hypothesis/h/pull/8709 in H
- Launch a bunch of assignments in https://hypothesis.instructure.com/courses/125, note the course ID
- Open http://localhost:8001/dashboard/api/course/XXX/assignments/stats to fetch the stats