### PR TITLE
Add new dashboard course page FE

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -143,20 +143,49 @@ export type YouTubeVideoInfo = {
   restrictions: YouTubeVideoRestriction[];
 };
 
-/**
- * Individual items in response for `/api/assignment/{assignment_id}/stats` call.
+/*
+ * Dashboard-related API types
  */
-export type StudentStats = {
-  display_name: string;
-  last_activity: string;
+
+export type BaseDashboardStats = {
+  last_activity: string | null;
   annotations: number;
   replies: number;
 };
 
 /**
- * Response for `/api/assignment/{assignment_id}` call.
+ * Response for `/dashboard/api/assignment/{assignment_id}` call.
  */
 export type Assignment = {
   id: number;
   title: string;
 };
+
+/**
+ * Response for `/dashboard/api/assignment/{assignment_id}/stats` call.
+ */
+export type StudentStats = BaseDashboardStats & {
+  display_name: string;
+};
+
+export type StudentsStats = StudentStats[];
+
+/**
+ * Response for `/dashboard/api/course/{course_id}` call.
+ */
+export type Course = {
+  id: number;
+  title: string;
+};
+
+/**
+ * Response for `/dashboard/api/course/{course_id}/stats` call.
+ */
+export type AssignmentStats = {
+  id: number;
+  title: string;
+  course: Course;
+  stats: BaseDashboardStats;
+};
+
+export type AssignmentsStats = AssignmentStats[];

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseAssignmentsActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseAssignmentsActivity.tsx
@@ -1,0 +1,112 @@
+import {
+  Card,
+  CardContent,
+  DataTable,
+  type DataTableProps,
+  Link,
+  useOrderedRows,
+} from '@hypothesis/frontend-shared';
+import { useMemo, useState } from 'preact/hooks';
+import { useParams, Link as RouterLink } from 'wouter-preact';
+
+import type { AssignmentsStats, Course } from '../../api-types';
+import { useConfig } from '../../config';
+import { useAPIFetch } from '../../utils/api';
+import { formatDateTime } from '../../utils/date';
+import { replaceURLParams } from '../../utils/url';
+
+type AssignmentsTableRow = {
+  id: number;
+  title: string;
+  last_activity: string | null;
+  annotations: number;
+  replies: number;
+};
+
+/**
+ * Activity in a list of assignments that are part of a specific course
+ */
+export default function CourseAssignmentsActivity() {
+  const { courseId } = useParams<{ courseId: string }>();
+  const { dashboard } = useConfig(['dashboard']);
+  const { routes } = dashboard;
+  const course = useAPIFetch<Course>(
+    replaceURLParams(routes.course, { course_id: courseId }),
+  );
+  const assignments = useAPIFetch<AssignmentsStats>(
+    replaceURLParams(routes.course_assignment_stats, {
+      course_id: courseId,
+    }),
+  );
+
+  const [order, setOrder] = useState<
+    NonNullable<DataTableProps<AssignmentsTableRow>['order']>
+  >({
+    field: 'title',
+    direction: 'ascending',
+  });
+  const rows: AssignmentsTableRow[] = useMemo(
+    () =>
+      (assignments.data ?? []).map(({ id, title, stats }) => ({
+        id,
+        title,
+        ...stats,
+      })),
+    [assignments.data],
+  );
+  const orderedAssignments = useOrderedRows(rows, order);
+
+  return (
+    <Card>
+      <CardContent>
+        <h2 className="text-brand mb-3 text-xl" data-testid="title">
+          {course.isLoading && 'Loading...'}
+          {course.error && 'Could not load course title'}
+          {course.data && course.data.title}
+        </h2>
+        <DataTable
+          grid
+          striped={false}
+          emptyMessage={
+            assignments.error
+              ? 'Could not load assignments'
+              : 'No assignments found'
+          }
+          title={course.data?.title ?? 'Loading...'}
+          rows={orderedAssignments}
+          columns={[
+            { field: 'title', label: 'Assignment', classes: 'w-[60%]' },
+            { field: 'annotations', label: 'Annotations' },
+            { field: 'replies', label: 'Replies' },
+            { field: 'last_activity', label: 'Last Activity' },
+          ]}
+          renderItem={(stats, field) => {
+            if (['annotations', 'replies'].includes(field)) {
+              return <div className="text-right">{stats[field]}</div>;
+            } else if (field === 'title') {
+              return (
+                <RouterLink href={`/assignment/${stats.id}`} asChild>
+                  <Link>{stats.title}</Link>
+                </RouterLink>
+              );
+            }
+
+            return (
+              stats.last_activity &&
+              formatDateTime(new Date(stats.last_activity))
+            );
+          }}
+          loading={assignments.isLoading}
+          orderableColumns={[
+            'title',
+            'annotations',
+            'replies',
+            'last_activity',
+          ]}
+          order={order}
+          onOrderChange={setOrder}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
-import { Route } from 'wouter-preact';
+import { Route, Switch } from 'wouter-preact';
 
+import CourseAssignmentsActivity from './CourseAssignmentsActivity';
 import DashboardFooter from './DashboardFooter';
 import StudentsActivity from './StudentsActivity';
 
@@ -21,9 +22,14 @@ export default function DashboardApp() {
       </div>
       <div className="flex-grow px-3">
         <div className="mx-auto max-w-6xl">
-          <Route path="/assignment/:assignmentId">
-            <StudentsActivity />
-          </Route>
+          <Switch>
+            <Route path="/assignment/:assignmentId">
+              <StudentsActivity />
+            </Route>
+            <Route path="/course/:courseId">
+              <CourseAssignmentsActivity />
+            </Route>
+          </Switch>
         </div>
       </div>
       <DashboardFooter />

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
@@ -8,7 +8,7 @@ import type { DataTableProps } from '@hypothesis/frontend-shared';
 import { useState } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
-import type { Assignment, StudentStats } from '../../api-types';
+import type { Assignment, StudentsStats, StudentStats } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
@@ -16,6 +16,9 @@ import { replaceURLParams } from '../../utils/url';
 
 type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
 
+/**
+ * Activity in a list of students that are part of a specific assignment
+ */
 export default function StudentsActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
@@ -23,7 +26,7 @@ export default function StudentsActivity() {
   const assignment = useAPIFetch<Assignment>(
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
-  const students = useAPIFetch<StudentStats[]>(
+  const students = useAPIFetch<StudentsStats>(
     replaceURLParams(routes.assignment_stats, { assignment_id: assignmentId }),
   );
 
@@ -49,20 +52,20 @@ export default function StudentsActivity() {
             students.error ? 'Could not load students' : 'No students found'
           }
           title={assignment.isLoading ? 'Loading...' : title}
+          rows={orderedStudents}
           columns={[
-            { field: 'display_name', label: 'Name', classes: 'w-[60%]' },
+            { field: 'display_name', label: 'Student', classes: 'w-[60%]' },
             { field: 'annotations', label: 'Annotations' },
             { field: 'replies', label: 'Replies' },
             { field: 'last_activity', label: 'Last Activity' },
           ]}
-          rows={orderedStudents}
           renderItem={(stats, field) => {
             if (['annotations', 'replies'].includes(field)) {
               return <div className="text-right">{stats[field]}</div>;
             }
 
-            return field === 'last_activity' && stats[field]
-              ? formatDateTime(new Date(stats[field]))
+            return field === 'last_activity' && stats.last_activity
+              ? formatDateTime(new Date(stats.last_activity))
               : stats[field];
           }}
           loading={students.isLoading}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseAssignmentsActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseAssignmentsActivity-test.js
@@ -1,0 +1,288 @@
+import {
+  checkAccessibility,
+  mockImportedComponents,
+} from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { Config } from '../../../config';
+import CourseAssignmentsActivity, {
+  $imports,
+} from '../CourseAssignmentsActivity';
+
+describe('CourseAssignmentsActivity', () => {
+  const assignments = [
+    {
+      id: 2,
+      title: 'b',
+      stats: {
+        last_activity: '2020-01-01T00:00:00',
+        annotations: 8,
+        replies: 0,
+      },
+    },
+    {
+      id: 1,
+      title: 'a',
+      stats: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 3,
+        replies: 20,
+      },
+    },
+    {
+      id: 3,
+      title: 'c',
+      stats: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 5,
+        replies: 100,
+      },
+    },
+  ];
+
+  let fakeUseAPIFetch;
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeUseAPIFetch = sinon.stub().callsFake(url => ({
+      isLoading: false,
+      data: url.endsWith('stats') ? assignments : { title: 'The title' },
+    }));
+    fakeConfig = {
+      dashboard: {
+        routes: {
+          course: '/dashboard/api/course/:course_id',
+          course_assignment_stats: '/dashboard/api/course/:course_id/stats',
+        },
+      },
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../../utils/api': {
+        useAPIFetch: fakeUseAPIFetch,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent() {
+    return mount(
+      <Config.Provider value={fakeConfig}>
+        <CourseAssignmentsActivity />
+      </Config.Provider>,
+    );
+  }
+
+  it('shows loading indicators while data is loading', () => {
+    fakeUseAPIFetch.returns({ isLoading: true });
+
+    const wrapper = createComponent();
+    const titleElement = wrapper.find('[data-testid="title"]');
+    const tableElement = wrapper.find('DataTable');
+
+    assert.equal(titleElement.text(), 'Loading...');
+    assert.isTrue(tableElement.prop('loading'));
+  });
+
+  it('shows error if loading data fails', () => {
+    fakeUseAPIFetch.returns({ error: new Error('Something failed') });
+
+    const wrapper = createComponent();
+    const titleElement = wrapper.find('[data-testid="title"]');
+    const tableElement = wrapper.find('DataTable');
+
+    assert.equal(titleElement.text(), 'Could not load course title');
+    assert.equal(
+      tableElement.prop('emptyMessage'),
+      'Could not load assignments',
+    );
+  });
+
+  it('shows expected title', () => {
+    const wrapper = createComponent();
+    const titleElement = wrapper.find('[data-testid="title"]');
+    const tableElement = wrapper.find('DataTable');
+    const expectedTitle = 'The title';
+
+    assert.equal(titleElement.text(), expectedTitle);
+    assert.equal(tableElement.prop('title'), expectedTitle);
+  });
+
+  it('shows empty assignments message', () => {
+    const wrapper = createComponent();
+    const tableElement = wrapper.find('DataTable');
+
+    assert.equal(tableElement.prop('emptyMessage'), 'No assignments found');
+  });
+
+  [
+    {
+      orderToSet: { field: 'annotations', direction: 'descending' },
+      expectedAssignments: [
+        {
+          id: 2,
+          title: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          id: 3,
+          title: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          id: 1,
+          title: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'replies', direction: 'ascending' },
+      expectedAssignments: [
+        {
+          id: 2,
+          title: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          id: 1,
+          title: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          id: 3,
+          title: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'last_activity', direction: 'descending' },
+      expectedAssignments: [
+        {
+          id: 1,
+          title: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          id: 3,
+          title: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          id: 2,
+          title: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+      ],
+    },
+  ].forEach(({ orderToSet, expectedAssignments }) => {
+    it('orders assignments on order change', () => {
+      const wrapper = createComponent();
+      const getRows = () => wrapper.find('DataTable').prop('rows');
+      const getOrder = () => wrapper.find('DataTable').prop('order');
+      const setOrder = order => {
+        wrapper.find('DataTable').props().onOrderChange(order);
+        wrapper.update();
+      };
+
+      // Initially, assignments are ordered by title
+      assert.deepEqual(getOrder(), {
+        field: 'title',
+        direction: 'ascending',
+      });
+      assert.deepEqual(getRows(), [
+        {
+          id: 1,
+          title: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          id: 2,
+          title: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          id: 3,
+          title: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ]);
+
+      setOrder(orderToSet);
+      assert.deepEqual(getOrder(), orderToSet);
+      assert.deepEqual(getRows(), expectedAssignments);
+    });
+  });
+
+  [
+    { fieldName: 'title', expectedValue: 'Frog dissection' },
+    { fieldName: 'annotations', expectedValue: '37' },
+    { fieldName: 'replies', expectedValue: '25' },
+    { fieldName: 'last_activity', expectedValue: '2024-01-01 10:35' },
+  ].forEach(({ fieldName, expectedValue }) => {
+    it('renders every field as expected', () => {
+      const assignmentStats = {
+        id: 123,
+        title: 'Frog dissection',
+        last_activity: '2024-01-01T10:35:18',
+        annotations: 37,
+        replies: 25,
+      };
+      const wrapper = createComponent();
+
+      const item = wrapper
+        .find('DataTable')
+        .props()
+        .renderItem(assignmentStats, fieldName);
+
+      if (fieldName === 'last_activity') {
+        assert.equal(item, expectedValue);
+        return;
+      }
+
+      const itemWrapper = mount(item);
+      assert.equal(itemWrapper.text(), expectedValue);
+
+      if (fieldName === 'title') {
+        assert.equal(itemWrapper.prop('href'), '/assignment/123');
+      }
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -243,6 +243,8 @@ export type EmailPreferences = {
 export type DashboardRoutes = {
   assignment: string;
   assignment_stats: string;
+  course: string;
+  course_assignment_stats: string;
 };
 
 export type DashboardConfig = {


### PR DESCRIPTION
Add a new FE route matching for the dashboard course stats displaying a list of assignments.

![image](https://github.com/hypothesis/lms/assets/2719332/46fe6d70-41ac-4d31-bd14-52151816f508)

### Considerations

- There's a bit of duplication with the students table. I will address that separately.
- Loading states and errors are handled individually. There's parallel work in progress to have a generic way to show a global loading indicator: https://github.com/hypothesis/lms/pull/6287
- As we add more pages, it becomes more obvious that components don't have specific enough names. I'll rename `StudentsActivity` to `AssignmentStudentsActivity` later, as at some point, we will need `OrganizationStudentsActivity`, `CourseStudentsActivity`, etc. They will wrap shared components.

### Testing steps

1. Go to the courses section of the LMS admin http://localhost:8001/admin/courses, then click "Search"
2. From the list, find the course named "Developer Test Course with Sections Enabled" and click "View"
3. See the course "ID" (the first field in that packe), and the organization ID, but discarding the `*.lms.com.` prefix.
4. Visit `http://localhost:8001/dashboard/organization/{org_id}/course/{course_id}`, replacing the placeholders with the values from previous step.
5. You should see something similar to the screenshot above.
6. If you click any of the assignment names, you should be redirected to the student stats for that particular assignment.