### PR TITLE
Take an explicit list of org ids instead of querying for them in course service

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -14,21 +14,13 @@ from lms.models import (
 )
 from lms.product import Product
 from lms.services.grouping import GroupingService
-from lms.services.organization import OrganizationService
 
 
 class CourseService:
-    def __init__(
-        self,
-        db,
-        application_instance,
-        grouping_service: GroupingService,
-        organization_service: OrganizationService,
-    ):
+    def __init__(self, db, application_instance, grouping_service: GroupingService):
         self._db = db
         self._application_instance = application_instance
         self._grouping_service = grouping_service
-        self._organization_service = organization_service
 
     def any_with_setting(self, group, key, value=True) -> bool:
         """
@@ -84,7 +76,7 @@ class CourseService:
         h_id: str | None = None,
         name: str | None = None,
         limit: int = 100,
-        organization: Organization | None = None,
+        organization_ids: list[int] | None = None,
     ) -> list[Course]:
         query = self._db.query(Course)
 
@@ -100,10 +92,7 @@ class CourseService:
         if name:
             query = query.filter(full_text_match(Course.lms_name, name))
 
-        if organization:
-            organization_ids = self._organization_service.get_hierarchy_ids(
-                organization.id, include_parents=False
-            )
+        if organization_ids:
             query = (
                 query.join(
                     ApplicationInstance,
@@ -264,5 +253,4 @@ def course_service_factory(_context, request):
             request.lti_user.application_instance if request.lti_user else None
         ),
         grouping_service=request.find_service(name="grouping"),
-        organization_service=request.find_service(OrganizationService),
     )

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -63,10 +63,14 @@ class AdminCourseViews:
         if flash_validation(self.request, SearchCourseSchema):
             return {}
 
-        organization = None
+        organization_ids = []
         if org_public_id := self.request.params.get("org_public_id", "").strip():
             try:
                 organization = self.organization_service.get_by_public_id(org_public_id)
+                organization_ids = self.organization_service.get_hierarchy_ids(
+                    organization.id, include_parents=False
+                )
+
             except InvalidPublicId as err:
                 self.request.session.flash(str(err), "errors")
                 return {}
@@ -76,7 +80,7 @@ class AdminCourseViews:
             name=self.request.params.get("name", "").strip(),
             context_id=self.request.params.get("context_id", "").strip(),
             h_id=self.request.params.get("h_id", "").strip(),
-            organization=organization,
+            organization_ids=organization_ids,
         )
 
         return {"courses": courses}

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import Mock, sentinel
 
 import pytest
 from pyramid.httpexceptions import HTTPNotFound
@@ -40,7 +40,7 @@ class TestAdminCourseViews:
             name="NAME",
             context_id="PUBLIC_ID",
             h_id="H_ID",
-            organization=None,
+            organization_ids=[],
         )
         assert result == {"courses": course_service.search.return_value}
 
@@ -48,16 +48,19 @@ class TestAdminCourseViews:
         self, pyramid_request, views, organization_service, course_service
     ):
         pyramid_request.params["org_public_id"] = " PUBLIC_ID "
-        organization_service.get_by_public_id.return_value = sentinel.org
+        organization_service.get_by_public_id.return_value = Mock(id=sentinel.id)
 
         views.search()
 
+        organization_service.get_hierarchy_ids.assert_called_once_with(
+            sentinel.id, include_parents=False
+        )
         course_service.search.assert_called_once_with(
             id_="",
             name="",
             context_id="DUMMY-CONTEXT-ID",
             h_id="",
-            organization=sentinel.org,
+            organization_ids=organization_service.get_hierarchy_ids.return_value,
         )
 
     def test_search_invalid_public_id(
@@ -80,7 +83,7 @@ class TestAdminCourseViews:
         views.search()
 
         course_service.search.assert_called_once_with(
-            id_="", name="", context_id="DUMMY-CONTEXT-ID", h_id="", organization=None
+            id_="", name="", context_id="DUMMY-CONTEXT-ID", h_id="", organization_ids=[]
         )
 
     @pytest.fixture


### PR DESCRIPTION
This allows callers to decide if the want to to include children, parents or single orgs.