### PR TITLE
Create common components to represent dashboard activity pages

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -1,0 +1,83 @@
+import type { DataTableProps, Order } from '@hypothesis/frontend-shared';
+import { DataTable } from '@hypothesis/frontend-shared';
+import { useOrderedRows } from '@hypothesis/frontend-shared';
+import type { OrderDirection } from '@hypothesis/frontend-shared/lib/types';
+import { useMemo, useState } from 'preact/hooks';
+
+import type { BaseDashboardStats } from '../../api-types';
+
+export type OrderableActivityTableProps<T extends BaseDashboardStats> = Pick<
+  DataTableProps<T>,
+  'emptyMessage' | 'rows' | 'renderItem' | 'loading' | 'title'
+> & {
+  columnNames: Partial<Record<keyof T, string>>;
+  defaultOrderField: keyof T;
+};
+
+/**
+ * List of columns which should start sorted in descending order.
+ *
+ * This is because for numeric columns ("annotations" and "replies") users will
+ * usually want to see the higher values first.
+ * Similarly, for date columns ("last_activity") users will want to see most
+ * recent values first.
+ */
+const descendingOrderColumns: readonly string[] = [
+  'last_activity',
+  'annotations',
+  'replies',
+];
+
+/**
+ * Annotation activity table for dashboard views. Includes built-in support for
+ * sorting columns.
+ */
+export default function OrderableActivityTable<T extends BaseDashboardStats>({
+  defaultOrderField,
+  rows,
+  columnNames,
+  ...restOfTableProps
+}: OrderableActivityTableProps<T>) {
+  const [order, setOrder] = useState<Order<keyof T>>({
+    field: defaultOrderField,
+    direction: 'ascending',
+  });
+  const orderedRows = useOrderedRows(rows, order);
+  const columns = useMemo(
+    () =>
+      Object.entries(columnNames).map(([field, label], index) => ({
+        field: field as keyof T,
+        label: label as string,
+        classes: index === 0 ? 'w-[60%]' : undefined,
+      })),
+    [columnNames],
+  );
+  // Map of column name to initial sort order
+  const orderableColumns = useMemo(
+    () =>
+      (Object.keys(columnNames) as Array<keyof T>).reduce<
+        Partial<Record<keyof T, OrderDirection>>
+      >((acc, columnName) => {
+        acc[columnName] =
+          typeof columnName === 'string' &&
+          descendingOrderColumns.includes(columnName)
+            ? 'descending'
+            : 'ascending';
+        return acc;
+      }, {}),
+    [columnNames],
+  );
+
+  return (
+    <DataTable
+      grid
+      striped={false}
+      columns={columns}
+      rows={orderedRows}
+      orderableColumns={orderableColumns}
+      order={order}
+      onOrderChange={setOrder}
+      {...restOfTableProps}
+    />
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentsActivity.tsx
@@ -1,20 +1,17 @@
 import {
   Card,
   CardContent,
-  DataTable,
-  useOrderedRows,
+  CardHeader,
+  CardTitle,
 } from '@hypothesis/frontend-shared';
-import type { DataTableProps } from '@hypothesis/frontend-shared';
-import { useState } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
-import type { Assignment, StudentsStats, StudentStats } from '../../api-types';
+import type { Assignment, StudentsStats } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
 import { replaceURLParams } from '../../utils/url';
-
-type MandatoryOrder<T> = NonNullable<DataTableProps<T>['order']>;
+import OrderableActivityTable from './OrderableActivityTable';
 
 /**
  * Activity in a list of students that are part of a specific assignment
@@ -31,34 +28,31 @@ export default function StudentsActivity() {
   );
 
   const title = `Assignment: ${assignment.data?.title}`;
-  const [order, setOrder] = useState<MandatoryOrder<StudentStats>>({
-    field: 'display_name',
-    direction: 'ascending',
-  });
-  const orderedStudents = useOrderedRows(students.data ?? [], order);
 
   return (
     <Card>
-      <CardContent>
-        <h2 className="text-brand mb-3 text-xl" data-testid="title">
+      <CardHeader fullWidth>
+        <CardTitle tagName="h2" data-testid="title">
           {assignment.isLoading && 'Loading...'}
           {assignment.error && 'Could not load assignment title'}
           {assignment.data && title}
-        </h2>
-        <DataTable
-          grid
-          striped={false}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <OrderableActivityTable
+          loading={students.isLoading}
+          title={assignment.isLoading ? 'Loading...' : title}
           emptyMessage={
             students.error ? 'Could not load students' : 'No students found'
           }
-          title={assignment.isLoading ? 'Loading...' : title}
-          rows={orderedStudents}
-          columns={[
-            { field: 'display_name', label: 'Student', classes: 'w-[60%]' },
-            { field: 'annotations', label: 'Annotations' },
-            { field: 'replies', label: 'Replies' },
-            { field: 'last_activity', label: 'Last Activity' },
-          ]}
+          rows={students.data ?? []}
+          columnNames={{
+            display_name: 'Student',
+            annotations: 'Annotations',
+            replies: 'Replies',
+            last_activity: 'Last Activity',
+          }}
+          defaultOrderField="display_name"
           renderItem={(stats, field) => {
             if (['annotations', 'replies'].includes(field)) {
               return <div className="text-right">{stats[field]}</div>;
@@ -68,15 +62,6 @@ export default function StudentsActivity() {
               ? formatDateTime(new Date(stats.last_activity))
               : stats[field];
           }}
-          loading={students.isLoading}
-          orderableColumns={[
-            'display_name',
-            'annotations',
-            'replies',
-            'last_activity',
-          ]}
-          order={order}
-          onOrderChange={setOrder}
         />
       </CardContent>
     </Card>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseAssignmentsActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseAssignmentsActivity-test.js
@@ -82,8 +82,8 @@ describe('CourseAssignmentsActivity', () => {
     fakeUseAPIFetch.returns({ isLoading: true });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Loading...');
     assert.isTrue(tableElement.prop('loading'));
@@ -93,8 +93,8 @@ describe('CourseAssignmentsActivity', () => {
     fakeUseAPIFetch.returns({ error: new Error('Something failed') });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Could not load course title');
     assert.equal(
@@ -105,8 +105,8 @@ describe('CourseAssignmentsActivity', () => {
 
   it('shows expected title', () => {
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
     const expectedTitle = 'The title';
 
     assert.equal(titleElement.text(), expectedTitle);
@@ -115,133 +115,38 @@ describe('CourseAssignmentsActivity', () => {
 
   it('shows empty assignments message', () => {
     const wrapper = createComponent();
-    const tableElement = wrapper.find('DataTable');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(tableElement.prop('emptyMessage'), 'No assignments found');
   });
 
-  [
-    {
-      orderToSet: { field: 'annotations', direction: 'descending' },
-      expectedAssignments: [
-        {
-          id: 2,
-          title: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          id: 3,
-          title: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-        {
-          id: 1,
-          title: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-      ],
-    },
-    {
-      orderToSet: { field: 'replies', direction: 'ascending' },
-      expectedAssignments: [
-        {
-          id: 2,
-          title: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          id: 1,
-          title: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          id: 3,
-          title: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-      ],
-    },
-    {
-      orderToSet: { field: 'last_activity', direction: 'descending' },
-      expectedAssignments: [
-        {
-          id: 1,
-          title: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          id: 3,
-          title: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-        {
-          id: 2,
-          title: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-      ],
-    },
-  ].forEach(({ orderToSet, expectedAssignments }) => {
-    it('orders assignments on order change', () => {
-      const wrapper = createComponent();
-      const getRows = () => wrapper.find('DataTable').prop('rows');
-      const getOrder = () => wrapper.find('DataTable').prop('order');
-      const setOrder = order => {
-        wrapper.find('DataTable').props().onOrderChange(order);
-        wrapper.update();
-      };
+  it('flattens assignments to table rows', () => {
+    const wrapper = createComponent();
+    const tableElement = wrapper.find('OrderableActivityTable');
 
-      // Initially, assignments are ordered by title
-      assert.deepEqual(getOrder(), {
-        field: 'title',
-        direction: 'ascending',
-      });
-      assert.deepEqual(getRows(), [
-        {
-          id: 1,
-          title: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          id: 2,
-          title: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          id: 3,
-          title: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-      ]);
-
-      setOrder(orderToSet);
-      assert.deepEqual(getOrder(), orderToSet);
-      assert.deepEqual(getRows(), expectedAssignments);
-    });
+    assert.deepEqual(tableElement.prop('rows'), [
+      {
+        id: 2,
+        title: 'b',
+        last_activity: '2020-01-01T00:00:00',
+        annotations: 8,
+        replies: 0,
+      },
+      {
+        id: 1,
+        title: 'a',
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 3,
+        replies: 20,
+      },
+      {
+        id: 3,
+        title: 'c',
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 5,
+        replies: 100,
+      },
+    ]);
   });
 
   [
@@ -261,7 +166,7 @@ describe('CourseAssignmentsActivity', () => {
       const wrapper = createComponent();
 
       const item = wrapper
-        .find('DataTable')
+        .find('OrderableActivityTable')
         .props()
         .renderItem(assignmentStats, fieldName);
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
@@ -1,0 +1,153 @@
+import { mount } from 'enzyme';
+
+import OrderableActivityTable from '../OrderableActivityTable';
+
+describe('OrderableActivityTable', () => {
+  const rows = [
+    {
+      display_name: 'b',
+      last_activity: '2020-01-01T00:00:00',
+      annotations: 8,
+      replies: 0,
+    },
+    {
+      display_name: 'a',
+      last_activity: '2020-01-02T00:00:00',
+      annotations: 3,
+      replies: 20,
+    },
+    {
+      display_name: 'c',
+      last_activity: '2020-01-02T00:00:00',
+      annotations: 5,
+      replies: 100,
+    },
+  ];
+
+  function createComponent(defaultOrderField = 'display_name') {
+    return mount(
+      <OrderableActivityTable
+        rows={rows}
+        columnNames={{
+          display_name: 'Name',
+          last_activity: 'Last activity',
+          annotations: 'Annotations',
+          replies: 'Replies',
+        }}
+        defaultOrderField={defaultOrderField}
+      />,
+    );
+  }
+
+  [
+    {
+      orderToSet: { field: 'annotations', direction: 'descending' },
+      expectedStudents: [
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'replies', direction: 'ascending' },
+      expectedStudents: [
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ],
+    },
+    {
+      orderToSet: { field: 'last_activity', direction: 'descending' },
+      expectedStudents: [
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+      ],
+    },
+  ].forEach(({ orderToSet, expectedStudents }) => {
+    it('reorders students on order change', () => {
+      const wrapper = createComponent();
+      const getRows = () => wrapper.find('DataTable').prop('rows');
+      const getOrder = () => wrapper.find('DataTable').prop('order');
+      const setOrder = order => {
+        wrapper.find('DataTable').props().onOrderChange(order);
+        wrapper.update();
+      };
+
+      // Initially ordered by name
+      assert.deepEqual(getOrder(), {
+        field: 'display_name',
+        direction: 'ascending',
+      });
+      assert.deepEqual(getRows(), [
+        {
+          display_name: 'a',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 3,
+          replies: 20,
+        },
+        {
+          display_name: 'b',
+          last_activity: '2020-01-01T00:00:00',
+          annotations: 8,
+          replies: 0,
+        },
+        {
+          display_name: 'c',
+          last_activity: '2020-01-02T00:00:00',
+          annotations: 5,
+          replies: 100,
+        },
+      ]);
+
+      setOrder(orderToSet);
+      assert.deepEqual(getOrder(), orderToSet);
+      assert.deepEqual(getRows(), expectedStudents);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/StudentsActivity-test.js
@@ -71,8 +71,8 @@ describe('StudentsActivity', () => {
     fakeUseAPIFetch.returns({ isLoading: true });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Loading...');
     assert.isTrue(tableElement.prop('loading'));
@@ -82,8 +82,8 @@ describe('StudentsActivity', () => {
     fakeUseAPIFetch.returns({ error: new Error('Something failed') });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Could not load assignment title');
     assert.equal(tableElement.prop('emptyMessage'), 'Could not load students');
@@ -91,8 +91,8 @@ describe('StudentsActivity', () => {
 
   it('shows expected title', () => {
     const wrapper = createComponent();
-    const titleElement = wrapper.find('[data-testid="title"]');
-    const tableElement = wrapper.find('DataTable');
+    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const tableElement = wrapper.find('OrderableActivityTable');
     const expectedTitle = `Assignment: The title`;
 
     assert.equal(titleElement.text(), expectedTitle);
@@ -101,121 +101,9 @@ describe('StudentsActivity', () => {
 
   it('shows empty students message', () => {
     const wrapper = createComponent();
-    const tableElement = wrapper.find('DataTable');
+    const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(tableElement.prop('emptyMessage'), 'No students found');
-  });
-
-  [
-    {
-      orderToSet: { field: 'annotations', direction: 'descending' },
-      expectedStudents: [
-        {
-          display_name: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          display_name: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-        {
-          display_name: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-      ],
-    },
-    {
-      orderToSet: { field: 'replies', direction: 'ascending' },
-      expectedStudents: [
-        {
-          display_name: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          display_name: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          display_name: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-      ],
-    },
-    {
-      orderToSet: { field: 'last_activity', direction: 'descending' },
-      expectedStudents: [
-        {
-          display_name: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          display_name: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-        {
-          display_name: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-      ],
-    },
-  ].forEach(({ orderToSet, expectedStudents }) => {
-    it('orders students on order change', () => {
-      const wrapper = createComponent();
-      const getRows = () => wrapper.find('DataTable').prop('rows');
-      const getOrder = () => wrapper.find('DataTable').prop('order');
-      const setOrder = order => {
-        wrapper.find('DataTable').props().onOrderChange(order);
-        wrapper.update();
-      };
-
-      // Initially, students are ordered by name
-      assert.deepEqual(getOrder(), {
-        field: 'display_name',
-        direction: 'ascending',
-      });
-      assert.deepEqual(getRows(), [
-        {
-          display_name: 'a',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 3,
-          replies: 20,
-        },
-        {
-          display_name: 'b',
-          last_activity: '2020-01-01T00:00:00',
-          annotations: 8,
-          replies: 0,
-        },
-        {
-          display_name: 'c',
-          last_activity: '2020-01-02T00:00:00',
-          annotations: 5,
-          replies: 100,
-        },
-      ]);
-
-      setOrder(orderToSet);
-      assert.deepEqual(getOrder(), orderToSet);
-      assert.deepEqual(getRows(), expectedStudents);
-    });
   });
 
   [
@@ -234,7 +122,7 @@ describe('StudentsActivity', () => {
       const wrapper = createComponent();
 
       const item = wrapper
-        .find('DataTable')
+        .find('OrderableActivityTable')
         .props()
         .renderItem(studentStats, fieldName);
       const value = typeof item === 'string' ? item : mount(item).text();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.9.0",
+    "@hypothesis/frontend-shared": "^7.10.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,15 +2137,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.9.0":
-  version: 7.9.0
-  resolution: "@hypothesis/frontend-shared@npm:7.9.0"
+"@hypothesis/frontend-shared@npm:^7.10.0":
+  version: 7.10.0
+  resolution: "@hypothesis/frontend-shared@npm:7.10.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 2c0a71f57436859e0b3f4fb617c13e7385b660d2676743f2008accd6460cd29f3e1b5ee7fa61b7540e64440610a5950dd41d22ec902dde31c0438c5ddb351224
+  checksum: 22b88111452b83a9a4c6987e47071b167e0c653e22519321eea871d4ffe7f0f38555b88572227e960abade87c62b1b4e46a01ed8d2f827ed05447bc4a886400c
   languageName: node
   linkType: hard
 
@@ -7346,7 +7346,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@babel/preset-typescript": ^7.24.1
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.9.0
+    "@hypothesis/frontend-shared": ^7.10.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.7


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6285

Create a common `OrderableActivityTable` component to render activity tables in the dashboard pages. This allows to:

1. Test the table ordering logic only once.
2. Have a consistent structure and look-and-feel between sections.

![image](https://github.com/hypothesis/lms/assets/2719332/1ea9e414-2685-4d80-a694-47da53b420dd)

![image](https://github.com/hypothesis/lms/assets/2719332/ab1ebf01-2eb9-4bb6-9e2c-87d42e20430d)

Additionally, this PR makes these other changes:

1. Render titles using `CardHeader` + `CardTitle` instead of a `h2` inside the `CardContent` itself. This title will potentially be removed replaced by a breadcrumb, but that requires a bit of experimentation.
2. Make all columns in the table but the first one be sorted in descending order by default, thanks to the implementation from https://github.com/hypothesis/frontend-shared/pull/1564