### PR TITLE
Use human-friendly dates in dashboard tables

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
+import { formatDateTime } from '../../../utils/date';
 import AssignmentActivity, { $imports } from '../AssignmentActivity';
 
 describe('AssignmentActivity', () => {
@@ -110,7 +111,10 @@ describe('AssignmentActivity', () => {
     { fieldName: 'display_name', expectedValue: 'Jane Doe' },
     { fieldName: 'annotations', expectedValue: '37' },
     { fieldName: 'replies', expectedValue: '25' },
-    { fieldName: 'last_activity', expectedValue: '2024-01-01 10:35' },
+    {
+      fieldName: 'last_activity',
+      expectedValue: formatDateTime(new Date('2024-01-01T10:35:18')),
+    },
   ].forEach(({ fieldName, expectedValue }) => {
     it('renders every field as expected', () => {
       const studentStats = {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
+import { formatDateTime } from '../../../utils/date';
 import CourseActivity, { $imports } from '../CourseActivity';
 
 describe('CourseActivity', () => {
@@ -151,7 +152,10 @@ describe('CourseActivity', () => {
     { fieldName: 'title', expectedValue: 'Frog dissection' },
     { fieldName: 'annotations', expectedValue: '37' },
     { fieldName: 'replies', expectedValue: '25' },
-    { fieldName: 'last_activity', expectedValue: '2024-01-01 10:35' },
+    {
+      fieldName: 'last_activity',
+      expectedValue: formatDateTime(new Date('2024-01-01T10:35:18')),
+    },
   ].forEach(({ fieldName, expectedValue }) => {
     it('renders every field as expected', () => {
       const assignmentStats = {

--- a/lms/static/scripts/frontend_apps/utils/date.ts
+++ b/lms/static/scripts/frontend_apps/utils/date.ts
@@ -1,12 +1,60 @@
 /**
- * Formats a date as `YYYY-MM-DD hh:mm`, using 24h and system timezone.
+ * Map of stringified `DateTimeFormatOptions` to cached `DateTimeFormat` instances.
  */
-export function formatDateTime(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
-  const hours = `${date.getHours()}`.padStart(2, '0');
-  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+let formatters = new Map<string, Intl.DateTimeFormat>();
 
-  return `${year}-${month}-${day} ${hours}:${minutes}`;
+/**
+ * Clears the cache of formatters.
+ */
+export function clearFormatters() {
+  formatters = new Map<string, Intl.DateTimeFormat>();
+}
+
+type IntlType = typeof window.Intl;
+
+/**
+ * Return date string formatted with `options`.
+ *
+ * This is a caching wrapper for `Intl.DateTimeFormat.format`, useful because
+ * constructing a `DateTimeFormat` is expensive.
+ *
+ * @param Intl - Test seam. JS `Intl` API implementation.
+ */
+function format(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  /* istanbul ignore next */
+  Intl: IntlType = window.Intl,
+): string {
+  const key = JSON.stringify(options);
+  let formatter = formatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(undefined, options);
+    formatters.set(key, formatter);
+  }
+  return formatter.format(date);
+}
+
+/**
+ * Formats a date as an absolute string in a human-readable format.
+ *
+ * The exact format will vary depending on the locale, but the verbosity will
+ * be consistent across locales. In en-US for example this will look like:
+ *
+ *  "Dec 17, 2017, 10:00 AM"
+ *
+ * @param Intl - Test seam. JS `Intl` API implementation.
+ */
+export function formatDateTime(date: Date, Intl?: IntlType): string {
+  return format(
+    date,
+    {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+    Intl,
+  );
 }

--- a/lms/static/scripts/frontend_apps/utils/test/date-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/date-test.js
@@ -1,13 +1,46 @@
-import { formatDateTime } from '../date';
+import { clearFormatters, formatDateTime } from '../date';
 
-describe('formatDateTime', () => {
-  [
-    new Date(Date.UTC(2023, 11, 20, 3, 5, 38)),
-    new Date('2020-05-04T23:02:01+05:00'),
-  ].forEach(date => {
-    it('returns right format for provided date', () => {
-      const expectedDateRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
-      assert.match(formatDateTime(date), expectedDateRegex);
+describe('date', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.useFakeTimers();
+
+    // Clear the formatters cache so that mocked formatters
+    // from one test run don't affect the next.
+    clearFormatters();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('formatDateTime', () => {
+    // Normalize "special" spaces (eg. "\u202F") to standard spaces.
+    function normalizeSpaces(str) {
+      return str.normalize('NFKC');
+    }
+
+    it('returns absolute formatted date', () => {
+      const date = new Date('2020-05-04T23:02:01');
+      const fakeIntl = locale => ({
+        DateTimeFormat: function (_, options) {
+          return new Intl.DateTimeFormat(locale, options);
+        },
+      });
+
+      assert.equal(
+        normalizeSpaces(formatDateTime(date, fakeIntl('en-US'))),
+        'May 04, 2020, 11:02 PM',
+      );
+
+      clearFormatters();
+
+      assert.equal(
+        normalizeSpaces(formatDateTime(date, fakeIntl('de-DE'))),
+        '04. Mai 2020, 23:02',
+      );
     });
   });
 });


### PR DESCRIPTION
Use a `Intl.DateTimeFormatter` instance to format last activity dates in dashboard tables, making sure they are more human-friendly than current `YYYY-MM-DD hh:mm` format.

Chosen format options translate into something like `Dec 17, 2017, 10:00 AM` for en-US, which is not too long, and therefore fits nicely in the table.