### PR TITLE
Add component to handle dashboard initial loading and fatal errors

### DIFF
--- a/lms/static/scripts/frontend_apps/components/HideUntilLoad.tsx
+++ b/lms/static/scripts/frontend_apps/components/HideUntilLoad.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent, Spinner } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
+
+import type { ErrorLike } from '../errors';
+import { InitialLoadingContext } from '../utils/initial-loading-context';
+import ErrorDisplay from './ErrorDisplay';
+
+export type InitialLoadingProps = {
+  children: ComponentChildren;
+
+  /**
+   * CSS classes to apply to the top-level element, regardless of it being the
+   * loading indicator, error or children wrapper.
+   */
+  classes?: string | string[];
+
+  /**
+   * A component to render after initial load or when a fatal error has been
+   * reported.
+   * It is hidden during initial load.
+   */
+  footer?: ComponentChildren;
+};
+
+export default function HideUntilLoad({
+  children,
+  classes,
+  footer,
+}: InitialLoadingProps) {
+  const [initialLoadInProgress, setInitialLoadInProgress] = useState(true);
+  const [fatalError, setFatalError] = useState<ErrorLike>();
+  const loadingInstances = useRef(new Set<string>());
+
+  const startLoading = useCallback(
+    (key: string) => loadingInstances.current.add(key),
+    [],
+  );
+  const finishLoading = useCallback((key: string) => {
+    loadingInstances.current.delete(key);
+    // We consider loading is in progress as long as there are loading
+    // instances.
+    // Also, once we have transitioned from true to false once, we don't want
+    // to go back to true ever again, considering the initial load has finished.
+    setInitialLoadInProgress(prev => prev && loadingInstances.current.size > 0);
+  }, []);
+  const contextValue = useMemo(
+    () => ({ startLoading, finishLoading, reportFatalError: setFatalError }),
+    [finishLoading, startLoading],
+  );
+  const showLoadingIndicator = initialLoadInProgress && !fatalError;
+
+  return (
+    <InitialLoadingContext.Provider value={contextValue}>
+      {showLoadingIndicator && (
+        <div
+          className={classnames(
+            'flex items-center justify-center bg-white/50',
+            classes,
+          )}
+          data-testid="initial-load-indicator"
+        >
+          <Spinner size="md" />
+        </div>
+      )}
+      <div
+        className={classnames(classes, { hidden: showLoadingIndicator })}
+        data-testid="children-wrapper"
+      >
+        <div className="mx-auto max-w-6xl px-3 py-5">
+          {!fatalError ? (
+            children
+          ) : (
+            <Card>
+              <CardContent>
+                <ErrorDisplay error={fatalError} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+      {!showLoadingIndicator && footer}
+    </InitialLoadingContext.Provider>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -27,6 +27,7 @@ export default function AssignmentActivity() {
   );
   const students = useAPIFetch<StudentsResponse>(
     replaceURLParams(routes.assignment_stats, { assignment_id: assignmentId }),
+    { reportToInitialLoading: true },
   );
 
   const title = `Assignment: ${assignment.data?.title}`;

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -39,6 +39,7 @@ export default function CourseActivity() {
     replaceURLParams(routes.course_assignment_stats, {
       course_id: courseId,
     }),
+    { reportToInitialLoading: true },
   );
 
   const rows: AssignmentsTableRow[] = useMemo(

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import { Route, Switch, useParams } from 'wouter-preact';
 
+import HideUntilLoad from '../HideUntilLoad';
 import AssignmentActivity from './AssignmentActivity';
 import CourseActivity from './CourseActivity';
 import DashboardFooter from './DashboardFooter';
@@ -12,8 +13,8 @@ export default function DashboardApp() {
   }>();
 
   return (
-    <div className="flex flex-col min-h-screen gap-5 bg-grey-2">
-      <div
+    <div className="flex flex-col min-h-screen bg-grey-2">
+      <header
         className={classnames(
           'flex justify-center p-3 w-full',
           'bg-white border-b shadow',
@@ -24,25 +25,20 @@ export default function DashboardApp() {
           src="/static/images/hypothesis-wordmark-logo.png"
           className="h-10"
         />
-      </div>
-      <div className="flex-grow px-3">
-        <div className="mx-auto max-w-6xl">
-          <Switch>
-            <Route path="/assignments/:assignmentId">
-              <AssignmentActivity />
-            </Route>
-            <Route path="/courses/:courseId">
-              <CourseActivity />
-            </Route>
-            <Route path="">
-              <OrganizationActivity
-                organizationPublicId={organizationPublicId}
-              />
-            </Route>
-          </Switch>
-        </div>
-      </div>
-      <DashboardFooter />
+      </header>
+      <HideUntilLoad classes="flex-grow" footer={<DashboardFooter />}>
+        <Switch>
+          <Route path="/assignments/:assignmentId">
+            <AssignmentActivity />
+          </Route>
+          <Route path="/courses/:courseId">
+            <CourseActivity />
+          </Route>
+          <Route path="">
+            <OrganizationActivity organizationPublicId={organizationPublicId} />
+          </Route>
+        </Switch>
+      </HideUntilLoad>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -28,6 +28,7 @@ export default function OrganizationActivity({
     replaceURLParams(routes.organization_courses, {
       organization_public_id: organizationPublicId,
     }),
+    { reportToInitialLoading: true },
   );
 
   return (

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/HideUntilLoad-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/HideUntilLoad-test.js
@@ -1,0 +1,143 @@
+import { mount } from 'enzyme';
+import { useContext } from 'preact/hooks';
+
+import { InitialLoadingContext } from '../../../utils/initial-loading-context';
+import HideUntilLoad from '../../HideUntilLoad';
+
+function ContentComponent() {
+  const { startLoading, finishLoading, reportFatalError } = useContext(
+    InitialLoadingContext,
+  );
+
+  return (
+    <div data-testid="children">
+      <button data-testid="start-foo" onClick={() => startLoading('foo')}>
+        Start foo
+      </button>
+      <button data-testid="finish-foo" onClick={() => finishLoading('foo')}>
+        Finish foo
+      </button>
+      <button data-testid="start-bar" onClick={() => startLoading('bar')}>
+        Start bar
+      </button>
+      <button data-testid="finish-bar" onClick={() => finishLoading('bar')}>
+        Finish bar
+      </button>
+      <button
+        data-testid="fatal-error"
+        onClick={() => reportFatalError(new Error('Something went wrong'))}
+      >
+        Fatal error
+      </button>
+    </div>
+  );
+}
+
+describe('HideUntilLoad', () => {
+  function createComponent(footer) {
+    return mount(
+      <HideUntilLoad footer={footer}>
+        <ContentComponent />
+      </HideUntilLoad>,
+    );
+  }
+
+  function loadingIndicatorIsVisible(wrapper) {
+    return wrapper.exists('[data-testid="initial-load-indicator"]');
+  }
+
+  function childrenWrapperIsVisible(wrapper) {
+    return !wrapper
+      .find('[data-testid="children-wrapper"]')
+      .getDOMNode()
+      .classList.contains('hidden');
+  }
+
+  function errorIsVisible(wrapper) {
+    return wrapper.exists('ErrorDisplay');
+  }
+
+  function startLoading(wrapper, id) {
+    wrapper.find(`[data-testid="start-${id}"]`).simulate('click');
+  }
+
+  function finishLoading(wrapper, id) {
+    wrapper.find(`[data-testid="finish-${id}"]`).simulate('click');
+  }
+
+  function reportFatalError(wrapper) {
+    wrapper.find('[data-testid="fatal-error"]').simulate('click');
+  }
+
+  it('is in loading state at first', () => {
+    const wrapper = createComponent();
+
+    assert.isTrue(loadingIndicatorIsVisible(wrapper));
+    assert.isFalse(childrenWrapperIsVisible(wrapper));
+  });
+
+  it('removes loading indicator once all individual loadings have finished', () => {
+    const wrapper = createComponent();
+
+    // We start two individual loadings
+    startLoading(wrapper, 'foo');
+    startLoading(wrapper, 'bar');
+
+    // After one of them has finished, we are still showing the loading indicator
+    finishLoading(wrapper, 'bar');
+    assert.isTrue(loadingIndicatorIsVisible(wrapper));
+    assert.isFalse(childrenWrapperIsVisible(wrapper));
+
+    // Once all have finished, we no longer show the loading indicator
+    finishLoading(wrapper, 'foo');
+    assert.isFalse(loadingIndicatorIsVisible(wrapper));
+    assert.isTrue(childrenWrapperIsVisible(wrapper));
+  });
+
+  it('no longer shows loading indicator once all initial loadings have finished once', () => {
+    const wrapper = createComponent();
+
+    // We start and finish a loading
+    startLoading(wrapper, 'foo');
+    finishLoading(wrapper, 'foo');
+
+    // Loading indicator is not shown
+    assert.isFalse(loadingIndicatorIsVisible(wrapper));
+    assert.isTrue(childrenWrapperIsVisible(wrapper));
+
+    // If we start another loading, the loading indicator is still not shown
+    startLoading(wrapper, 'bar');
+    assert.isFalse(loadingIndicatorIsVisible(wrapper));
+    assert.isTrue(childrenWrapperIsVisible(wrapper));
+  });
+
+  it('replaces children with error when a fatal error is reported', () => {
+    const wrapper = createComponent();
+
+    reportFatalError(wrapper);
+
+    assert.isFalse(loadingIndicatorIsVisible(wrapper));
+    assert.isTrue(childrenWrapperIsVisible(wrapper));
+    assert.isFalse(wrapper.exists('[data-testid="children"]'));
+    assert.isTrue(errorIsVisible(wrapper));
+  });
+
+  it('shows footer only when loaded or error', () => {
+    const wrapper = createComponent(
+      <footer data-testid="footer">The footer</footer>,
+    );
+    const footerIsVisible = () => wrapper.exists('[data-testid="footer"]');
+
+    // Footer is not visible while loading
+    startLoading(wrapper, 'foo');
+    assert.isFalse(footerIsVisible());
+
+    // Footer is visible after initial load
+    finishLoading(wrapper, 'foo');
+    assert.isTrue(footerIsVisible());
+
+    // Footer is still visible after reporting an error
+    reportFatalError(wrapper);
+    assert.isTrue(footerIsVisible());
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -1,5 +1,6 @@
 import { useConfig } from '../config';
 import { APIError } from '../errors';
+import type { UseFetchOptions } from './fetch';
 import { useFetch } from './fetch';
 import type { FetchResult, Fetcher } from './fetch';
 
@@ -185,6 +186,10 @@ export function urlPath(strings: TemplateStringsArray, ...params: string[]) {
   return result + strings[strings.length - 1];
 }
 
+export type UseAPIFetchOptions = UseFetchOptions & {
+  params?: Record<string, string>;
+};
+
 /**
  * Hook that fetches data using authenticated API requests.
  *
@@ -193,7 +198,7 @@ export function urlPath(strings: TemplateStringsArray, ...params: string[]) {
  */
 export function useAPIFetch<T = unknown>(
   path: string | null,
-  params?: Record<string, string>,
+  { params, ...fetchOptions }: UseAPIFetchOptions = {},
 ): FetchResult<T> {
   const {
     api: { authToken },
@@ -214,5 +219,5 @@ export function useAPIFetch<T = unknown>(
   // token is not included in the key, as we assume currently that it does not
   // change the result.
   const paramStr = params ? '?' + new URLSearchParams(params).toString() : '';
-  return useFetch(path ? `${path}${paramStr}` : null, fetcher);
+  return useFetch(path ? `${path}${paramStr}` : null, fetcher, fetchOptions);
 }

--- a/lms/static/scripts/frontend_apps/utils/initial-loading-context.ts
+++ b/lms/static/scripts/frontend_apps/utils/initial-loading-context.ts
@@ -1,0 +1,28 @@
+import { createContext } from 'preact';
+
+import type { ErrorLike } from '../errors';
+
+export type InitialLoadingContextState = {
+  /**
+   * Report the beginning of a loading that needs to be taken into
+   * consideration for the initial load.
+   *
+   * @param id - The unique identifier for this loading instance
+   */
+  startLoading: (id: string) => void;
+
+  /**
+   * Report the end of a loading that needs to be taken into consideration
+   * for the initial load.
+   *
+   * @param id - The same unique identifier that was first passed to
+   *             startLoading. Unknown IDs will be ignored.
+   */
+  finishLoading: (id: string) => void;
+
+  /** Report an error from which it is not possible to recover */
+  reportFatalError: (error: ErrorLike) => void;
+};
+
+export const InitialLoadingContext =
+  createContext<InitialLoadingContextState | null>(null);

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -424,7 +424,7 @@ describe('useAPIFetch', () => {
     },
   ].forEach(({ path, params, expectedURL }) => {
     it('fetches data from API if a path is provided', async () => {
-      const result = useAPIFetch(path, params);
+      const result = useAPIFetch(path, { params });
       assert.equal(result, fakeFetchResult);
       assert.calledWith(fakeUseFetch, expectedURL, sinon.match.func);
 


### PR DESCRIPTION
This PR adds a global wrapper sharing a context down the component tree, intended to track async operations to display a global loading indicator for initial page loads.

This context is initially used by the existing `useFetch` hook, to notify when the fetch starts and ends, but can be potentially used for other cases as well.

This new component is only intended to avoid a lot of simultaneous flickering states due to multiple loads at initial page load, consolidating all of them in a shared global spinner.

After the first page load, this component will ignore any subsequent async operations, and let children components handle loading on their own.

Additionally, it also allows to display a global error message for fatal errors, like when the user has ended up loading a page where they don't have permissions to see none of the information. We don't want to show a bunch of individual error messages in that case.

### Considerations

* The way this component "knows" if the initial set of loads have finished, is by capturing when all they start and end. Once the initial ones have ended, it considers the page is loaded.
  As a side effect, if no async operations are notified at all, the component will stay in the loading state forever.
* Since this component needs to be notified by logic running in components down the tree, children are unconditionally rendered, but hidden via CSS until the first page loading finishes.
* When a fatal error is notified, we are currently just rendering an `ErrorDisplay` component wrapped in a `Card`. We'll probably need to design something nicer.
    ![image](https://github.com/hypothesis/lms/assets/2719332/c86e2a24-602a-48b4-bd31-432c893353f8)
* In the error indicator, we probably want to add instructions on how to recover from the error. That's not handled in this PR.

### Testing steps

**Loading indicator:** In this branch, you'll notice that the first time any dashboard section is loaded, a common loading indicator is displayed until the data is loaded.

**Error handling:**

1. Apply this diff to fake an error:
    ```diff
    diff --git a/lms/views/dashboard/api/assignment.py b/lms/views/dashboard/api/assignment.py
    index 206c8f17a..4c04f272e 100644
    --- a/lms/views/dashboard/api/assignment.py
    +++ b/lms/views/dashboard/api/assignment.py
    @@ -31,7 +31,7 @@ class AssignmentViews:
            route_name="api.dashboard.assignment.stats",
            request_method="GET",
            renderer="json",
    -        permission=Permissions.DASHBOARD_VIEW,
    +        permission=Permissions.LTI_LAUNCH_ASSIGNMENT,
        )
        def assignment_stats(self) -> APIStudents:
            """Fetch the stats for one particular assignment."""
    ```
2. Navigate to any course page in the dashboard.
3. You should see a global error indicator.

### TODO

- [x] ~Use something more subtle than a big spinner. Gmail has this nice effect where its splash screen shows the logo subtly zooming and fading in.~ We'll use this PR as a general proof of concept of the solution, and apply UI improvements separately.
- [x] Add tests

### Demo

I manually slowed down the requests (one takes 2s, the other 3s) and added logs for when they start and finish, to demonstrate how this works.

When the page loads, it shows a general spinner until all calls have finished (two calls in this case).

After that, trying to reload individual pieces of state does not cause the global spinner to show again, but just the individual loading indicators on every component:

https://github.com/hypothesis/lms/assets/2719332/d7b36cc3-b555-42a1-8e0f-b6a41385730b

