### PR TITLE
Use plural forms in all dashboard-related routes

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -231,29 +231,29 @@ def includeme(config):  # noqa: PLR0915
     )
 
     config.add_route(
-        "dashboard.launch.assignment", "/dashboard/launch/assignment/{assignment_id}"
+        "dashboard.launch.assignment", "/dashboard/launch/assignments/{assignment_id}"
     )
 
     config.add_route(
         "dashboard.assignment",
-        "/dashboard/organization/{public_id}/assignment/{assignment_id}",
+        "/dashboard/organizations/{public_id}/assignments/{assignment_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
         "dashboard.course",
-        "/dashboard/organization/{public_id}/course/{course_id}",
+        "/dashboard/organizations/{public_id}/courses/{course_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
 
     config.add_route(
-        "dashboard.api.assignment", "/dashboard/api/assignment/{assignment_id}"
+        "dashboard.api.assignment", "/dashboard/api/assignments/{assignment_id}"
     )
     config.add_route(
         "dashboard.api.assignment.stats",
-        "/dashboard/api/assignment/{assignment_id}/stats",
+        "/dashboard/api/assignments/{assignment_id}/stats",
     )
-    config.add_route("dashboard.api.course", "/dashboard/api/course/{course_id}")
+    config.add_route("dashboard.api.course", "/dashboard/api/courses/{course_id}")
     config.add_route(
         "dashboard.api.course.assignments.stats",
-        "/dashboard/api/course/{course_id}/assignments/stats",
+        "/dashboard/api/courses/{course_id}/assignments/stats",
     )

--- a/lms/security.py
+++ b/lms/security.py
@@ -152,7 +152,7 @@ class SecurityPolicy:
             # LTUser serialized in a from for non deep-linked assignment configuration
             return FormBearerTokenLTIUserPolicy()
 
-        if path.startswith("/dashboard/organization/"):
+        if path.startswith("/dashboard/organizations/"):
             return CookiesBearerTokenLTIUserPolicy()
 
         if path in {"/email/preferences", "/email/unsubscribe"}:

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -154,7 +154,7 @@ export type BaseDashboardStats = {
 };
 
 /**
- * Response for `/dashboard/api/assignment/{assignment_id}` call.
+ * Response for `/dashboard/api/assignments/{assignment_id}` call.
  */
 export type Assignment = {
   id: number;
@@ -162,7 +162,7 @@ export type Assignment = {
 };
 
 /**
- * Response for `/dashboard/api/assignment/{assignment_id}/stats` call.
+ * Response for `/dashboard/api/assignments/{assignment_id}/stats` call.
  */
 export type StudentStats = BaseDashboardStats & {
   display_name: string;
@@ -171,7 +171,7 @@ export type StudentStats = BaseDashboardStats & {
 export type StudentsStats = StudentStats[];
 
 /**
- * Response for `/dashboard/api/course/{course_id}` call.
+ * Response for `/dashboard/api/courses/{course_id}` call.
  */
 export type Course = {
   id: number;
@@ -179,7 +179,7 @@ export type Course = {
 };
 
 /**
- * Response for `/dashboard/api/course/{course_id}/stats` call.
+ * Response for `/dashboard/api/courses/{course_id}/assignments/stats` call.
  */
 export type AssignmentStats = {
   id: number;

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/dashboard/organization/:organizationId" nest>
+          <Route path="/dashboard/organizations/:organizationId" nest>
             <DashboardApp />
           </Route>
           <Route path="/email/preferences">

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -80,7 +80,7 @@ export default function CourseActivity() {
               return <div className="text-right">{stats[field]}</div>;
             } else if (field === 'title') {
               return (
-                <RouterLink href={`/assignment/${stats.id}`} asChild>
+                <RouterLink href={`/assignments/${stats.id}`} asChild>
                   <Link>{stats.title}</Link>
                 </RouterLink>
               );

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -41,8 +41,8 @@ describe('AssignmentActivity', () => {
     fakeConfig = {
       dashboard: {
         routes: {
-          assignment: '/api/assignment/:assignment_id',
-          assignment_stats: '/api/assignment/:assignment_id/stats',
+          assignment: '/api/assignments/:assignment_id',
+          assignment_stats: '/api/assignments/:assignment_id/stats',
         },
       },
     };

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -177,7 +177,7 @@ describe('CourseActivity', () => {
       assert.equal(itemWrapper.text(), expectedValue);
 
       if (fieldName === 'title') {
-        assert.equal(itemWrapper.prop('href'), '/assignment/123');
+        assert.equal(itemWrapper.prop('href'), '/assignments/123');
       }
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -75,7 +75,7 @@ describe('AppRoot', () => {
     {
       config: { mode: 'dashboard' },
       appComponent: 'DashboardApp',
-      route: '/dashboard/organization/ORG_ID/assignment/123',
+      route: '/dashboard/organizations/ORG_ID/assignments/123',
     },
     {
       config: { mode: 'error-dialog' },

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -102,7 +102,7 @@ class DashboardViews:
             secure=not self.request.registry.settings["dev"],
             httponly=True,
             # Scope the cookie to all the org endpoints
-            path=f"/dashboard/organization/{lti_user.application_instance.organization._public_id}",  # noqa: SLF001
+            path=f"/dashboard/organizations/{lti_user.application_instance.organization._public_id}",  # noqa: SLF001
             max_age=60 * 60 * 24,  # 24 hours, matches the lifetime of the auth_token
         )
         return response

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -689,10 +689,10 @@ class TestEnableDashboardMode:
         assert config["mode"] == JSConfig.Mode.DASHBOARD
         assert config["dashboard"] == {
             "routes": {
-                "assignment": "/dashboard/api/assignment/:assignment_id",
-                "assignment_stats": "/dashboard/api/assignment/:assignment_id/stats",
-                "course": "/dashboard/api/course/:course_id",
-                "course_assignment_stats": "/dashboard/api/course/:course_id/assignments/stats",
+                "assignment": "/dashboard/api/assignments/:assignment_id",
+                "assignment_stats": "/dashboard/api/assignments/:assignment_id/stats",
+                "course": "/dashboard/api/courses/:course_id",
+                "course_assignment_stats": "/dashboard/api/courses/:course_id/assignments/stats",
             }
         }
 
@@ -708,7 +708,7 @@ class TestEnableInstructorDashboardEntryPoint:
         assert config["hypothesisClient"]["dashboard"] == {
             "showEntryPoint": True,
             "authTokenRPCMethod": "requestAuthToken",
-            "entryPointURL": f"http://example.com/dashboard/launch/assignment/{assignment.id}",
+            "entryPointURL": f"http://example.com/dashboard/launch/assignments/{assignment.id}",
             "authFieldName": "authorization",
         }
 

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -429,7 +429,7 @@ class TestSecurityPolicy:
         assert user_id == get_policy.return_value.forget.return_value
 
     @pytest.mark.parametrize(
-        "path", ["/dashboard/api/assignment/10", "/dashboard/organization/ORGID"]
+        "path", ["/dashboard/api/assignments/10", "/dashboard/organizations/ORGID"]
     )
     def test_get_policy_google_when_available(
         self, pyramid_request, path, LMSGoogleSecurityPolicy
@@ -468,18 +468,21 @@ class TestSecurityPolicy:
             ("/api/canvas/pages/proxy", QueryStringBearerTokenLTIUserPolicy),
             ("/api/canvas/files", HeadersBearerTokenLTIUserPolicy),
             ("/api/blackboard/groups", HeadersBearerTokenLTIUserPolicy),
-            ("/dashboard/api/assignment/X", HeadersBearerTokenLTIUserPolicy),
-            ("/dashboard/api/assignment/X/stats", HeadersBearerTokenLTIUserPolicy),
-            ("/dashboard/api/course/X", HeadersBearerTokenLTIUserPolicy),
-            ("/dashboard/api/course/X/stats", HeadersBearerTokenLTIUserPolicy),
+            ("/dashboard/api/assignments/X", HeadersBearerTokenLTIUserPolicy),
+            ("/dashboard/api/assignments/X/stats", HeadersBearerTokenLTIUserPolicy),
+            ("/dashboard/api/courses/X", HeadersBearerTokenLTIUserPolicy),
+            (
+                "/dashboard/api/courses/X/assignments/stats",
+                HeadersBearerTokenLTIUserPolicy,
+            ),
             ("/lti/1.3/deep_linking/form_fields", HeadersBearerTokenLTIUserPolicy),
             ("/lti/1.1/deep_linking/form_fields", HeadersBearerTokenLTIUserPolicy),
             ("/lti/reconfigure", HeadersBearerTokenLTIUserPolicy),
             ("/assignment", FormBearerTokenLTIUserPolicy),
             ("/assignment/edit", FormBearerTokenLTIUserPolicy),
-            ("/dashboard/launch/assignment/10", FormBearerTokenLTIUserPolicy),
+            ("/dashboard/launch/assignments/10", FormBearerTokenLTIUserPolicy),
             (
-                "/dashboard/organization/ORGID/assignment/10",
+                "/dashboard/organizations/ORGID/assignments/10",
                 CookiesBearerTokenLTIUserPolicy,
             ),
         ],

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -57,7 +57,7 @@ class TestAdminAssignmentViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/organization/{organization._public_id}/assignment/{assignment.id}",  # noqa: SLF001
+                "location": f"http://example.com/dashboard/organizations/{organization._public_id}/assignments/{assignment.id}",  # noqa: SLF001
             }
         )
 

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -27,12 +27,12 @@ class TestDashboardViews:
         )
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/organization/{organization._public_id}/assignment/sentinel.id",
+                "location": f"http://example.com/dashboard/organizations/{organization._public_id}/assignments/sentinel.id",
             }
         )
         assert (
             response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organization/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     @freeze_time("2024-04-01 12:00:00")
@@ -51,7 +51,7 @@ class TestDashboardViews:
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organization/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     @freeze_time("2024-04-01 12:00:00")
@@ -68,7 +68,7 @@ class TestDashboardViews:
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organization/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     def test_assignment_show_with_no_lti_user(


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6296

As agreed with the broader team, this PR replaces all occurrences of `organization`, `assignment` and `course` by `organizations`, `assignments` and `courses` in all dashboard routes.