### PR TITLE
Use advisory locks to prevent concurrent OAuth token refreshes

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
 from lms.db._columns import varchar_enum
-from lms.db._locks import LockType, TryLockError, try_advisory_transaction_lock
+from lms.db._locks import CouldNotAcquireLock, LockType, try_advisory_transaction_lock
 from lms.db._text_search import full_text_match
 
 __all__ = ("Base", "create_engine", "varchar_enum")

--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
 from lms.db._columns import varchar_enum
+from lms.db._locks import LockType, TryLockError, try_advisory_transaction_lock
 from lms.db._text_search import full_text_match
 
 __all__ = ("Base", "create_engine", "varchar_enum")

--- a/lms/db/_locks.py
+++ b/lms/db/_locks.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 
-class TryLockError(Exception):
+class CouldNotAcquireLock(Exception):
     """Exception raised if a lock cannot be immediately acquired."""
 
 
@@ -31,11 +31,11 @@ def try_advisory_transaction_lock(db: Session, lock_type: LockType, id_: int):
 
     The lock is released when the transaction is closed.
 
-    :param db: Database session
-    :param lock_type: The type of entity for the lock
-    :param id_: A type-specific ID for the entity being locked
-    :raise TryLockError: if the lock cannot be acquired immediately
+    :param db: database session
+    :param lock_type: the type of entity for the lock
+    :param id_: a type-specific ID for the entity being locked
+    :raise CouldNotAcquireLock: if the lock cannot be acquired immediately
     """
     query = sa.text("SELECT pg_try_advisory_xact_lock(:key1, :key2)")
     if not db.execute(query, {"key1": lock_type, "key2": id_}).scalar():
-        raise TryLockError()
+        raise CouldNotAcquireLock(lock_type, id_)

--- a/lms/db/_locks.py
+++ b/lms/db/_locks.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 
 class CouldNotAcquireLock(Exception):
-    """Exception raised if a lock cannot be immediately acquired."""
+    """A lock could not be immediately acquired."""
 
 
 class LockType(IntEnum):

--- a/lms/db/_locks.py
+++ b/lms/db/_locks.py
@@ -1,0 +1,41 @@
+from enum import IntEnum
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+
+class TryLockError(Exception):
+    """Exception raised if a lock cannot be immediately acquired."""
+
+
+class LockType(IntEnum):
+    """
+    Identifies a type of resource for an advisory lock.
+
+    Advisory locks are identified by a `(type, object_id)` tuple, where both
+    are 32-bit integers. This enum provides values for `type`. The meaning of
+    `object_id` depends on the type.
+    """
+
+    OAUTH2_TOKEN_REFRESH = 1
+    """
+    Lock for an OAuth 2 token update.
+
+    The object ID is the `OAuth2Token.id` value for the token being updated.
+    """
+
+
+def try_advisory_transaction_lock(db: Session, lock_type: LockType, id_: int):
+    """
+    Attempt to acquire an advisory lock, scoped to the current transaction.
+
+    The lock is released when the transaction is closed.
+
+    :param db: Database session
+    :param lock_type: The type of entity for the lock
+    :param id_: A type-specific ID for the entity being locked
+    :raise TryLockError: if the lock cannot be acquired immediately
+    """
+    query = sa.text("SELECT pg_try_advisory_xact_lock(:key1, :key2)")
+    if not db.execute(query, {"key1": lock_type, "key2": id_}).scalar():
+        raise TryLockError()

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -11,7 +11,14 @@ from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
 from lms.product.d2l import D2L
 from lms.resources._js_config.file_picker_config import FilePickerConfig
-from lms.services import HAPI, EventService, HAPIError, JSTORService, VitalSourceService
+from lms.services import (
+    HAPI,
+    CanvasStudioService,
+    EventService,
+    HAPIError,
+    JSTORService,
+    VitalSourceService,
+)
 from lms.validation.authentication import BearerTokenSchema
 from lms.views.helpers import via_url
 
@@ -82,8 +89,18 @@ class JSConfig:
             }
 
         elif document_url.startswith("canvas-studio://media"):
+            canvas_studio_svc = self._request.find_service(CanvasStudioService)
+
+            # Requests for the transcript and video are made as the admin user.
+            # Only set `authUrl` if the current user is the admin to make sure
+            # we don't unnecessarily launch the auth flow for other users.
+            if canvas_studio_svc.is_admin():
+                auth_url = self._request.route_url("canvas_studio_api.oauth.authorize")
+            else:
+                auth_url = None
+
             self._config["api"]["viaUrl"] = {
-                "authUrl": self._request.route_url("canvas_studio_api.oauth.authorize"),
+                "authUrl": auth_url,
                 "path": self._request.route_path("canvas_studio_api.via_url"),
             }
 

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -152,6 +152,7 @@ class CanvasStudioService:
             self._token_url(),
             self.redirect_uri(),
             auth=(self._client_id, self._client_secret),
+            prevent_concurrent_refreshes=True,
         )
 
     def refresh_admin_access_token(self):
@@ -162,6 +163,7 @@ class CanvasStudioService:
                 self._token_url(),
                 self.redirect_uri(),
                 auth=(self._client_id, self._client_secret),
+                prevent_concurrent_refreshes=True,
             )
         except ExternalRequestError as refresh_err:
             raise SerializableError(

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -407,7 +407,7 @@ class CanvasStudioService:
         """
         url = self._api_url(path)
 
