### PR TITLE
Allow DataLoader's loading to be cancelled on unmount

### DIFF
--- a/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DataLoader-test.js
@@ -59,4 +59,19 @@ describe('DataLoader', () => {
     assert.isFalse(wrapper.exists('[data-testid="content"]'));
     assert.isFalse(wrapper.exists('SpinnerOverlay'));
   });
+
+  it('aborts loading when DataLoader is unmounted', () => {
+    const onAbort = sinon.stub();
+    const wrapper = mount(
+      <TestContainer
+        load={async signal => {
+          signal.onabort = onAbort;
+          return 'Hello world';
+        }}
+      />,
+    );
+
+    wrapper.unmount();
+    assert.called(onAbort);
+  });
 });


### PR DESCRIPTION
Update the `DataLoader` so that it creates an `AbortController` during side effects and a) calls `abortController.abort()` in the side effect's cleanup function and b) passes `abortController.signal` to the `load` callback, so that consumers can use it for "abortable" async operations, like API calls.

This capability is not used anywhere yet. We can refactor usages afterwards.