### PR TITLE
Import HubSpot companies and display them in the admin pages

### DIFF
--- a/lms/config.py
+++ b/lms/config.py
@@ -117,6 +117,8 @@ SETTINGS = (
     _Setting("mailchimp_digests_email"),
     _Setting("mailchimp_digests_name"),
     _Setting("email_preferences_secret"),
+    _Setting("hubspot_api_key"),
+    _Setting("hubspot_account_id"),
 )
 
 

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -19,6 +19,7 @@ from lms.models.grouping import (
     GroupingMembership,
 )
 from lms.models.h_user import HUser
+from lms.models.hubspot import HubSpotCompany
 from lms.models.json_settings import JSONSettings
 from lms.models.jwt_oauth2_token import JWTOAuth2Token
 from lms.models.lti_params import CLAIM_PREFIX, LTIParams

--- a/lms/models/hubspot.py
+++ b/lms/models/hubspot.py
@@ -12,10 +12,10 @@ class HubSpotCompany(Base):
     __tablename__ = "hubspot_company"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    hs_object_id: Mapped[int] = mapped_column(BigInteger, unique=True)
+    hubspot_id: Mapped[int] = mapped_column(BigInteger, unique=True)
 
     name: Mapped[str | None]
-    lms_organization_id: Mapped[str | None]
 
+    lms_organization_id: Mapped[str | None]
     current_deal_services_start: Mapped[date | None]
     current_deal_services_end: Mapped[date | None]

--- a/lms/models/hubspot.py
+++ b/lms/models/hubspot.py
@@ -1,0 +1,21 @@
+from datetime import date
+
+from sqlalchemy import BigInteger
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lms.db import Base
+
+
+class HubSpotCompany(Base):
+    """Raw companies data imported from HS."""
+
+    __tablename__ = "hubspot_company"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    hs_object_id: Mapped[int] = mapped_column(BigInteger, unique=True)
+
+    name: Mapped[str | None]
+    lms_organization_id: Mapped[str | None]
+
+    current_deal_services_start: Mapped[date | None]
+    current_deal_services_end: Mapped[date | None]

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -16,6 +16,7 @@ from lms.services.exceptions import (
     SerializableError,
 )
 from lms.services.h_api import HAPI, HAPIError
+from lms.services.hubspot import HubSpotService
 from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
 from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
@@ -119,6 +120,7 @@ def includeme(config):
         "lms.services.jwt_oauth2_token.factory", iface=JWTOAuth2TokenService
     )
     config.register_service_factory("lms.services.rsa_key.factory", iface=RSAKeyService)
+    config.register_service_factory(HubSpotService.factory, iface=HubSpotService)
     config.register_service_factory(
         "lms.services.ltia_http.factory", iface=LTIAHTTPService
     )
@@ -146,7 +148,6 @@ def includeme(config):
     # Importing them here to:
     # - Don't pollute the lms.services namespace
     # - Ease some circular-dependency problems
