### PR TITLE
Better error message for canvas submission failures

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -327,6 +327,11 @@ export default function BasicLTILaunchApp() {
           errorState={errorState}
           error={error}
           onRetry={authorizeAndFetchURL}
+          /* istanbul ignore next */
+          onCancel={() =>
+            /* istanbul ignore next */
+            setErrorState(null)
+          }
         />
       )}
       <div

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -18,6 +18,9 @@ export type LaunchErrorDialogProps = {
   error: ErrorLike | null;
   /** Callback invoked when user clicks the "Try again" button */
   onRetry: () => void;
+
+  /** Callback invoked when user clicks the "Try again" button */
+  onCancel: () => void;
 };
 
 /**
@@ -63,6 +66,7 @@ export default function LaunchErrorDialog({
   error,
   errorState,
   onRetry,
+  onCancel,
 }: LaunchErrorDialogProps) {
   const { instructorToolbar } = useConfig();
   const canEdit = Boolean(instructorToolbar?.editingEnabled);
@@ -611,17 +615,51 @@ export default function LaunchErrorDialog({
       );
 
     case 'error-reporting-submission':
-      // nb. There is no retry action here as we just suggest reloading the entire
-      // page.
       return (
         <ErrorModal
           {...defaultProps}
           onRetry={undefined}
-          title="Something went wrong"
+          onCancel={onCancel}
+          cancelLabel="Close"
+          title="We were unable to create a submission in this Assignment"
         >
           <p>
-            There was a problem submitting this Hypothesis assignment.{' '}
-            <b>To fix this problem, try reloading the page.</b>
+            {' '}
+            Hypothesis saved your annotation, but was unable to generate a
+            submission.
+          </p>
+
+          <p>
+            {' '}
+            <b>
+              Your instructor is not aware you have saved an annotation;
+            </b>{' '}
+            you might need to reach out to them.
+          </p>
+        </ErrorModal>
+      );
+
+    case 'canvas_submission_course_not_available':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          onCancel={onCancel}
+          cancelLabel="Close"
+          title="We were unable to create a submission in this Assignment"
+        >
+          <p>
+            Hypothesis saved your annotation, but was unable to generate a
+            submission. This may be because the course has ended and we are no
+            longer allowed to create submissions
+          </p>
+
+          <p>
+            {' '}
+            <b>
+              Your instructor is not aware you have saved an annotation;
+            </b>{' '}
+            you might need to reach out to them.
           </p>
         </ErrorModal>
       );

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -53,6 +53,7 @@ describe('LaunchErrorDialog', () => {
       hasRetry: true,
       retryAction: 'Authorize',
       withError: false,
+      cancelLabel: null,
     },
     {
       errorState: 'blackboard_file_not_found_in_course',
@@ -251,10 +252,21 @@ describe('LaunchErrorDialog', () => {
     },
     {
       errorState: 'error-reporting-submission',
-      expectedText: 'There was a problem submitting this Hypothesis assignment',
-      expectedTitle: 'Something went wrong',
+      expectedText:
+        'Hypothesis saved your annotation, but was unable to generate a submission.',
+      expectedTitle: 'We were unable to create a submission in this Assignment',
       hasRetry: false,
       withError: true,
+      cancelLabel: 'Close',
+    },
+    {
+      errorState: 'canvas_submission_course_not_available',
+      expectedText:
+        'This may be because the course has ended and we are no longer allowed to create submissions',
+      expectedTitle: 'We were unable to create a submission in this Assignment',
+      hasRetry: false,
+      withError: true,
+      cancelLabel: 'Close',
     },
   ].forEach(
     ({
@@ -263,6 +275,7 @@ describe('LaunchErrorDialog', () => {
       expectedTitle,
       hasRetry = false,
       withError = true,
+      cancelLabel = null,
       retryAction,
     }) => {
       it(`displays expected error for "${errorState}" error state`, () => {
@@ -280,6 +293,9 @@ describe('LaunchErrorDialog', () => {
         }
         if (retryAction) {
           assert.equal(modalProps.retryLabel, retryAction);
+        }
+        if (cancelLabel) {
+          assert.equal(modalProps.cancelLabel, cancelLabel);
         }
         if (!withError) {
           assert.isUndefined(modalProps.error);

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -22,6 +22,7 @@ export type LTILaunchServerErrorCode =
   | 'canvas_studio_download_unavailable'
   | 'canvas_studio_transcript_unavailable'
   | 'canvas_studio_media_not_found'
+  | 'canvas_submission_course_not_available'
   | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_file_not_found_in_course_student'
   | 'd2l_group_set_empty'
@@ -169,6 +170,7 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_studio_download_unavailable',
       'canvas_studio_transcript_unavailable',
       'canvas_studio_media_not_found',
+      'canvas_submission_course_not_available',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
       'moodle_page_not_found_in_course',


### PR DESCRIPTION
### TODO

- [ ] Fix tests
- [ ] Allow to see the content in the back (ie not hide the background with the loaded assigment)


### Testing

if you want to repro the error code, the easiest path is to apply a diff like


```diff
diff --git a/lms/views/api/grading.py b/lms/views/api/grading.py
index a8a7dbceb..26d894450 100644
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -96,6 +96,9 @@ class GradingViews:
 
         [1] https://canvas.instructure.com/doc/api/file.assignment_tools.html
         """
+        raise SerializableError(
+            error_code=ErrorCode.CANVAS_SUBMISSION_COURSE_NOT_AVAILABLE
+        )
 
         # Send the SpeedGrader LTI launch URL to the Canvas instance, if we haven't
         # already created a submission OR if the existing submission has not been
```


- Reload [an assignment](https://hypothesis.instructure.com/courses/319/assignments/4701) **as a student** and make one annotation.
