### PR TITLE
Capture "not in course" errors while sending Canvas submissions

### DIFF
--- a/lms/error_code.py
+++ b/lms/error_code.py
@@ -16,3 +16,4 @@ class ErrorCode(str, Enum):
         "vitalsource_student_pay_license_launch_instructor"
     )
     REUSED_CONSUMER_KEY = "reused_consumer_key"
+    CANVAS_SUBMISSION_COURSE_NOT_AVAILABLE = "canvas_submission_course_not_available"


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/110


These occur while setting a participation date limit in the course.

While this commit doesn't really solve the issue for students it:

- Generates an error message that at least mentions "submissions". The previous error was a generic one generated by an unhandled exceptions.

- Records an event in the event table pointing to the student / assignment / course


## Testing

- Set a course participation end date in the past in both the LTI1.1 and LTI1.3 courses, you have to select "Course" to set the date.

  - https://hypothesis.instructure.com/courses/125/settings#tab-details
  - https://hypothesis.instructure.com/courses/319/settings#tab-details


**Remember to clear it by switching back to "Term" after finishing the test**

![Screenshot from 2024-05-22 09-52-15](https://github.com/hypothesis/lms/assets/1433832/fc2a2ee4-041c-4705-bb48-9c97c78498b1)


- Open a new incognito window, login in canvas as ``. 

Launch these assignment and make an annotation. you now we'll get a generic error messages about submissions:

- https://hypothesis.instructure.com/courses/125/assignments/873
- https://hypothesis.instructure.com/courses/319/assignments/3308


- Clear the participation end date it by switching back to "Term".








