### PR TITLE
Expose each assignment parent course

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -33,6 +33,7 @@ class AssignmentStats(TypedDict):
 class APIAssignment(TypedDict):
     id: int
     title: str
+    course: APICourse
     stats: NotRequired[AssignmentStats]
 
 

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -1,6 +1,6 @@
 from pyramid.view import view_config
 
-from lms.js_config_types import APIAssignment, APIStudentStats
+from lms.js_config_types import APIAssignment, APICourse, APIStudentStats
 from lms.models import RoleScope, RoleType
 from lms.security import Permissions
 from lms.services.h_api import HAPI
@@ -21,10 +21,11 @@ class AssignmentViews:
     )
     def assignment(self) -> APIAssignment:
         assignment = get_request_assignment(self.request, self.assignment_service)
-        return {
-            "id": assignment.id,
-            "title": assignment.title,
-        }
+        return APIAssignment(
+            id=assignment.id,
+            title=assignment.title,
+            course=APICourse(id=assignment.course.id, title=assignment.course.lms_name),
+        )
 
     @view_config(
         route_name="dashboard.api.assignment.stats",

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -47,6 +47,8 @@ class CourseViews:
         stats_by_assignment = {s["assignment_id"]: s for s in stats}
         assignment_stats: list[APIAssignment] = []
 
+        # Same course for all these assignments
+        api_course = APICourse(id=course.id, title=course.lms_name)
         for assignment in course.assignments:
             if h_stats := stats_by_assignment.get(assignment.resource_link_id):
                 stats = AssignmentStats(
@@ -62,6 +64,7 @@ class CourseViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
+                    course=api_course,
                     stats=stats,
                 )
             )

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -61,6 +61,10 @@ class TestCourseViews:
             {
                 "id": assignment.id,
                 "title": assignment.title,
+                "course": {
+                    "id": course.id,
+                    "title": course.lms_name,
+                },
                 "stats": {
                     "annotations": sentinel.annotations,
                     "replies": sentinel.replies,
@@ -70,6 +74,10 @@ class TestCourseViews:
             {
                 "id": assignment_with_no_annos.id,
                 "title": assignment_with_no_annos.title,
+                "course": {
+                    "id": course.id,
+                    "title": course.lms_name,
+                },
                 "stats": {
                     "annotations": 0,
                     "replies": 0,


### PR DESCRIPTION
Expose the course assignments belong.

This should help navigation from assignment to parent and from a list of assignment of different courses as the dashboards evolve.

### Testing

FInd a course ID and open an URL like:

http://localhost:8001/dashboard/api/course/1830/assignments/stats