-
     from lms.product.plugin.course_copy import (  # noqa: PLC0415
         CourseCopyFilesHelper,
         CourseCopyGroupsHelper,

--- a/lms/services/hubspot/__init__.py
+++ b/lms/services/hubspot/__init__.py
@@ -1,0 +1,1 @@
+from lms.services.hubspot.service import HubSpotService

--- a/lms/services/hubspot/_client.py
+++ b/lms/services/hubspot/_client.py
@@ -1,0 +1,23 @@
+from hubspot import HubSpot
+
+
+class HubSpotClient:
+    """A nicer client for the Hubspot API."""
+
+    def __init__(self, api_client: HubSpot):
+        self._api_client = api_client
+
+    def get_companies(self):
+        """Get companies from Hubspot."""
+        fields = [
+            "hs_object_id",
+            "name",
+            "lms_organization_id",
+            "current_deal__services_start",
+            "current_deal__services_end",
+        ]
+        yield from self._get_objects(self._api_client.crm.companies, fields)
+
+    @classmethod
+    def _get_objects(cls, accessor, fields: list[str]):
+        return accessor.get_all(properties=fields)

--- a/lms/services/hubspot/service.py
+++ b/lms/services/hubspot/service.py
@@ -36,7 +36,7 @@ class HubSpotService:
             HubSpotCompany,
             [
                 {
-                    "hs_object_id": int(company.properties["hs_object_id"]),
+                    "hubspot_id": int(company.properties["hs_object_id"]),
                     "name": company.properties["name"],
                     "lms_organization_id": company.properties["lms_organization_id"],
                     "current_deal_services_start": date_or_timestamp(
@@ -54,7 +54,7 @@ class HubSpotService:
                     self._region_code
                 )
             ],
-            index_elements=["hs_object_id"],
+            index_elements=["hubspot_id"],
             update_columns=[
                 "name",
                 "lms_organization_id",

--- a/lms/services/hubspot/service.py
+++ b/lms/services/hubspot/service.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+
+from hubspot import HubSpot
+from sqlalchemy import select
+from sqlalchemy.exc import MultipleResultsFound
+
+from lms.models.hubspot import HubSpotCompany
+from lms.services.hubspot._client import HubSpotClient
+from lms.services.upsert import bulk_upsert
+
+
+class HubSpotService:
+    def __init__(self, db, client: HubSpotClient, region_code: str):
+        self._db = db
+        self._client = client
+        self._region_code = region_code
+
+    def get_company(self, organization_id: str) -> HubSpotCompany | None:
+        """Get the HubSpot company associated to the given LMS organization ID."""
+        try:
+            return self._db.scalars(
+                select(HubSpotCompany).where(
+                    HubSpotCompany.lms_organization_id == organization_id
+                )
+            ).one_or_none()
+        except MultipleResultsFound:
+            # More than one company pointing to the same org is a data entry error, ignore them.
+            return None
+
+    def refresh_companies(self) -> None:
+        """Refresh all companies in the DB upserting accordingly."""
+        companies = self._client.get_companies()
+
+        bulk_upsert(
+            self._db,
+            HubSpotCompany,
+            [
+                {
+                    "hs_object_id": int(company.properties["hs_object_id"]),
+                    "name": company.properties["name"],
+                    "lms_organization_id": company.properties["lms_organization_id"],
+                    "current_deal_services_start": date_or_timestamp(
+                        company.properties["current_deal__services_start"]
+                    ),
+                    "current_deal_services_end": date_or_timestamp(
+                        company.properties["current_deal__services_end"]
+                    ),
+                }
+                for company in companies
+                # Only get companies with an org ID
+                if company.properties["lms_organization_id"]
+                # only for the current region
+                and company.properties["lms_organization_id"].startswith(
+                    self._region_code
+                )
+            ],
+            index_elements=["hs_object_id"],
+            update_columns=[
+                "name",
+                "lms_organization_id",
+                "current_deal_services_start",
+                "current_deal_services_end",
+            ],
+        )
+
+    @classmethod
+    def factory(cls, _context, request):
+        return cls(
+            db=request.db,
+            client=HubSpotClient(
+                HubSpot(access_token=request.registry.settings["hubspot_api_key"])
+            ),
+            region_code=request.registry.settings["region_code"],
+        )
+
+
+def date_or_timestamp(value: str | int | None) -> str | None:
+    """
+    Format either timestamp or already formatted dates as YYYY-MM-DD.
+
+    We seem to be getting different formats for the same fields,
+    coerce them to always be string formated dates.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value) / 1000).strftime("%Y-%m-%d")
+    except ValueError:
+        # Date is already formatted, return it verbatim
+        return value

--- a/lms/tasks/hubspot.py
+++ b/lms/tasks/hubspot.py
@@ -1,0 +1,12 @@
+from lms.services import HubSpotService
+from lms.tasks.celery import app
+
+
+@app.task
+def refresh_hubspot_data():
+    """Refresh the HubSpot companies, scheduled daily in h-periodic."""
+    with app.request_context() as request:  # pylint: disable=no-member
+        with request.tm:
+            hs = request.find_service(HubSpotService)
+
+            hs.refresh_companies()

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -161,6 +161,23 @@
         <div class="has-text-centered">No Application Instance</div>
     {% endif %}
 {% endmacro %}
+{% macro company_preview(request, company) %}
+    {% if company %}
+        <div class="block has-text-right">
+            <a class="button" target="_blank" href="https://app.hubspot.com/contacts/{{ request.registry.settings['hubspot_account_id'] }}/company/{{ company.hubspot_id}}">Open in HubSpot</a>
+        </div>
+        <div class="columns">
+            <div class="column is-full">{{ disabled_text_field("Name", company.name) }}</div>
+        </div>
+        <div class="columns">
+            <div class="column is-half">{{ disabled_text_field("Deal start", company.current_deal_services_start) }}</div>
+            <div class="column is-half">{{ disabled_text_field("Deal end", company.current_deal_services_end) }}</div>
+        </div>
+    {% else %}
+        <div class="has-text-centered">No company in HubSpot</div>
+    {% endif %}
+{% endmacro %}
+
 {% macro course_preview(request, course) %}
     <div class="block has-text-right">
         <a class="button"

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -78,6 +78,11 @@
                     </div>
                 </li>
                 <li class="tab-panel" data-section-id="usage">
+                    <fieldset class="box mt-6">
+                      <legend class="label has-text-centered">Company</legend>
+                      {{ macros.company_preview(request, company) }}
+                    </fieldset>
+
                     <fieldset class="box">
                         <legend class="label has-text-centered">Usage report</legend>
                         <form method="POST"

--- a/lms/templates/admin/organization/usage.html.jinja2
+++ b/lms/templates/admin/organization/usage.html.jinja2
@@ -6,6 +6,12 @@
         <legend class="label has-text-centered">Organization</legend>
         {{ macros.organization_preview(request,org) }}
     </fieldset>
+
+    <fieldset class="box mt-6">
+      <legend class="label has-text-centered">Company</legend>
+      {{ macros.organization_preview(request, company) }}
+    </fieldset>
+
     <fieldset class="box mt-6">
         <div class="columns">
             <div class="column is-half">{{ macros.disabled_text_field("Since", since.strftime("%Y-%m-%d") ) }}</div>

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -9,7 +9,7 @@ from lms.events import AuditTrailEvent
 from lms.models import Organization
 from lms.models.public_id import InvalidPublicId
 from lms.security import Permissions
-from lms.services import OrganizationService
+from lms.services import HubSpotService, OrganizationService
 from lms.services.organization import InvalidOrganizationParent
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
@@ -39,6 +39,7 @@ class AdminOrganizationViews:
         self.organization_service: OrganizationService = request.find_service(
             OrganizationService
         )
+        self.hubspot_service: HubSpotService = request.find_service(HubSpotService)
 
     @view_config(
         route_name="admin.organizations",
@@ -87,11 +88,12 @@ class AdminOrganizationViews:
         permission=Permissions.STAFF,
     )
     def show_organization(self):
-        org_id = self.request.matchdict["id_"]
+        org = self._get_org_or_404(self.request.matchdict["id_"])
 
         return {
-            "org": self._get_org_or_404(org_id),
-            "hierarchy_root": self.organization_service.get_hierarchy_root(org_id),
+            "org": org,
+            "company": self.hubspot_service.get_company(org.public_id),
+            "hierarchy_root": self.organization_service.get_hierarchy_root(org.id),
             "sort_by_name": lambda items: sorted(
                 items, key=lambda value: value.name or ""
             ),
@@ -208,7 +210,13 @@ class AdminOrganizationViews:
             )
             report = []
 
-        return {"org": org, "since": since, "until": until, "report": report}
+        return {
+            "org": org,
+            "since": since,
+            "until": until,
+            "report": report,
+            "company": self.hubspot_service.get_company(org.public_id),
+        }
 
     def _get_org_or_404(self, id_) -> Organization:
         if org := self.organization_service.get_by_id(id_):

--- a/requirements/bddtests.txt
+++ b/requirements/bddtests.txt
@@ -41,6 +41,7 @@ celery==5.3.6
 certifi==2023.11.17
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -116,6 +117,8 @@ h-vialib==1.3.0
     # via -r prod.txt
 httpretty==1.1.4
     # via -r bddtests.in
+hubspot-api-client==9.0.0
+    # via -r prod.txt
 hupper==1.12
     # via
     #   -r prod.txt
@@ -284,6 +287,7 @@ python-dateutil==2.8.2
     #   -r prod.txt
     #   celery
     #   faker
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -317,6 +321,7 @@ six==1.16.0
     # via
     #   -r prod.txt
     #   behave
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   parse-type
     #   python-dateutil
@@ -357,6 +362,7 @@ tzdata==2023.3
 urllib3==2.1.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,3 +4,4 @@ pip-sync-faster
 factory-boy
 pyramid-ipython
 supervisor
+h_testkit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,6 +39,7 @@ celery==5.3.6
 certifi==2023.11.17
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -111,6 +112,8 @@ h-assets==1.0.6
 h-pyramid-sentry==1.2.4
     # via -r prod.txt
 h-vialib==1.3.0
+    # via -r prod.txt
+hubspot-api-client==9.0.0
     # via -r prod.txt
 hupper==1.12
     # via
@@ -287,6 +290,7 @@ python-dateutil==2.8.2
     #   -r prod.txt
     #   celery
     #   faker
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -320,6 +324,7 @@ six==1.16.0
     # via
     #   -r prod.txt
     #   asttokens
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.29
@@ -365,6 +370,7 @@ tzdata==2023.3
 urllib3==2.1.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -111,6 +111,8 @@ h-assets==1.0.6
     # via -r prod.txt
 h-pyramid-sentry==1.2.4
     # via -r prod.txt
+h-testkit==1.0.1
+    # via -r dev.in
 h-vialib==1.3.0
     # via -r prod.txt
 hubspot-api-client==9.0.0

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -39,6 +39,7 @@ celery==5.3.6
 certifi==2023.11.17
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -116,6 +117,8 @@ h-vialib==1.3.0
     # via -r prod.txt
 httpretty==1.1.4
     # via -r functests.in
+hubspot-api-client==9.0.0
+    # via -r prod.txt
 hupper==1.12
     # via
     #   -r prod.txt
@@ -285,6 +288,7 @@ python-dateutil==2.8.2
     #   -r prod.txt
     #   celery
     #   faker
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -317,6 +321,7 @@ sentry-sdk==2.0.1
 six==1.16.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   python-dateutil
 soupsieve==2.5
@@ -357,6 +362,7 @@ tzdata==2023.3
 urllib3==2.1.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -74,6 +74,7 @@ certifi==2023.11.17
     #   -r bddtests.txt
     #   -r functests.txt
     #   -r tests.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -214,6 +215,11 @@ h-vialib==1.3.0
     #   -r functests.txt
     #   -r tests.txt
 httpretty==1.1.4
+    # via
+    #   -r bddtests.txt
+    #   -r functests.txt
+    #   -r tests.txt
+hubspot-api-client==9.0.0
     # via
     #   -r bddtests.txt
     #   -r functests.txt
@@ -519,6 +525,7 @@ python-dateutil==2.8.2
     #   celery
     #   faker
     #   freezegun
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -568,6 +575,7 @@ six==1.16.0
     #   -r functests.txt
     #   -r tests.txt
     #   behave
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   parse-type
     #   python-dateutil
@@ -630,6 +638,7 @@ urllib3==2.1.0
     #   -r bddtests.txt
     #   -r functests.txt
     #   -r tests.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -15,6 +15,7 @@ h-assets
 sentry-sdk
 h-pyramid-sentry
 h-vialib
+hubspot-api-client
 importlib_resources
 mailchimp-transactional
 marshmallow

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -25,6 +25,7 @@ celery==5.3.6
     # via -r prod.in
 certifi==2023.11.17
     # via
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -69,6 +70,8 @@ h-assets==1.0.6
 h-pyramid-sentry==1.2.4
     # via -r prod.in
 h-vialib==1.3.0
+    # via -r prod.in
+hubspot-api-client==9.0.0
     # via -r prod.in
 hupper==1.12
     # via pyramid
@@ -181,6 +184,7 @@ pyramid-tm==2.5
 python-dateutil==2.8.2
     # via
     #   celery
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -208,6 +212,7 @@ sentry-sdk==2.0.1
     #   h-pyramid-sentry
 six==1.16.0
     # via
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.29
@@ -238,6 +243,7 @@ tzdata==2023.3
     # via celery
 urllib3==2.1.0
     # via
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -41,6 +41,7 @@ celery==5.3.6
 certifi==2023.11.17
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -124,6 +125,8 @@ h-vialib==1.3.0
     # via -r prod.txt
 httpretty==1.1.4
     # via -r tests.in
+hubspot-api-client==9.0.0
+    # via -r prod.txt
 hupper==1.12
     # via
     #   -r prod.txt
@@ -302,6 +305,7 @@ python-dateutil==2.8.2
     #   celery
     #   faker
     #   freezegun
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -334,6 +338,7 @@ sentry-sdk==2.0.1
 six==1.16.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.29
@@ -372,6 +377,7 @@ tzdata==2023.3
 urllib3==2.1.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -37,6 +37,7 @@ celery==5.3.6
 certifi==2023.11.17
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk
@@ -101,6 +102,8 @@ h-assets==1.0.6
 h-pyramid-sentry==1.2.4
     # via -r prod.txt
 h-vialib==1.3.0
+    # via -r prod.txt
+hubspot-api-client==9.0.0
     # via -r prod.txt
 hupper==1.12
     # via
@@ -260,6 +263,7 @@ python-dateutil==2.8.2
     # via
     #   -r prod.txt
     #   celery
+    #   hubspot-api-client
     #   mailchimp-transactional
 referencing==0.32.0
     # via
@@ -292,6 +296,7 @@ sentry-sdk==2.0.1
 six==1.16.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   python-dateutil
 sqlalchemy==2.0.29
@@ -336,6 +341,7 @@ tzdata==2023.3
 urllib3==2.1.0
     # via
     #   -r prod.txt
+    #   hubspot-api-client
     #   mailchimp-transactional
     #   requests
     #   sentry-sdk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ TEST_SETTINGS = {
     "h_jwt_client_id": "TEST_JWT_CLIENT_ID",
     "h_jwt_client_secret": "TEST_JWT_CLIENT_SECRET",
     "h_authority": "lms.hypothes.is",
+    "hubspot_api_key": "HUBSPOT_API_KEY",
     "region_code": "us",
     "h_api_url_public": "https://h.example.com/api/",
     "h_api_url_private": "https://h.example.com/private/api/",

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -25,6 +25,7 @@ from tests.factories.group_info import GroupInfo
 from tests.factories.grouping import BlackboardGroup, CanvasGroup, CanvasSection, Course
 from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
+from tests.factories.hubspot_company import HubSpotCompany
 from tests.factories.jwt_oauth2_token import JWTOAuth2Token
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride

--- a/tests/factories/hubspot_company.py
+++ b/tests/factories/hubspot_company.py
@@ -1,0 +1,11 @@
+from factory import Faker, fuzzy, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+HubSpotCompany = make_factory(
+    models.HubSpotCompany,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    name=Faker("company"),
+    hs_object_id=fuzzy.FuzzyInteger(1, 9999999999),
+)

--- a/tests/factories/hubspot_company.py
+++ b/tests/factories/hubspot_company.py
@@ -7,5 +7,5 @@ HubSpotCompany = make_factory(
     models.HubSpotCompany,
     FACTORY_CLASS=SQLAlchemyModelFactory,
     name=Faker("company"),
-    hs_object_id=fuzzy.FuzzyInteger(1, 9999999999),
+    hubspot_id=fuzzy.FuzzyInteger(1, 9999999999),
 )

--- a/tests/unit/lms/services/hubspot/_client_test.py
+++ b/tests/unit/lms/services/hubspot/_client_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import create_autospec
+
+import pytest
+from hubspot import HubSpot
+
+from lms.services.hubspot._client import HubSpotClient
+
+
+class TestHubSpotClient:
+    def test_get_companies(self, api_client, svc):
+        companies = list(svc.get_companies())
+
+        api_client.crm.companies.get_all.assert_called_once_with(
+            properties=[
+                "hs_object_id",
+                "name",
+                "lms_organization_id",
+                "current_deal__services_start",
+                "current_deal__services_end",
+            ]
+        )
+        assert companies == list(api_client.crm.companies.get_all.return_value)
+
+    @pytest.fixture
+    def api_client(self):
+        return create_autospec(HubSpot, spec_set=True, instance=True)
+
+    @pytest.fixture
+    def svc(self, api_client):
+        return HubSpotClient(api_client=api_client)

--- a/tests/unit/lms/services/hubspot/service_test.py
+++ b/tests/unit/lms/services/hubspot/service_test.py
@@ -44,7 +44,7 @@ class TestHubSpotService:
 
         company = db_session.query(HubSpotCompany).one()
         assert company.name == "COMPANY"
-        assert company.hs_object_id == 100
+        assert company.hubspot_id == 100
 
     def test_factory(self, pyramid_request, db_session, HubSpotClient, HubSpot):
         svc = HubSpotService.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/services/hubspot/service_test.py
+++ b/tests/unit/lms/services/hubspot/service_test.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock, create_autospec, sentinel
+
+import pytest
+
+from lms.models import HubSpotCompany
+from lms.services.hubspot import HubSpotService
+from lms.services.hubspot._client import HubSpotClient
+from tests import factories
+
+
+class TestHubSpotService:
+    def test_get_company(self, svc):
+        org = factories.Organization()
+        factories.HubSpotCompany(lms_organization_id=org.public_id)
+
+        assert svc.get_company(org.public_id)
+
+    def test_get_company_multiple_mapping(self, svc):
+        org = factories.Organization()
+        factories.HubSpotCompany(lms_organization_id=org.public_id)
+        factories.HubSpotCompany(lms_organization_id=org.public_id)
+
+        assert not svc.get_company(org.public_id)
+
+    def test_refresh_companies(self, svc, hubspot_api_client, db_session):
+        hubspot_api_client.get_companies.return_value = [
+            Mock(properties={"lms_organization_id": None}),  # No org ID
+            # Org in another region
+            Mock(properties={"lms_organization_id": "es.org.XXX"}),
+            Mock(
+                properties={
+                    "lms_organization_id": "us.org.1",
+                    "name": "COMPANY",
+                    "hs_object_id": 100,
+                    "current_deal__services_start": "2024-01-01",
+                    "current_deal__services_end": None,
+                }
+            ),
+        ]
+
+        svc.refresh_companies()
+
+        hubspot_api_client.get_companies.assert_called_once()
+
+        company = db_session.query(HubSpotCompany).one()
+        assert company.name == "COMPANY"
+        assert company.hs_object_id == 100
+
+    def test_factory(self, pyramid_request, db_session, HubSpotClient, HubSpot):
+        svc = HubSpotService.factory(sentinel.context, pyramid_request)
+
+        HubSpot.assert_called_once_with(access_token="HUBSPOT_API_KEY")
+        HubSpotClient.assert_called_once_with(HubSpot.return_value)
+        assert svc._db == db_session  # noqa: SLF001
+        assert svc._region_code == "us"  # noqa: SLF001
+        assert svc._client == HubSpotClient.return_value  # noqa: SLF001
+
+    @pytest.fixture
+    def HubSpotClient(self, patch):
+        return patch("lms.services.hubspot.service.HubSpotClient")
+
+    @pytest.fixture
+    def HubSpot(self, patch):
+        return patch("lms.services.hubspot.service.HubSpot")
+
+    @pytest.fixture
+    def hubspot_api_client(self):
+        return create_autospec(HubSpotClient, spec_set=True, instance=True)
+
+    @pytest.fixture
+    def svc(self, db_session, hubspot_api_client):
+        return HubSpotService(
+            db=db_session, client=hubspot_api_client, region_code="us"
+        )

--- a/tests/unit/lms/tasks/hubpost_test.py
+++ b/tests/unit/lms/tasks/hubpost_test.py
@@ -1,0 +1,24 @@
+from contextlib import contextmanager
+
+import pytest
+
+from lms.tasks.hubspot import refresh_hubspot_data
+
+
+def test_refresh_hubspot_data(hubspot_service):
+    refresh_hubspot_data()
+
+    hubspot_service.refresh_companies.assert_called_once()
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.hubspot.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -29,6 +29,7 @@ from lms.services.group_info import GroupInfoService
 from lms.services.grouping import GroupingService
 from lms.services.h_api import HAPI
 from lms.services.http import HTTPService
+from lms.services.hubspot import HubSpotService
 from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
 from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
@@ -73,6 +74,7 @@ __all__ = (
     "grouping_service",
     "h_api",
     "http_service",
+    "hubspot_service",
     "jstor_service",
     "jwt_service",
     "jwt_oauth2_token_service",
@@ -238,6 +240,11 @@ def http_service(mock_service):
     http_service.request.return_value = factories.requests.Response()
 
     return http_service
+
+
+@pytest.fixture
+def hubspot_service(mock_service):
+    return mock_service(HubSpotService)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,8 @@ passenv =
     dev: DISABLE_KEY_ROTATION
     dev: EMAIL_PREFERENCES_SECRET
     dev: ADMIN_USERS
+    dev: HUBSPOT_API_KEY
+    dev: HUBSPOT_ACCOUNT_ID
 deps =
     pip-tools
     pip-sync-faster


### PR DESCRIPTION


## Why we do this

The goal is to use the data from HS to automatically generate usage report based on data (dates) from HS company deals.

As a first step we are just fetching the organizations to the LMS DB. We add that information to the admin pages mostly as a way to check the import.

Based on this information we'll generate to automated alerts in slack:

- Active orgs with no company
- Active orgs that map to more than one company.

These will need to be fixed in HS.



## Is this not duplicating what report does?

Yes, this information is already imported in report, see [01_hubspot_import.py
](https://github.com/hypothesis/report/blob/main/report/data_tasks/report/create_from_scratch/02_hubspot_read/02_data_import/01_hubspot_import.py)

The HB import is mostly copied and simplified from that code.


Reports imports a bunch of data from HS but it does it:

- In a global DB, instead of the LMS DB. We need this data both in the context of US and CA.
- Doesn't use celery but "data tasks". 
- Can't join this data with the full LMS dataset.

This is not expected to replace the import in report but it might in the future.



## Testing

- Needs https://github.com/hypothesis/devdata/pull/109
- Needs https://github.com/hypothesis/lms/pull/6294
- In `make shell`

```
from lms.tasks.hubspot import refresh_hubspot_data
refresh_hubspot_data.delay()
```


You'll get something like this on the server output:


```
Task lms.tasks.hubspot.refresh_hubspot_data[3e8b2729-ab06-4e4b-a6f5-2e2af81bab86] received
Task lms.tasks.hubspot.refresh_hubspot_data[3e8b2729-ab06-4e4b-a6f5-2e2af81bab86] succeeded in 25.548992632015143s: None
```


- In `make sql` update any of the new records to match any organization in the DB (find orgs IDs in  http://localhost:8001/admin/orgs)


```
update hubspot_company set lms_organization_id = 'us.lms.org.FFIHD9f1RwyLPfx14zM_7Q' where hs_object_id = 2489130686;
```


- Open the corresponding org in the admin pages, go to the "usage" page, there's now section there for the company.


