### PR TITLE
Add logic to dynamically build URLs from a template and params

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
@@ -12,6 +12,7 @@ import type { Assignment, StudentStats } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
+import { replaceURLParams } from '../../utils/url';
 
 type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
 
@@ -20,10 +21,10 @@ export default function StudentsActivity() {
   const { routes } = dashboard;
   const { assignmentId } = useParams<{ assignmentId: string }>();
   const assignment = useAPIFetch<Assignment>(
-    routes.assignment.replace(':assignment_id', assignmentId),
+    replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
   const students = useAPIFetch<StudentStats[]>(
-    routes.assignment_stats.replace(':assignment_id', assignmentId),
+    replaceURLParams(routes.assignment_stats, { assignment_id: assignmentId }),
   );
 
   const title = `Assignment: ${assignment.data?.title}`;

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivity-test.js
@@ -41,8 +41,8 @@ describe('StudentsActivity', () => {
     fakeConfig = {
       dashboard: {
         routes: {
-          assignment: '/api/assignment/:id',
-          assignment_stats: '/api/assignment/:id/stats',
+          assignment: '/api/assignment/:assignment_id',
+          assignment_stats: '/api/assignment/:assignment_id/stats',
         },
       },
     };

--- a/lms/static/scripts/frontend_apps/utils/test/url-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/url-test.js
@@ -1,0 +1,38 @@
+import { replaceURLParams } from '../url';
+
+describe('replaceURLParams', () => {
+  it('should replace params in URLs', () => {
+    const replaced = replaceURLParams('https://foo.com/things/:id', {
+      id: 'test',
+    });
+    assert.equal(replaced, 'https://foo.com/things/test');
+  });
+
+  it('should replace multiple instances of the same placeholder', () => {
+    const replaced = replaceURLParams(
+      'https://foo.com/things/:id/more-things/:id',
+      {
+        id: 'test',
+      },
+    );
+    assert.equal(replaced, 'https://foo.com/things/test/more-things/test');
+  });
+
+  it('should URL encode params in URLs', () => {
+    const replaced = replaceURLParams('https://foo.com/things/:id', {
+      id: 'foo=bar',
+    });
+    assert.equal(replaced, 'https://foo.com/things/foo%3Dbar');
+  });
+
+  it('should throw if some provided params cannot be replaced', () => {
+    assert.throws(
+      () =>
+        replaceURLParams('https://foo.com/:id', {
+          id: 'test',
+          q: 'unused',
+        }),
+      'Parameter "q" not found in "https://foo.com/:id" URL template',
+    );
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/url.ts
+++ b/lms/static/scripts/frontend_apps/utils/url.ts
@@ -1,0 +1,30 @@
+/**
+ * Replace parameters in a URL template with values from a `params` object and
+ * returns the expanded URL.
+ *
+ *   replaceURLParams('/things/:id', {id: 'foo'}) => '/things/foo'
+ *
+ * @throws Error in case any provided param does not have a matching
+ *               placeholder in the template URL
+ */
+export function replaceURLParams<Param>(
+  urlTemplate: string,
+  params: Record<string, Param>,
+): string {
+  const paramEntries = Object.entries(params);
+  let url = urlTemplate;
+
+  for (const [param, value] of paramEntries) {
+    const urlParam = `:${param}`;
+    if (!url.includes(urlParam)) {
+      throw new Error(
+        `Parameter "${param}" not found in "${urlTemplate}" URL template`,
+      );
+    }
+
+    // Replace all occurrences of the same param in the template
+    url = url.replaceAll(urlParam, encodeURIComponent(String(value)));
+  }
+
+  return url;
+}

--- a/lms/static/scripts/tsconfig.json
+++ b/lms/static/scripts/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2021", "dom"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",


### PR DESCRIPTION
In preparation for more dynamic API endpoints being consumed from the dashboard's frontend, this PR adds a helper function that given a URL template and a params record, does the proper replacing and expands the final URL.

The helper function is inspired in the one [from `client`](https://github.com/hypothesis/client/blob/d366c36ccc4676dac2f6ff0ad662e525d03a1613/src/sidebar/util/url.ts#L12), but with the next changes:

1. It does not return unused params, only the expanded URL. Instead, if some provided param does not have a matching placeholder in the template, it throws an error.
2. If the URL template has more than one appearance of the same placeholder, all of them are replaced with the corresponding value.

This PR also updates the existing API calls in `StudentsActivity` to use the helper function.

### Testing steps.

1. Launch an assignment, click on the user dropdown, and select "Open dashboard".
3. The students activity and the assignment title should be properly loaded.