### PR TITLE
Change Canvas Studio admin token refresh to work more like other refreshes

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -148,6 +148,10 @@ def includeme(config):  # pylint:disable=too-many-statements
     config.add_route(
         "canvas_studio_api.oauth.refresh", "/api/canvas_studio/oauth/refresh"
     )
+    config.add_route(
+        "canvas_studio_api.oauth.refresh_admin",
+        "/api/canvas_studio/oauth/refresh_admin",
+    )
     config.add_route("canvas_studio_api.media.list", "/api/canvas_studio/media")
     config.add_route(
         "canvas_studio_api.collections.media.list",

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -356,6 +356,21 @@ export default function LaunchErrorDialog({
           </p>
         </ErrorModal>
       );
+
+    case 'canvas_studio_admin_token_refresh_failed':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Unable to access Canvas Studio video"
+        >
+          <p>
+            Your Canvas LMS administrator needs to re-authorize the integration
+            between Hypothesis and Canvas Studio.
+          </p>
+        </ErrorModal>
+      );
+
     case 'blackboard_group_set_not_found':
       return (
         <ErrorModal

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -106,6 +106,14 @@ describe('LaunchErrorDialog', () => {
       withError: true,
     },
     {
+      errorState: 'canvas_studio_admin_token_refresh_failed',
+      expectedText:
+        'Your Canvas LMS administrator needs to re-authorize the integration between Hypothesis and Canvas Studio',
+      expectedTitle: 'Unable to access Canvas Studio video',
+      hasRetry: false,
+      withError: true,
+    },
+    {
       errorState: 'd2l_file_not_found_in_course_instructor',
       expectedText:
         'To fix the issue, recreate this assignment and select a different file.',

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -22,6 +22,7 @@ export type LTILaunchServerErrorCode =
   | 'canvas_studio_download_unavailable'
   | 'canvas_studio_transcript_unavailable'
   | 'canvas_studio_media_not_found'
+  | 'canvas_studio_admin_token_refresh_failed'
   | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_file_not_found_in_course_student'
   | 'd2l_group_set_empty'
@@ -169,6 +170,7 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_studio_download_unavailable',
       'canvas_studio_transcript_unavailable',
       'canvas_studio_media_not_found',
+      'canvas_studio_admin_token_refresh_failed',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
       'moodle_page_not_found_in_course',

--- a/lms/views/api/refresh.py
+++ b/lms/views/api/refresh.py
@@ -25,6 +25,10 @@ class RefreshViews:
     def get_refreshed_token_from_canvas_studio(self):
         self.request.find_service(CanvasStudioService).refresh_access_token()
 
+    @view_config(route_name="canvas_studio_api.oauth.refresh_admin")
+    def get_refreshed_admin_token_from_canvas_studio(self):
+        self.request.find_service(CanvasStudioService).refresh_admin_access_token()
+
     @view_config(route_name="blackboard_api.oauth.refresh")
     def get_refreshed_token_from_blackboard(self):
         blackboard_api_client = self.request.find_service(name="blackboard_api_client")

--- a/tests/unit/lms/views/api/refresh_test.py
+++ b/tests/unit/lms/views/api/refresh_test.py
@@ -25,6 +25,13 @@ class TestRefreshViews:
 
         canvas_studio_service.refresh_access_token.assert_called_once_with()
 
+    def test_get_refreshed_admin_token_from_canvas_studio(
+        self, canvas_studio_service, views
+    ):
+        views.get_refreshed_admin_token_from_canvas_studio()
+
+        canvas_studio_service.refresh_admin_access_token.assert_called_once_with()
+
     def test_get_refreshed_token_from_d2l(self, d2l_api_client, views):
         views.get_refreshed_token_from_d2l()
 


### PR DESCRIPTION
Canvas Studio admin token refreshes used to be done transparently by the backend when needed, which is different than how this is handled for other APIs. We need to introduce a mechanism to prevent concurrent refreshes of access tokens, and this will be easier to do if all token refreshes work the same way. Hence this commit changes Canvas Studio APIs to fail with an error if an admin refresh token is needed, and the frontend will initiate a refresh.

Unlike other token refreshes, if it fails, we show a custom error dialog to the user which doesn't prompt them to re-authorize (they can't, the current user is not the admin) and instead shows more specific instructions.

This change only applies if the current user is *not* an admin, otherwise refreshes are handled exactly as with other APIs, including providing the option to re-authorize if the request fails.

There is nothing in place currently to prevent multiple concurrent calls to the admin token refresh endpoint. This will be addressed in future changes.

---

**Testing:**

1. Launch a Canvas Studio assignment (eg. https://hypothesis.instructure.com/courses/125/assignments/6473). It should refresh if needed. For testing purposes, you can expire existing tokens in the LMS DB using `UPDATE oauth2_token SET access_token = 'foo' WHERE service = 'canvas_studio'`.
2. Invalidate the current access token, then force the refresh to fail using:

```diff
diff --git a/lms/services/canvas_studio.py b/lms/services/canvas_studio.py
index 9c76dd152..ff05b2172 100644
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -158,6 +158,8 @@ class CanvasStudioService:
         """Refresh the existing admin access token for Canvas Studio API calls."""
 
         try:
+            # TESTING
+            raise ExternalRequestError(message="Oh no!")
             self._admin_oauth_http.refresh_access_token(
                 self._token_url(),
                 self.redirect_uri(),
```

This should result in an error dialog like:

<img width="674" alt="Canvas Studio admin refresh error" src="https://github.com/hypothesis/lms/assets/2458/0d0334a9-ea55-4ac1-8475-595134991cbe">

