### PR TITLE
Rename StudentsActivity to AssignmentStudentsActivity

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -16,7 +16,7 @@ import OrderableActivityTable from './OrderableActivityTable';
 /**
  * Activity in a list of students that are part of a specific assignment
  */
-export default function StudentsActivity() {
+export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
   const { assignmentId } = useParams<{ assignmentId: string }>();

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -26,7 +26,7 @@ type AssignmentsTableRow = {
 /**
  * Activity in a list of assignments that are part of a specific course
  */
-export default function CourseAssignmentsActivity() {
+export default function CourseActivity() {
   const { courseId } = useParams<{ courseId: string }>();
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { Route, Switch } from 'wouter-preact';
 
 import AssignmentActivity from './AssignmentActivity';
-import CourseAssignmentsActivity from './CourseAssignmentsActivity';
+import CourseActivity from './CourseActivity';
 import DashboardFooter from './DashboardFooter';
 
 export default function DashboardApp() {
@@ -27,7 +27,7 @@ export default function DashboardApp() {
               <AssignmentActivity />
             </Route>
             <Route path="/course/:courseId">
-              <CourseAssignmentsActivity />
+              <CourseActivity />
             </Route>
           </Switch>
         </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
 import { Route, Switch } from 'wouter-preact';
 
+import AssignmentActivity from './AssignmentActivity';
 import CourseAssignmentsActivity from './CourseAssignmentsActivity';
 import DashboardFooter from './DashboardFooter';
-import StudentsActivity from './StudentsActivity';
 
 export default function DashboardApp() {
   return (
@@ -24,7 +24,7 @@ export default function DashboardApp() {
         <div className="mx-auto max-w-6xl">
           <Switch>
             <Route path="/assignment/:assignmentId">
-              <StudentsActivity />
+              <AssignmentActivity />
             </Route>
             <Route path="/course/:courseId">
               <CourseAssignmentsActivity />

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -6,9 +6,9 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
-import StudentsActivity, { $imports } from '../StudentsActivity';
+import AssignmentActivity, { $imports } from '../AssignmentActivity';
 
-describe('StudentsActivity', () => {
+describe('AssignmentActivity', () => {
   const students = [
     {
       display_name: 'b',
@@ -62,7 +62,7 @@ describe('StudentsActivity', () => {
   function createComponent() {
     return mount(
       <Config.Provider value={fakeConfig}>
-        <StudentsActivity />
+        <AssignmentActivity />
       </Config.Provider>,
     );
   }

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -6,11 +6,9 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
-import CourseAssignmentsActivity, {
-  $imports,
-} from '../CourseAssignmentsActivity';
+import CourseActivity, { $imports } from '../CourseActivity';
 
-describe('CourseAssignmentsActivity', () => {
+describe('CourseActivity', () => {
   const assignments = [
     {
       id: 2,
@@ -73,7 +71,7 @@ describe('CourseAssignmentsActivity', () => {
   function createComponent() {
     return mount(
       <Config.Provider value={fakeConfig}>
-        <CourseAssignmentsActivity />
+        <CourseActivity />
       </Config.Provider>,
     );
   }


### PR DESCRIPTION
To better prepare for how the dashboard is going to evolve, this PR renames `StudentsActivity` to `AssignmentActivity`, and `CourseAssignmentsActivity` to `CourseActivity`. That way, they can serve as top-level components for each dashboard page, and we can later extract specific table components and reuse them.
