### PR TITLE
Expose more details if available in the exception for forbidden views

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -25,6 +25,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
             "exclog.extra_info": True,
             "exclog.ignore": [
                 "lms.services.exceptions.OAuth2TokenError",
+                "lms.validation.ValidationError",
                 "pyramid.httpexceptions.HTTPNotFound",
             ],
         }

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -50,7 +50,10 @@ class ExceptionViews:
                 )
                 return self.serializable_error()
 
-        return self.error_response(403, _("You're not authorized to view this page"))
+        messages = ["You're not authorized to view this page"]
+        if details := getattr(self.exception, "message"):
+            messages.append(details)
+        return self.error_response(403, _("<p>".join(messages)))
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -50,10 +50,7 @@ class ExceptionViews:
                 )
                 return self.serializable_error()
 
-        messages = ["You're not authorized to view this page"]
-        if details := getattr(self.exception, "message"):
-            messages.append(details)
-        return self.error_response(403, _("<p>".join(messages)))
+        return self.error_response(403, _("You're not authorized to view this page"))
 
     @exception_view_config(context=HTTPClientError)
     def http_client_error(self):

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -65,6 +65,11 @@ class ExceptionViews:
     )
     def validation_error(self):
         self.request.response.status_int = self.exception.status_int
+        LOG.info(
+            "Validation error: %s. Parameters: %s",
+            self.exception.messages,
+            self.request.params,
+        )
         return {"error": self.exception}
 
     @exception_view_config(

--- a/lms/views/lti/oidc.py
+++ b/lms/views/lti/oidc.py
@@ -29,13 +29,12 @@ The actual LTI launch with an JWT token.
 import uuid
 from urllib.parse import urlencode
 
-from pyramid.httpexceptions import HTTPForbidden, HTTPFound
+from pyramid.httpexceptions import HTTPFound
 from pyramid.view import view_config
 from webargs import fields
 
 from lms.services import LTIRegistrationService
-from lms.validation import PyramidRequestSchema
-from lms.validation import ValidationError
+from lms.validation import PyramidRequestSchema, ValidationError
 
 
 class OIDCRequestSchema(PyramidRequestSchema):

--- a/lms/views/lti/oidc.py
+++ b/lms/views/lti/oidc.py
@@ -35,6 +35,7 @@ from webargs import fields
 
 from lms.services import LTIRegistrationService
 from lms.validation import PyramidRequestSchema
+from lms.validation import ValidationError
 
 
 class OIDCRequestSchema(PyramidRequestSchema):
@@ -59,8 +60,12 @@ def oidc_view(request):
 
     registration = request.find_service(LTIRegistrationService).get(issuer, client_id)
     if not registration:
-        raise HTTPForbidden(
-            f"""Registration not found. iss:'{issuer}', client_id:'{client_id}'"""
+        raise ValidationError(
+            messages={
+                "lti": {
+                    f"""Registration not found. iss:'{issuer}', client_id:'{client_id}'"""
+                }
+            }
         )
 
     params = {

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -29,16 +29,6 @@ class TestExceptionViews:
         assert pyramid_request.response.status_int == 403
         assert template_data == {"message": "You're not authorized to view this page"}
 
-    def test_forbidden_with_message(self, pyramid_request):
-        exception = httpexceptions.HTTPForbidden("EXTRA")
-
-        template_data = ExceptionViews(exception, pyramid_request).forbidden()
-
-        assert pyramid_request.response.status_int == 403
-        assert template_data == {
-            "message": "You're not authorized to view this page<p>EXTRA"
-        }
-
     def test_forbidden_with_validation_error(self, pyramid_request):
         exception = ValidationError(sentinel.messages)
         forbidden = httpexceptions.HTTPForbidden(result=DeniedWithException(exception))

--- a/tests/unit/lms/views/exceptions_test.py
+++ b/tests/unit/lms/views/exceptions_test.py
@@ -29,6 +29,16 @@ class TestExceptionViews:
         assert pyramid_request.response.status_int == 403
         assert template_data == {"message": "You're not authorized to view this page"}
 
+    def test_forbidden_with_message(self, pyramid_request):
+        exception = httpexceptions.HTTPForbidden("EXTRA")
+
+        template_data = ExceptionViews(exception, pyramid_request).forbidden()
+
+        assert pyramid_request.response.status_int == 403
+        assert template_data == {
+            "message": "You're not authorized to view this page<p>EXTRA"
+        }
+
     def test_forbidden_with_validation_error(self, pyramid_request):
         exception = ValidationError(sentinel.messages)
         forbidden = httpexceptions.HTTPForbidden(result=DeniedWithException(exception))

--- a/tests/unit/lms/views/lti/oidc_test.py
+++ b/tests/unit/lms/views/lti/oidc_test.py
@@ -1,7 +1,8 @@
 import pytest
 from h_matchers import Any
-from pyramid.httpexceptions import HTTPForbidden, HTTPFound
+from pyramid.httpexceptions import HTTPFound
 
+from lms.validation import ValidationError
 from lms.views.lti.oidc import oidc_view
 
 
@@ -9,7 +10,7 @@ class TestOIDC:
     def test_missing_registration(self, lti_registration_service, pyramid_request):
         lti_registration_service.get.return_value = None
 
-        with pytest.raises(HTTPForbidden):
+        with pytest.raises(ValidationError):
             oidc_view(pyramid_request)
 
     def test_it(self, lti_registration_service, pyramid_request):


### PR DESCRIPTION
The current "You are not authorized" message for bad LTI configuration is misleading as it points to the current user "you" and not a wider problem.

See: https://hypothes-is.slack.com/archives/C2C2U40LW/p1715865571948539

These are not as common but we'll start showing a more informative message that points to the actual source of the problem

We reuse here the current mechanism for displaying ValidationErrors. 





## Testing

- Obliterate your lti_registrations 

```update lti_registration set client_id = 'NOOO' || "id" ;``` 

(can be fixed with make devdata)


- Launch https://hypothesis.instructure.com/courses/319/assignments/3308

![Screenshot from 2024-05-17 12-45-37](https://github.com/hypothesis/lms/assets/1433832/792ab037-c975-47f9-8b92-ad603b4d8aa9)