### PR TITLE
Landing pages for the course dashboards

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -33,6 +33,7 @@ class AssignmentStats(TypedDict):
 class APIAssignment(TypedDict):
     id: int
     title: str
+    course: APICourse
     stats: NotRequired[AssignmentStats]
 
 

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -233,9 +233,15 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "dashboard.launch.assignment", "/dashboard/launch/assignment/{assignment_id}"
     )
+
     config.add_route(
         "dashboard.assignment",
         "/dashboard/organization/{public_id}/assignment/{assignment_id}",
+        factory="lms.resources.dashboard.DashboardResource",
+    )
+    config.add_route(
+        "dashboard.course",
+        "/dashboard/organization/{public_id}/course/{course_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
 

--- a/lms/security.py
+++ b/lms/security.py
@@ -147,7 +147,7 @@ class SecurityPolicy:
             return HeadersBearerTokenLTIUserPolicy()
 
         if path in {"/assignment", "/assignment/edit"} or path.startswith(
-            "/dashboard/launch/assignment/"
+            "/dashboard/launch/"
         ):
             # LTUser serialized in a from for non deep-linked assignment configuration
             return FormBearerTokenLTIUserPolicy()

--- a/lms/templates/dashboard/index.html.jinja2
+++ b/lms/templates/dashboard/index.html.jinja2
@@ -2,7 +2,7 @@
 
 
 {% block title %}
-  {{ assignment.title }} - Hypothesis
+  {{ title }} - Hypothesis
 {% endblock %}
 
 {% block content %}

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -1,6 +1,6 @@
 from pyramid.view import view_config
 
-from lms.js_config_types import APIAssignment, APIStudentStats
+from lms.js_config_types import APIAssignment, APICourse, APIStudentStats
 from lms.models import RoleScope, RoleType
 from lms.security import Permissions
 from lms.services.h_api import HAPI
@@ -21,10 +21,11 @@ class AssignmentViews:
     )
     def assignment(self) -> APIAssignment:
         assignment = get_request_assignment(self.request, self.assignment_service)
-        return {
-            "id": assignment.id,
-            "title": assignment.title,
-        }
+        return APIAssignment(
+            id=assignment.id,
+            title=assignment.title,
+            course=APICourse(id=assignment.course.id, title=assignment.course.lms_name),
+        )
 
     @view_config(
         route_name="dashboard.api.assignment.stats",

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -47,6 +47,8 @@ class CourseViews:
         stats_by_assignment = {s["assignment_id"]: s for s in stats}
         assignment_stats: list[APIAssignment] = []
 
+        # Same course for all these assignments
+        api_course = APICourse(id=course.id, title=course.lms_name)
         for assignment in course.assignments:
             if h_stats := stats_by_assignment.get(assignment.resource_link_id):
                 stats = AssignmentStats(
@@ -62,6 +64,7 @@ class CourseViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
+                    course=api_course,
                     stats=stats,
                 )
             )

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -3,7 +3,7 @@ from pyramid.view import forbidden_view_config, view_config
 
 from lms.security import Permissions
 from lms.validation.authentication import BearerTokenSchema
-from lms.views.dashboard.base import get_request_assignment
+from lms.views.dashboard.base import get_request_assignment, get_request_course
 
 
 @forbidden_view_config(
@@ -16,6 +16,11 @@ from lms.views.dashboard.base import get_request_assignment
     request_method="GET",
     renderer="lms:templates/dashboard/forbidden.html.jinja2",
 )
+@forbidden_view_config(
+    route_name="dashboard.course",
+    request_method="GET",
+    renderer="lms:templates/dashboard/forbidden.html.jinja2",
+)
 def forbidden(_request):  # pragma: no cover
     return {}
 
@@ -24,6 +29,7 @@ class DashboardViews:
     def __init__(self, request) -> None:
         self.request = request
         self.assignment_service = request.find_service(name="assignment")
+        self.course_service = request.find_service(name="course")
 
     @view_config(
         route_name="dashboard.launch.assignment",
@@ -32,7 +38,7 @@ class DashboardViews:
     )
     def assignment_redirect_from_launch(self):
         """
-        Entry point to the dashboards from an LTI launch.
+        Entry point to the single assignment view from an LTI launch.
 
         Here we "promote" the LTILaunch token present as a form parameter to a cookie.
         """
@@ -62,7 +68,23 @@ class DashboardViews:
         assignment = get_request_assignment(self.request, self.assignment_service)
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
-        return {"assignment": assignment}
+        return {"title": assignment.title}
+
+    @view_config(
+        route_name="dashboard.course",
+        permission=Permissions.DASHBOARD_VIEW,
+        request_method="GET",
+        renderer="lms:templates/dashboard/index.html.jinja2",
+    )
+    def course_show(self):
+        """Start the dashboard miniapp in the frontend.
+
+        Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
+        """
+        course = get_request_course(self.request, self.course_service)
+        self.request.context.js_config.enable_dashboard_mode()
+        self._set_lti_user_cookie(self.request.response)
+        return {"title": course.lms_name}
 
     def _set_lti_user_cookie(self, response):
         lti_user = self.request.lti_user

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -61,6 +61,10 @@ class TestCourseViews:
             {
                 "id": assignment.id,
                 "title": assignment.title,
+                "course": {
+                    "id": course.id,
+                    "title": course.lms_name,
+                },
                 "stats": {
                     "annotations": sentinel.annotations,
                     "replies": sentinel.replies,
@@ -70,6 +74,10 @@ class TestCourseViews:
             {
                 "id": assignment_with_no_annos.id,
                 "title": assignment_with_no_annos.title,
+                "course": {
+                    "id": course.id,
+                    "title": course.lms_name,
+                },
                 "stats": {
                     "annotations": 0,
                     "replies": 0,


### PR DESCRIPTION
This should be enough to have the first version of the "Course dashboard". 

On top the "landing" routes added here we have merged:

- https://github.com/hypothesis/lms/pull/6267
- https://github.com/hypothesis/lms/pull/6270
- https://github.com/hypothesis/lms/pull/6271


# Testing


Find the ID of course and navigate to 

http://localhost:8001/dashboard/organization/LDtcl7EUTeW2UERPJLAVtA/course/1829

you should get a mostly empty FE page.