-        if as_admin and not self._is_admin():
+        if as_admin and not self.is_admin():
             return self._admin_api_request(path, allow_redirects=allow_redirects)
 
         try:
@@ -447,7 +447,7 @@ class CanvasStudioService:
             )
         return admin_email
 
-    def _is_admin(self) -> bool:
+    def is_admin(self) -> bool:
         """Return true if the current LTI user is the configure Canvas Studio admin."""
         return self._request.lti_user.email == self._admin_email()
 
@@ -466,7 +466,7 @@ class CanvasStudioService:
 
         # The caller should check for this condition before calling this method
         # and use the standard `self._oauth_http_service` property instead.
-        assert not self._is_admin()
+        assert not self.is_admin()
 
         admin_email = self._admin_email()
         admin_user = (

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -158,6 +158,10 @@ class OAuth2TokenError(ExternalRequestError):
     """
 
 
+class ConflictError(Exception):
+    """A request failed due to a conflicting operation."""
+
+
 class CanvasAPIError(ExternalRequestError):
     """A problem with a Canvas API request."""
 

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -158,8 +158,8 @@ class OAuth2TokenError(ExternalRequestError):
     """
 
 
-class ConflictError(Exception):
-    """A request failed due to a conflicting operation."""
+class ConcurrentTokenRefreshError(Exception):
+    """Another process is attempting to refresh the same OAuth token."""
 
 
 class CanvasAPIError(ExternalRequestError):

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -73,9 +73,12 @@ class OAuth2TokenService:
         """
         Attempt to acquire an advisory lock before a token refresh.
 
+        This does not block if the lock is already held. Instead it raises an
+        error.
+
         The lock is released at the end of the current transaction.
 
-        :raise TryLockError: if the lock cannot be immediately acquired
+        :raise CouldNotAcquireLock: if the lock cannot be immediately acquired
         """
         token = self.get(service)
         try_advisory_transaction_lock(self._db, LockType.OAUTH2_TOKEN_REFRESH, token.id)

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -1,8 +1,15 @@
+from datetime import datetime, timedelta
+
 from marshmallow import fields
 
+from lms.db import TryLockError
 from lms.models.oauth2_token import Service
-from lms.services.exceptions import ExternalRequestError, OAuth2TokenError
-from lms.services.oauth2_token import oauth2_token_service_factory
+from lms.services.exceptions import (
+    ConflictError,
+    ExternalRequestError,
+    OAuth2TokenError,
+)
+from lms.services.oauth2_token import OAuth2TokenService, oauth2_token_service_factory
 from lms.validation import RequestsResponseSchema
 from lms.validation.authentication import OAuthTokenResponseSchema
 
@@ -17,7 +24,10 @@ class OAuthHTTPService:
     """Send OAuth 2.0 requests and return the responses."""
 
     def __init__(
-        self, http_service, oauth2_token_service, service: Service = Service.LMS
+        self,
+        http_service,
+        oauth2_token_service: OAuth2TokenService,
+        service: Service = Service.LMS,
     ):
         self._http_service = http_service
         self._oauth2_token_service = oauth2_token_service
@@ -90,11 +100,27 @@ class OAuthHTTPService:
         (https://datatracker.ietf.org/doc/html/rfc6749#section-6) to get a new
         access token for the current user and save it to the DB.
 
+        :raise ConflictError: if this token is being refreshed concurrently by another request
         :raise OAuth2TokenError: if we don't have a refresh token for the user
         :raise ExternalRequestError: if the HTTP request fails
         :raise ValidationError: if the server's access token response is invalid
         """
-        refresh_token = self._oauth2_token_service.get(self.service).refresh_token
+        old_token = self._oauth2_token_service.get(self.service)
+
+        # If the "old" token is already current, just return immediately.
+        if (
+            old_token.access_token
+            and datetime.utcnow() - old_token.received_at < timedelta(seconds=30)
+        ):
+            return old_token.access_token
+
+        # Prevent concurrent refresh attempts. If the client gets this, it
+        # should wait briefly and try again, at which point it should find the
+        # refreshed token already available and skip the refresh.
+        try:
+            self._oauth2_token_service.try_lock_for_refresh(self.service)
+        except TryLockError as exc:
+            raise ConflictError() from exc
 
         try:
             return self._token_request(
@@ -103,7 +129,7 @@ class OAuthHTTPService:
                 data={
                     "redirect_uri": redirect_uri,
                     "grant_type": "refresh_token",
-                    "refresh_token": refresh_token,
+                    "refresh_token": old_token.refresh_token,
                 },
             )
         except ExternalRequestError as err:

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -293,15 +293,15 @@ export default function BasicLTILaunchApp() {
    * the content URL and groups again.
    */
   const authorizeAndFetchURL = useCallback(async () => {
-    setErrorState('error-authorizing');
-
     if (authWindow.current) {
+      setErrorState('error-authorizing');
       authWindow.current.focus();
       return;
     }
 
     try {
       if (authURL) {
+        setErrorState('error-authorizing');
         authWindow.current = new AuthWindow({ authToken, authUrl: authURL });
         await authWindow.current.authorize();
         setAuthURL(null);

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -67,9 +67,16 @@ export type APICallOptions = {
   /** Internal. Counts the number of times this request has been retried. */
   retryCount?: number;
 
+  /** Internal. Amount of time to wait between retries. */
+  retryDelay?: number;
+
   /** Signal that can be used to cancel the request. */
   signal?: AbortSignal;
 };
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 /**
  * Make an API call to the LMS app backend.
@@ -88,6 +95,7 @@ export async function apiCall<Result = unknown>(
     method,
     params,
     retryCount = 0,
+    retryDelay = 1000,
     signal,
   } = options;
 
@@ -122,6 +130,7 @@ export async function apiCall<Result = unknown>(
 
   if (result.status >= 400 && result.status < 600) {
     if (result.status === 409 && retryCount < maxRetries) {
+      await delay(retryDelay);
       return apiCall({ ...options, retryCount: retryCount + 1 });
     }
 

--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -333,10 +333,13 @@ describe('api', () => {
     window.fetch.withArgs('/api/test').onCall(1).resolves(conflictResponse);
     window.fetch.withArgs('/api/test').onCall(2).resolves(okResponse);
 
+    const retryDelay = 1;
+
     // An HTTP 409 response should trigger an automatic retry.
     const result = await apiCall({
       path: '/api/test',
       authToken: 'auth',
+      retryDelay,
     });
 
     assert.deepEqual(result, { ok: true });
@@ -345,7 +348,12 @@ describe('api', () => {
     window.fetch.resetHistory();
     let error;
     try {
-      await apiCall({ path: '/api/test', authToken: 'auth', maxRetries: 1 });
+      await apiCall({
+        path: '/api/test',
+        authToken: 'auth',
+        maxRetries: 1,
+        retryDelay,
+      });
     } catch (err) {
       error = err;
     }

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -23,7 +23,7 @@ from lms.services import (
     ExternalRequestError,
     OAuth2TokenError,
 )
-from lms.services.exceptions import SerializableError
+from lms.services.exceptions import ConflictError, SerializableError
 from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -109,6 +109,11 @@ class APIExceptionViews:
         # 400 is the default status for error responses.
         # Some of the views below override this.
         self.request.response.status_int = 400
+
+    @exception_view_config(context=ConflictError)
+    def conflict_error(self):
+        self.request.response.status_int = 409
+        return ErrorBody(message="Operation failed due to a conflicting update")
 
     @exception_view_config(context=ValidationError)
     def validation_error(self):

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -23,7 +23,7 @@ from lms.services import (
     ExternalRequestError,
     OAuth2TokenError,
 )
-from lms.services.exceptions import ConflictError, SerializableError
+from lms.services.exceptions import ConcurrentTokenRefreshError, SerializableError
 from lms.validation import ValidationError
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -110,10 +110,13 @@ class APIExceptionViews:
         # Some of the views below override this.
         self.request.response.status_int = 400
 
-    @exception_view_config(context=ConflictError)
-    def conflict_error(self):
+    @exception_view_config(context=ConcurrentTokenRefreshError)
+    def concurrent_token_refresh_error(self):
         self.request.response.status_int = 409
-        return ErrorBody(message="Operation failed due to a conflicting update")
+        return ErrorBody(
+            error_code="concurrent_token_refresh",
+            message="API token is already being refreshed",
+        )
 
     @exception_view_config(context=ValidationError)
     def validation_error(self):

--- a/tests/factories/oauth2_token.py
+++ b/tests/factories/oauth2_token.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from factory import SubFactory, make_factory
 from factory.alchemy import SQLAlchemyModelFactory
 
@@ -11,5 +13,6 @@ OAuth2Token = make_factory(
     user_id=USER_ID,
     application_instance=SubFactory(ApplicationInstance),
     access_token=ACCESS_TOKEN,
+    received_at=datetime(2023, 12, 1),
     refresh_token=REFRESH_TOKEN,
 )

--- a/tests/factories/oauth2_token.py
+++ b/tests/factories/oauth2_token.py
@@ -13,6 +13,8 @@ OAuth2Token = make_factory(
     user_id=USER_ID,
     application_instance=SubFactory(ApplicationInstance),
     access_token=ACCESS_TOKEN,
+    # This is intentionally an "old" time and not a token that was very recently
+    # received.
     received_at=datetime(2023, 12, 1),
     refresh_token=REFRESH_TOKEN,
 )

--- a/tests/unit/lms/db/_locks_test.py
+++ b/tests/unit/lms/db/_locks_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from lms.db import LockType, TryLockError, try_advisory_transaction_lock
+
+
+class TestTryAdvisoryTransactionLock:
+    def test_it(self, db_session, other_db_session):
+        # Initial lock attempt should succeed.
+        try_advisory_transaction_lock(db_session, LockType.OAUTH2_TOKEN_REFRESH, 123)
+
+        # Another session attempting a conflicting lock should fail
+        with pytest.raises(TryLockError):
+            try_advisory_transaction_lock(
+                other_db_session, LockType.OAUTH2_TOKEN_REFRESH, 123
+            )
+
+        # Another session attempting a non-conflicting lock should succeed
+        try_advisory_transaction_lock(
+            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, 456
+        )
+
+        # After the transaction ends, the lock should be released and other
+        # sessions should be able to acquire it.
+        db_session.rollback()
+        try_advisory_transaction_lock(
+            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, 123
+        )
+
+    @pytest.fixture
+    def other_db_session(self, db_engine, db_sessionfactory):
+        connection = db_engine.connect()
+        return db_sessionfactory(bind=connection)

--- a/tests/unit/lms/db/_locks_test.py
+++ b/tests/unit/lms/db/_locks_test.py
@@ -2,32 +2,47 @@ import pytest
 
 from lms.db import CouldNotAcquireLock, LockType, try_advisory_transaction_lock
 
+# Two very random IDs which shouldn't conflict with any tests that happen to
+# be running in parallel with this module.
+LOCK_ID = 1_000_001
+OTHER_LOCK_ID = 1_000_002
 
+
+# Make sure locks acquired in different tests don't conflict.
+@pytest.mark.xdist_group("TryAdvisoryTransactionLock")
 class TestTryAdvisoryTransactionLock:
     def test_it_succeeds_if_lock_available(self, db_session):
-        try_advisory_transaction_lock(db_session, LockType.OAUTH2_TOKEN_REFRESH, 123)
+        try_advisory_transaction_lock(
+            db_session, LockType.OAUTH2_TOKEN_REFRESH, LOCK_ID
+        )
 
     def test_it_fails_if_lock_not_available(self, db_session, other_db_session):
-        try_advisory_transaction_lock(db_session, LockType.OAUTH2_TOKEN_REFRESH, 123)
+        try_advisory_transaction_lock(
+            db_session, LockType.OAUTH2_TOKEN_REFRESH, LOCK_ID
+        )
 
         lock_type = LockType.OAUTH2_TOKEN_REFRESH
         with pytest.raises(CouldNotAcquireLock) as exc_info:
-            try_advisory_transaction_lock(other_db_session, lock_type, 123)
-        assert exc_info.value.args == (lock_type, 123)
+            try_advisory_transaction_lock(other_db_session, lock_type, LOCK_ID)
+        assert exc_info.value.args == (lock_type, LOCK_ID)
 
     def test_it_succeeds_if_lock_with_different_id_held(
         self, db_session, other_db_session
     ):
-        try_advisory_transaction_lock(db_session, LockType.OAUTH2_TOKEN_REFRESH, 123)
         try_advisory_transaction_lock(
-            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, 456
+            db_session, LockType.OAUTH2_TOKEN_REFRESH, LOCK_ID
+        )
+        try_advisory_transaction_lock(
+            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, OTHER_LOCK_ID
         )
 
     def test_it_releases_lock_when_transaction_ends(self, db_session, other_db_session):
-        try_advisory_transaction_lock(db_session, LockType.OAUTH2_TOKEN_REFRESH, 123)
+        try_advisory_transaction_lock(
+            db_session, LockType.OAUTH2_TOKEN_REFRESH, LOCK_ID
+        )
         db_session.rollback()
         try_advisory_transaction_lock(
-            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, 123
+            other_db_session, LockType.OAUTH2_TOKEN_REFRESH, LOCK_ID
         )
 
     @pytest.fixture

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -275,13 +275,6 @@ class TestAddDocumentURL:
                 },
             ),
             (
-                "canvas-studio://media/media_id",
-                {
-                    "authUrl": "http://example.com/api/canvas_studio/oauth/authorize",
-                    "path": "/api/canvas_studio/via_url",
-                },
-            ),
-            (
                 "d2l://file/course/125/file_id/100",
                 {
                     "authUrl": "http://example.com/api/d2l/oauth/authorize",
@@ -308,6 +301,24 @@ class TestAddDocumentURL:
         js_config.add_document_url(url)
 
         assert js_config.asdict()["api"]["viaUrl"] == via_url
+
+    @pytest.mark.parametrize("is_admin", (True, False))
+    def test_canvas_studio_adds_config(
+        self, js_config, canvas_studio_service, is_admin
+    ):
+        canvas_studio_service.is_admin.return_value = is_admin
+
+        document_url = "canvas-studio://media/media_id"
+        js_config.add_document_url(document_url)
+
+        expected_auth_url = None
+        if is_admin:
+            expected_auth_url = "http://example.com/api/canvas_studio/oauth/authorize"
+
+        assert js_config.asdict()["api"]["viaUrl"] == {
+            "authUrl": expected_auth_url,
+            "path": "/api/canvas_studio/via_url",
+        }
 
     def test_vitalsource_sets_config_with_sso(
         self, js_config, pyramid_request, vitalsource_service

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -38,6 +38,7 @@ class TestCanvasStudioService:
             "https://hypothesis.instructuremedia.com/api/public/oauth/token",
             "http://example.com/api/canvas_studio/oauth/callback",
             auth=("the_client_id", client_secret),
+            prevent_concurrent_refreshes=True,
         )
 
     def test_refresh_admin_access_token(
@@ -49,6 +50,7 @@ class TestCanvasStudioService:
             "https://hypothesis.instructuremedia.com/api/public/oauth/token",
             "http://example.com/api/canvas_studio/oauth/callback",
             auth=("the_client_id", client_secret),
+            prevent_concurrent_refreshes=True,
         )
 
     def test_refresh_admin_access_token_error(self, svc, admin_oauth_http_service):

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -5,7 +5,7 @@ import pytest
 from h_matchers import Any
 from pytest import param
 
-from lms.db import LockType, TryLockError
+from lms.db import CouldNotAcquireLock, LockType
 from lms.models import OAuth2Token
 from lms.services import OAuth2TokenError
 from lms.services.oauth2_token import (
@@ -105,8 +105,8 @@ class TestOAuth2TokenService:
         )
 
         # If locking fails, the service should propagate the exception
-        try_advisory_transaction_lock.side_effect = TryLockError()
-        with pytest.raises(TryLockError):
+        try_advisory_transaction_lock.side_effect = CouldNotAcquireLock()
+        with pytest.raises(CouldNotAcquireLock):
             svc.try_lock_for_refresh(Service.LMS)
 
     @pytest.fixture

--- a/tests/unit/lms/services/oauth2_token_test.py
+++ b/tests/unit/lms/services/oauth2_token_test.py
@@ -5,6 +5,7 @@ import pytest
 from h_matchers import Any
 from pytest import param
 
+from lms.db import LockType, TryLockError
 from lms.models import OAuth2Token
 from lms.services import OAuth2TokenError
 from lms.services.oauth2_token import (
@@ -19,15 +20,8 @@ from tests import factories
 class TestOAuth2TokenService:
     @pytest.mark.usefixtures("oauth_token_in_db_or_not")
     @pytest.mark.parametrize("service", [Service.LMS, Service.CANVAS_STUDIO])
-    def test_save(self, svc, db_session, application_instance, lti_user, service):
-        svc.save(
-            access_token="access_token",
-            refresh_token="refresh_token",
-            expires_in=1234,
-            service=service,
-        )
-
-        oauth2_token = db_session.query(OAuth2Token).filter_by(service=service).one()
+    def test_save(self, application_instance, lti_user, service, save_token):
+        oauth2_token = save_token(service)
         assert oauth2_token == Any.object(OAuth2Token).with_attrs(
             {
                 "application_instance_id": application_instance.id,
@@ -95,6 +89,26 @@ class TestOAuth2TokenService:
 
         return oauth_token
 
+    def test_try_lock_for_refresh(
+        self,
+        pyramid_request,
+        svc,
+        try_advisory_transaction_lock,
+        save_token,
+    ):
+        oauth2_token = save_token()
+
+        # Successful lock
+        svc.try_lock_for_refresh(Service.LMS)
+        try_advisory_transaction_lock.assert_called_with(
+            pyramid_request.db, LockType.OAUTH2_TOKEN_REFRESH, oauth2_token.id
+        )
+
+        # If locking fails, the service should propagate the exception
+        try_advisory_transaction_lock.side_effect = TryLockError()
+        with pytest.raises(TryLockError):
+            svc.try_lock_for_refresh(Service.LMS)
+
     @pytest.fixture
     def svc(self, pyramid_request, application_instance):
         return OAuth2TokenService(
@@ -102,6 +116,23 @@ class TestOAuth2TokenService:
             application_instance,
             pyramid_request.lti_user.user_id,
         )
+
+    @pytest.fixture
+    def save_token(self, db_session, svc):
+        def save_token(service=Service.LMS):
+            svc.save(
+                access_token="access_token",
+                refresh_token="refresh_token",
+                expires_in=1234,
+                service=service,
+            )
+            return db_session.query(OAuth2Token).filter_by(service=service).one()
+
+        return save_token
+
+    @pytest.fixture
+    def try_advisory_transaction_lock(self, patch):
+        return patch("lms.services.oauth2_token.try_advisory_transaction_lock")
 
 
 class TestOAuth2TokenServiceFactory:

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -3,10 +3,10 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.db import TryLockError
+from lms.db import CouldNotAcquireLock
 from lms.models.oauth2_token import Service
 from lms.services.exceptions import (
-    ConflictError,
+    ConcurrentTokenRefreshError,
     ExternalRequestError,
     OAuth2TokenError,
 )
@@ -232,14 +232,14 @@ class TestOAuthHTTPService:
                 sentinel.token_url, sentinel.redirect_uri, sentinel.auth
             )
 
-    def test_refresh_access_token_raises_ConflictError_on_concurrent_refresh(
+    def test_refresh_access_token_raises_ConcurrentTokenRefreshError_on_concurrent_refresh(
         self,
         svc,
         oauth2_token_service,
     ):
-        oauth2_token_service.try_lock_for_refresh.side_effect = TryLockError()
+        oauth2_token_service.try_lock_for_refresh.side_effect = CouldNotAcquireLock()
 
-        with pytest.raises(ConflictError):
+        with pytest.raises(ConcurrentTokenRefreshError):
             svc.refresh_access_token(
                 sentinel.token_url, sentinel.redirect_uri, sentinel.auth
             )

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -16,6 +16,16 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+class TestConflictError:
+    def test_it(self, pyramid_request, views):
+        error_body = views.conflict_error()
+
+        assert pyramid_request.response.status_code == 409
+        assert error_body == ErrorBody(
+            message="Operation failed due to a conflicting update"
+        )
+
+
 class TestSchemaValidationError:
     def test_it(self, pyramid_request, views):
         error_body = views.validation_error()

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -16,13 +16,14 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-class TestConflictError:
+class TestConcurrentTokenRefreshError:
     def test_it(self, pyramid_request, views):
-        error_body = views.conflict_error()
+        error_body = views.concurrent_token_refresh_error()
 
         assert pyramid_request.response.status_code == 409
         assert error_body == ErrorBody(
-            message="Operation failed due to a conflicting update"
+            error_code="concurrent_token_refresh",
+            message="API token is already being refreshed",
         )
 
 


### PR DESCRIPTION
Use transaction-scoped advisory locks to prevent concurrent refreshes of the
same OAuth token. If a client tries to make a conflicting request, it will fail
with an HTTP 409. The frontend will then retry a few times.  Clients that retry
after the token is refreshed will find the token is already up to date and skip
the refresh.

See [this page](https://www.postgresql.org/docs/9.1/functions-admin.html) for details of the `pg_try_advisory_xact_lock` function.

Fixes https://github.com/hypothesis/lms/issues/6247

**TODO:**

- [x] Tests
- [x] Limit the number of retries made by the frontend
- [x] Improve error handling if retry limit is reached

---

**Testing:**

To test this, you first need to invalidate the refresh token for an existing API. The easiest way to do this is using `UPDATE oauth2_token SET access_token = 'foo'` in the lms DB. Then apply the diff below to make the refreshes take longer than normal:

```diff
diff --git a/lms/services/oauth_http.py b/lms/services/oauth_http.py
index f68d6ac3a..52b08c034 100644
--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -121,6 +121,10 @@ class OAuthHTTPService:
             raise ConflictError()
 
         try:
+            # Simulate slow refresh
+            import time
+            time.sleep(10)
+
             return self._token_request(
                 token_url=token_url,
                 auth=auth,
```

With a change like the above applied, launch an assignment which requires LMS API usage in two separate tabs. The first tab will begin the refresh and should eventually succeed. The second will encounter a conflict and keep retrying, until it discovers that a refreshed token is already available and proceed.