### PR TITLE
Add breadcrumbs to the dashboard views

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -154,11 +154,20 @@ export type BaseDashboardStats = {
 };
 
 /**
+ * Response for `/api/dashboard/courses/{course_id}` call.
+ */
+export type Course = {
+  id: number;
+  title: string;
+};
+
+/**
  * Response for `/api/dashboard/assignments/{assignment_id}` call.
  */
 export type Assignment = {
   id: number;
   title: string;
+  course: Course;
 };
 
 /**
@@ -171,20 +180,9 @@ export type StudentStats = BaseDashboardStats & {
 export type StudentsStats = StudentStats[];
 
 /**
- * Response for `/api/dashboard/courses/{course_id}` call.
- */
-export type Course = {
-  id: number;
-  title: string;
-};
-
-/**
  * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
  */
-export type AssignmentStats = {
-  id: number;
-  title: string;
-  course: Course;
+export type AssignmentStats = Assignment & {
   stats: BaseDashboardStats;
 };
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -1,16 +1,13 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@hypothesis/frontend-shared';
+import { Card, CardContent, CardHeader } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useParams } from 'wouter-preact';
 
 import type { Assignment, StudentsStats } from '../../api-types';
 import { useConfig } from '../../config';
-import { useAPIFetch } from '../../utils/api';
+import { urlPath, useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
 import { replaceURLParams } from '../../utils/url';
+import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import OrderableActivityTable from './OrderableActivityTable';
 
 /**
@@ -31,12 +28,30 @@ export default function AssignmentActivity() {
 
   return (
     <Card>
-      <CardHeader fullWidth>
-        <CardTitle tagName="h2" data-testid="title">
+      <CardHeader
+        fullWidth
+        classes={classnames(
+          // Overwriting gap-x-2 and items-center from CardHeader
+          'flex-col !gap-x-0 !items-start',
+        )}
+      >
+        {assignment.data && (
+          <div className="mb-3 mt-1 w-full">
+            <DashboardBreadcrumbs
+              links={[
+                {
+                  title: assignment.data.course.title,
+                  href: urlPath`/courses/${String(assignment.data.course.id)}`,
+                },
+              ]}
+            />
+          </div>
+        )}
+        <h2 data-testid="title" className="text-lg text-brand font-semibold">
           {assignment.isLoading && 'Loading...'}
           {assignment.error && 'Could not load assignment title'}
           {assignment.data && title}
-        </CardTitle>
+        </h2>
       </CardHeader>
       <CardContent>
         <OrderableActivityTable

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
@@ -1,0 +1,65 @@
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  Link,
+} from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { Link as RouterLink } from 'wouter-preact';
+
+export type BreadcrumbLink = {
+  title: string;
+  href: string;
+};
+
+export type DashboardBreadcrumbsProps = {
+  links: BreadcrumbLink[];
+};
+
+function BreadcrumbLink({ title, href }: BreadcrumbLink) {
+  return (
+    <RouterLink href={href} asChild>
+      <Link underline="hover" variant="text-light" classes="truncate">
+        <ArrowLeftIcon className="inline-block md:hidden mr-1 align-sub" />
+        {title}
+      </Link>
+    </RouterLink>
+  );
+}
+
+/**
+ * Navigation breadcrumbs showing a list of links
+ */
+export default function DashboardBreadcrumbs({
+  links,
+}: DashboardBreadcrumbsProps) {
+  return (
+    <div
+      className="flex flex-row gap-0.5 w-full font-semibold"
+      data-testid="breadcrumbs-container"
+    >
+      {links.map(({ title, href }, index) => {
+        const isLastLink = index === links.length - 1;
+        return (
+          <span
+            key={`${index}${href}`}
+            className={classnames('gap-0.5', {
+              // In mobile devices, show only the last link
+              'md:flex hidden': !isLastLink,
+              'flex max-w-full': isLastLink,
+              // Distribute max width for every link as evenly as possible.
+              // These must be static values for Tailwind to detect them.
+              // See https://tailwindcss.com/docs/content-configuration#dynamic-class-names
+              'md:max-w-[50%]': links.length === 2,
+              'md:max-w-[33.333333%]': links.length === 3,
+              'md:max-w-[25%]': links.length === 4,
+              'md:max-w-[230px]': links.length > 4,
+            })}
+          >
+            <BreadcrumbLink href={href} title={title} />
+            {!isLastLink && <CaretRightIcon />}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -37,7 +37,14 @@ describe('AssignmentActivity', () => {
   beforeEach(() => {
     fakeUseAPIFetch = sinon.stub().callsFake(url => ({
       isLoading: false,
-      data: url.endsWith('stats') ? students : { title: 'The title' },
+      data: url.endsWith('stats')
+        ? students
+        : {
+            title: 'The title',
+            course: {
+              title: 'The course',
+            },
+          },
     }));
     fakeConfig = {
       dashboard: {
@@ -72,7 +79,7 @@ describe('AssignmentActivity', () => {
     fakeUseAPIFetch.returns({ isLoading: true });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const titleElement = wrapper.find('[data-testid="title"]');
     const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Loading...');
@@ -83,7 +90,7 @@ describe('AssignmentActivity', () => {
     fakeUseAPIFetch.returns({ error: new Error('Something failed') });
 
     const wrapper = createComponent();
-    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const titleElement = wrapper.find('[data-testid="title"]');
     const tableElement = wrapper.find('OrderableActivityTable');
 
     assert.equal(titleElement.text(), 'Could not load assignment title');
@@ -92,9 +99,9 @@ describe('AssignmentActivity', () => {
 
   it('shows expected title', () => {
     const wrapper = createComponent();
-    const titleElement = wrapper.find('CardTitle[data-testid="title"]');
+    const titleElement = wrapper.find('[data-testid="title"]');
     const tableElement = wrapper.find('OrderableActivityTable');
-    const expectedTitle = `Assignment: The title`;
+    const expectedTitle = 'Assignment: The title';
 
     assert.equal(titleElement.text(), expectedTitle);
     assert.equal(tableElement.prop('title'), expectedTitle);

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
@@ -1,0 +1,33 @@
+import { checkAccessibility } from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+
+import DashboardBreadcrumbs from '../DashboardBreadcrumbs';
+
+describe('DashboardBreadcrumbs', () => {
+  function createComponent(props = {}) {
+    return mount(<DashboardBreadcrumbs {...props} />);
+  }
+
+  [['foo', 'bar'], [], ['one', 'two', 'three']].forEach(links => {
+    it('shows expected amount of links', () => {
+      const wrapper = createComponent({
+        links: links.map(title => ({ title, href: `/${title}` })),
+      });
+
+      assert.equal(wrapper.find('BreadcrumbLink').length, links.length);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () =>
+        createComponent({
+          links: [
+            { title: 'Foo', href: '/foo' },
+            { title: 'Bar', href: '/bar' },
+          ],
+        }),
+    }),
+  );
+});


### PR DESCRIPTION
Add a breadcrumbs component to the dashboard pages.

> [!TIP]
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/lms/pull/6298/files?w=1).

https://github.com/hypothesis/lms/assets/2719332/7ede6c81-401b-41de-9fbb-caa5f1f0ca73

### Design decisions

I looked for examples on how some websites do breadcrumbs, and read some articles around the subject. Based on that, I decided breadcrumbs should never span multiple lines, specially in mobile devices, where they could end up using too much screen space.

Using a combination of tailwind classes, I implemented in a way that:

* Every link has a maximum width, and then they truncate their content with `text-overflow: ellipsis` individually.
    The space to reserve is calculated based on the total amount of links, with a porcentual max width for the first 4 links, and a fixed 230px max width when there's more than 4. This is just a fail safe, as it's unlikely we end up with so many levels.
    
    https://github.com/hypothesis/lms/assets/2719332/b972c251-34b2-4c7a-8b4d-13fd66b3c0a2

* In mobile devices, we try to display just a single item in the breadcrumbs, which represents the direct parent
    
    ![image](https://github.com/hypothesis/lms/assets/2719332/2e86be82-cd53-4372-a306-a4019ab45681)

 * Text overflow rules still apply in mobile devices, for items with long text.
 
    ![image](https://github.com/hypothesis/lms/assets/2719332/05f1281c-48ea-42c7-bacf-427265269589)

### Considerations

* When the breadcrumb has a single item, it's not immediately obvious that you can click on it. I'm thinking on making links underline always.
* In the top level, the breadcrumb doesn't show at all, making the header height mismatch with the rest. I don't think this is terrible though.