### PR TITLE
Generate an error code when the attempts limit has been reached

### DIFF
--- a/lms/error_code.py
+++ b/lms/error_code.py
@@ -17,3 +17,4 @@ class ErrorCode(str, Enum):
     )
     REUSED_CONSUMER_KEY = "reused_consumer_key"
     CANVAS_SUBMISSION_COURSE_NOT_AVAILABLE = "canvas_submission_course_not_available"
+    CANVAS_SUBMISSION_MAX_ATTEMPTS = "canvas_submission_max_attempts"

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -106,15 +106,6 @@ class LTI13GradingService(LTIGradingService):
             )
 
         except ExternalRequestError as err:
-            if (
-                err.status_code == 422
-                and "maximum number of allowed attempts has been reached"
-                in err.response.text
-            ):
-                LOG.error("record_result: maximum number of allowed attempts")
-                # We silently shallow this type of error
-                return None
-
             for expected_code, expected_text in [
                 # Blackboard
                 (400, "User could not be found:"),

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -118,6 +118,16 @@ class GradingViews:
             )
 
         except ExternalRequestError as err:
+            if (
+                err.status_code == 422
+                # This is LTI1.3 only. In LTI1.1 canvas behaves differently and allows this type of submissions.
+                and "maximum number of allowed attempts has been reached"
+                in err.response.text
+            ):
+                raise SerializableError(
+                    error_code=ErrorCode.CANVAS_SUBMISSION_MAX_ATTEMPTS
+                ) from err
+
             # This is Canvas only, we do the error handling here instead of the view to avoid
             # conflicting different, more general use cases.
             # This is what we get with the Course Participation end date has passed.

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -182,18 +182,6 @@ class TestLTI13GradingService:
         with pytest.raises(StudentNotInCourse):
             svc.record_result(sentinel.user_id, sentinel.score)
 
-    def test_record_result_doesnt_raise_max_submissions(self, svc, ltia_http_service):
-        ltia_http_service.request.side_effect = ExternalRequestError(
-            response=Mock(
-                status_code=422,
-                text="maximum number of allowed attempts has been reached",
-            )
-        )
-
-        response = svc.record_result(sentinel.user_id, sentinel.score)
-
-        assert not response
-
     def test_create_line_item(self, svc, ltia_http_service):
         response = svc.create_line_item(
             sentinel.resource_link_id,

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -42,6 +42,17 @@ class TestRecordCanvasSpeedgraderSubmission:
 
         lti_grading_service.record_result.assert_not_called()
 
+    def test_it_max_attempts(self, pyramid_request, lti_grading_service):
+        lti_grading_service.read_result.side_effect = ExternalRequestError(
+            response=Mock(
+                status_code=422,
+                text="maximum number of allowed attempts has been reached",
+            )
+        )
+
+        with pytest.raises(SerializableError):
+            GradingViews(pyramid_request).record_canvas_speedgrader_submission()
+
     @pytest.mark.parametrize(
         "error_message",
         ["Course not available for students", "This course has concluded"],


### PR DESCRIPTION
~~Blocked by: https://github.com/hypothesis/lms/pull/6289~~


For:

- https://github.com/hypothesis/support/issues/110


Now that we have a better error message for submissions related issues emit a known error code for these instead of silently not generating a submission.


## Testing 

- Log in as `eng+canvasstudent@hypothes.is` in Canvas
- Launch https://hypothesis.instructure.com/courses/319/assignments/4700
- Make one annotation.
- You'll get a generic `Grading submission failed` dialog.

