### PR TITLE
Increase timeout for LTIA token requests

### DIFF
--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -77,7 +77,7 @@ class LTIAHTTPService:
                 "client_assertion": signed_jwt,
                 "scope": " ".join(scopes),
             },
-            timeout=(20, 20),
+            timeout=(30, 30),
         )
 
         try:

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -46,7 +46,7 @@ class TestLTIAHTTPService:
                 "client_assertion": jwt_service.encode_with_private_key.return_value,
                 "scope": " ".join(scopes),
             },
-            timeout=(20, 20),
+            timeout=(30, 30),
         )
         http_service.request.assert_called_once_with(
             "POST",


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/pull/6274


We seem frequent timeouts in this type of requests. Bumping to 30 seconds to see if we can clean up the logs and find other related issues.


See errors at:

https://hypothesis.sentry.io/issues/4844569539/?project=259908&query=transaction%3Alti_api.submissions.record&referrer=issue-stream&statsPeriod=7d&stream_index=2


`HTTPSConnectionPool(host='sso.canvaslms.com', port=443): Read timed out. (read timeout=20)`