### PR TITLE
Basic listing of courses in an organization

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -266,6 +266,9 @@ class JSConfig:
                         course_assignment_stats=self._to_frontend_template(
                             "api.dashboard.course.assignments.stats"
                         ),
+                        organization_courses=self._to_frontend_template(
+                            "api.dashboard.organizations.courses"
+                        ),
                     ),
                 ),
             }

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -252,7 +252,7 @@ def includeme(config):  # noqa: PLR0915
 
     config.add_route(
         "api.dashboard.organizations.courses",
-        "/api/dashboard/organizations/{public_id}/courses",
+        "/api/dashboard/organizations/{organization_public_id}/courses",
     )
 
     config.add_route(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -251,6 +251,11 @@ def includeme(config):  # noqa: PLR0915
     )
 
     config.add_route(
+        "api.dashboard.organizations.courses",
+        "/api/dashboard/organizations/{public_id}/courses",
+    )
+
+    config.add_route(
         "api.dashboard.assignment", "/api/dashboard/assignments/{assignment_id}"
     )
     config.add_route(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -251,6 +251,12 @@ def includeme(config):  # noqa: PLR0915
     )
 
     config.add_route(
+        "dashboard.organization",
+        "/dashboard/organizations/{organization_public_id}",
+        factory="lms.resources.dashboard.DashboardResource",
+    )
+
+    config.add_route(
         "api.dashboard.organizations.courses",
         "/api/dashboard/organizations/{organization_public_id}/courses",
     )

--- a/lms/security.py
+++ b/lms/security.py
@@ -374,6 +374,9 @@ def get_lti_user(request) -> LTIUser | None:
 
 
 def _get_user(request) -> User | None:
+    if not request.lti_user:
+        return None
+
     return request.find_service(UserService).get(
         request.lti_user.application_instance, request.lti_user.user_id
     )

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -7,6 +7,7 @@ from lms.db import full_text_match
 from lms.models import (
     ApplicationInstance,
     Course,
+    GroupingMembership,
     CourseGroupsExportedFromH,
     Grouping,
     Organization,
@@ -77,6 +78,7 @@ class CourseService:
         name: str | None = None,
         limit: int = 100,
         organization_ids: list[int] | None = None,
+        user: User | None = None,
     ) -> list[Course]:
         query = self._db.query(Course)
 
@@ -100,6 +102,14 @@ class CourseService:
                 )
                 .join(Organization)
                 .filter(Organization.id.in_(organization_ids))
+            )
+
+        if user:
+            # Only courses `user` belongs to
+            query = (
+                query.join(GroupingMembership)
+                .join(User)
+                .filter(User.h_userid == user.h_userid)
             )
 
         return query.limit(limit).all()

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -7,9 +7,9 @@ from lms.db import full_text_match
 from lms.models import (
     ApplicationInstance,
     Course,
-    GroupingMembership,
     CourseGroupsExportedFromH,
     Grouping,
+    GroupingMembership,
     Organization,
     User,
 )

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -70,8 +70,7 @@ class OrganizationService:
         # Get all the objects in the hierarchy, to ensure they are cached by
         # SQLAlchemy, and should be fast to access.
         hierarchy = (
-            self._db_session.query(Organization)
-            .filter(
+            self._db_session.query(Organization).filter(
                 Organization.id.in_(self.get_hierarchy_ids(id_, include_parents=True))
             )
             # Order by parent id, this will cause the root (if any) to be last.
@@ -362,8 +361,7 @@ class OrganizationService:
         # https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE
         cols = [Organization.id, Organization.parent_id]
         base_case = (
-            self._db_session.query(*cols)
-            .filter(Organization.id == id_)
+            self._db_session.query(*cols).filter(Organization.id == id_)
             # The name of the CTE is arbitrary, but must be present
             .cte("organizations", recursive=True)
         )

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -395,8 +395,8 @@ class OrganizationService:
             .join(Course)
             .join(ApplicationInstance)
             .where(
-                GroupingMembership.user == user,
-                ApplicationInstance.organization == organization,
+                GroupingMembership.user_id == user.id,
+                ApplicationInstance.organization_id == organization.id,
             )
             .limit(1)
         )

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -7,7 +7,8 @@ from lms.js_config_types import (
 )
 from lms.security import Permissions
 from lms.services.h_api import HAPI
-from lms.views.dashboard.base import get_request_course
+from lms.services.organization import OrganizationService
+from lms.views.dashboard.base import get_request_course, get_request_organization
 
 
 class CourseViews:
@@ -15,6 +16,21 @@ class CourseViews:
         self.request = request
         self.course_service = request.find_service(name="course")
         self.h_api = request.find_service(HAPI)
+        self.organization_service = request.find_service(OrganizationService)
+
+    @view_config(
+        route_name="api.dashboard.organizations.courses",
+        request_method="GET",
+        renderer="json",
+        permission=Permissions.DASHBOARD_VIEW,
+    )
+    def get_organization_courses(self) -> list[APICourse]:
+        org = get_request_organization(self.request, self.organization_service)
+        print(self.request.user)
+        courses = self.course_service.search(
+            limit=None, organization_ids=[org.id], user=self.request.user
+        )
+        return [APICourse(id=course.id, title=course.lms_name) for course in courses]
 
     @view_config(
         route_name="api.dashboard.course",

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -26,7 +26,6 @@ class CourseViews:
     )
     def get_organization_courses(self) -> list[APICourse]:
         org = get_request_organization(self.request, self.organization_service)
-        print(self.request.user)
         courses = self.course_service.search(
             limit=None, organization_ids=[org.id], user=self.request.user
         )

--- a/lms/views/dashboard/base.py
+++ b/lms/views/dashboard/base.py
@@ -31,3 +31,19 @@ def get_request_course(request, course_service):
         raise HTTPUnauthorized()
 
     return course
+
+
+def get_request_organization(request, organization_service):
+    public_id = f"{request.registry.settings['region_code']}.lms.org.{request.matchdict['organization_public_id']}"
+    organization = organization_service.get_by_public_id(public_id)
+    if not organization:
+        raise HTTPNotFound()
+
+    if request.has_permission(Permissions.STAFF):
+        # STAFF members in our admin pages can access all organizations
+        return organization
+
+    if not organization_service.is_member(organization, request.user):
+        raise HTTPUnauthorized()
+
+    return organization

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -704,6 +704,7 @@ class TestEnableDashboardMode:
                 "assignment_stats": "/api/dashboard/assignments/:assignment_id/stats",
                 "course": "/api/dashboard/courses/:course_id",
                 "course_assignment_stats": "/api/dashboard/courses/:course_id/assignments/stats",
+                "organization_courses": "/api/dashboard/organizations/:organization_public_id/courses",
             }
         }
 

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -676,6 +676,11 @@ class TestGetUser:
         )
         assert user == user_service.get.return_value
 
+    def test_it_when_no_lti_user(self, pyramid_request):
+        pyramid_request.lti_user = None
+
+        assert not _get_user(pyramid_request)
+
 
 @pytest.fixture(autouse=True)
 def AuthTktCookieHelper(patch):

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -300,6 +300,18 @@ class TestCourseService:
 
         assert result == [course]
 
+    def test_search_by_user(self, svc, db_session):
+        user = factories.User()
+        course = factories.Course()
+        factories.Course.create_batch(10)
+        factories.GroupingMembership(grouping=course, user=user)
+        # Ensure ids are written
+        db_session.flush()
+
+        result = svc.search(user=user)
+
+        assert result == [course]
+
     def test_search_limit(self, svc):
         orgs = factories.Course.create_batch(10)
 

--- a/tests/unit/lms/services/organization_test.py
+++ b/tests/unit/lms/services/organization_test.py
@@ -314,6 +314,18 @@ class TestOrganizationService:
 
         assert "no courses with activity" in str(error.value).lower()
 
+    def test_is_member(self, svc, db_session):
+        org = factories.Organization()
+        ai = factories.ApplicationInstance(organization=org)
+        user = factories.User()
+        other_user = factories.User()
+        course = factories.Course(application_instance=ai)
+        factories.GroupingMembership(user=user, grouping=course)
+        db_session.flush()
+
+        assert svc.is_member(org, user)
+        assert not svc.is_member(org, other_user)
+
     @pytest.fixture
     def org_with_parent(self, db_session):
         org_with_parent = factories.Organization.create(

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -5,7 +5,7 @@ import pytest
 from lms.views.dashboard.api.course import CourseViews
 from tests import factories
 
-pytestmark = pytest.mark.usefixtures("course_service", "h_api")
+pytestmark = pytest.mark.usefixtures("course_service", "h_api", "organization_service")
 
 
 class TestCourseViews:

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -16,7 +16,7 @@ class TestCourseViews:
         courses = factories.Course.create_batch(5)
         organization_service.get_by_public_id.return_value = org
         course_service.search.return_value = courses
-        pyramid_request.matchdict["public_id"] = sentinel.id_
+        pyramid_request.matchdict["organization_public_id"] = sentinel.id_
         db_session.flush()
 
         response = views.get_organization_courses()

--- a/tests/unit/lms/views/dashboard/base_test.py
+++ b/tests/unit/lms/views/dashboard/base_test.py
@@ -86,7 +86,7 @@ class TestBase:
         pyramid_request,
         organization_service,
     ):
-        pyramid_request.matchdict["public_id"] = sentinel.id
+        pyramid_request.matchdict["organization_public_id"] = sentinel.id
         organization_service.get_by_public_id.return_value = None
 
         with pytest.raises(HTTPNotFound):
@@ -97,7 +97,7 @@ class TestBase:
         pyramid_request,
         organization_service,
     ):
-        pyramid_request.matchdict["public_id"] = sentinel.id
+        pyramid_request.matchdict["organization_public_id"] = sentinel.id
         organization_service.is_member.return_value = False
 
         with pytest.raises(HTTPUnauthorized):
@@ -107,13 +107,13 @@ class TestBase:
         self, pyramid_request, organization_service, pyramid_config
     ):
         pyramid_config.testing_securitypolicy(permissive=True)
-        pyramid_request.matchdict["public_id"] = sentinel.id
+        pyramid_request.matchdict["organization_public_id"] = sentinel.id
         organization_service.is_member.return_value = False
 
         assert get_request_organization(pyramid_request, organization_service)
 
     def test_get_request_organization(self, pyramid_request, organization_service):
-        pyramid_request.matchdict["public_id"] = sentinel.id
+        pyramid_request.matchdict["organization_public_id"] = sentinel.id
         organization_service.is_member.return_value = True
 
         assert get_request_organization(pyramid_request, organization_service)

--- a/tests/unit/lms/views/dashboard/base_test.py
+++ b/tests/unit/lms/views/dashboard/base_test.py
@@ -3,7 +3,11 @@ from unittest.mock import sentinel
 import pytest
 from pyramid.httpexceptions import HTTPNotFound, HTTPUnauthorized
 
-from lms.views.dashboard.base import get_request_assignment, get_request_course
+from lms.views.dashboard.base import (
+    get_request_assignment,
+    get_request_course,
+    get_request_organization,
+)
 
 pytestmark = pytest.mark.usefixtures("h_api", "assignment_service")
 
@@ -76,6 +80,43 @@ class TestBase:
         course_service.is_member.return_value = True
 
         assert get_request_course(pyramid_request, course_service)
+
+    def test_get_request_organization_404(
+        self,
+        pyramid_request,
+        organization_service,
+    ):
+        pyramid_request.matchdict["public_id"] = sentinel.id
+        organization_service.get_by_public_id.return_value = None
+
+        with pytest.raises(HTTPNotFound):
+            get_request_organization(pyramid_request, organization_service)
+
+    def test_get_request_organization_403(
+        self,
+        pyramid_request,
+        organization_service,
+    ):
+        pyramid_request.matchdict["public_id"] = sentinel.id
+        organization_service.is_member.return_value = False
+
+        with pytest.raises(HTTPUnauthorized):
+            get_request_organization(pyramid_request, organization_service)
+
+    def test_get_request_organization_for_staff(
+        self, pyramid_request, organization_service, pyramid_config
+    ):
+        pyramid_config.testing_securitypolicy(permissive=True)
+        pyramid_request.matchdict["public_id"] = sentinel.id
+        organization_service.is_member.return_value = False
+
+        assert get_request_organization(pyramid_request, organization_service)
+
+    def test_get_request_organization(self, pyramid_request, organization_service):
+        pyramid_request.matchdict["public_id"] = sentinel.id
+        organization_service.is_member.return_value = True
+
+        assert get_request_organization(pyramid_request, organization_service)
 
     @pytest.fixture(autouse=True)
     def pyramid_config(self, pyramid_config):

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -10,7 +10,9 @@ from lms.resources._js_config import JSConfig
 from lms.resources.dashboard import DashboardResource
 from lms.views.dashboard.views import DashboardViews
 
-pytestmark = pytest.mark.usefixtures("h_api", "assignment_service", "course_service")
+pytestmark = pytest.mark.usefixtures(
+    "h_api", "assignment_service", "course_service", "organization_service"
+)
 
 
 class TestDashboardViews:
@@ -71,6 +73,31 @@ class TestDashboardViews:
             == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
+    @freeze_time("2024-04-01 12:00:00")
+    @pytest.mark.usefixtures("BearerTokenSchema")
+    def test_organization_show(
+        self,
+        views,
+        pyramid_request,
+        organization_service,
+        organization,
+        get_request_organization,
+    ):
+        context = DashboardResource(pyramid_request)
+        context.js_config = create_autospec(JSConfig, spec_set=True, instance=True)
+        pyramid_request.context = context
+
+        views.organization_show()
+
+        get_request_organization.assert_called_once_with(
+            pyramid_request, organization_service
+        )
+        pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
+        assert (
+            pyramid_request.response.headers["Set-Cookie"]
+            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization._public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+        )
+
     def test_assignment_show_with_no_lti_user(
         self, views, pyramid_request, assignment_service
     ):
@@ -90,6 +117,10 @@ class TestDashboardViews:
         mock = patch("lms.views.dashboard.views.BearerTokenSchema")
         mock.return_value.authorization_param.return_value = "Bearer TOKEN"
         return mock
+
+    @pytest.fixture
+    def get_request_organization(self, patch):
+        return patch("lms.views.dashboard.views.get_request_organization")
 
     @pytest.fixture(autouse=True)
     def pyramid_config(self, pyramid_config):


### PR DESCRIPTION
This allows to have another "extra level" for navigation.

See: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1716983621819659


The approach here is the simplest we can merge with hopefully the goal of unblocking FE work.


## Testing

(Adjust public id accordingly to localhost data, I have a note about making this part of devdata in my pile)

- Entrypoint http://localhost:8001/dashboard/organizations/LDtcl7EUTeW2UERPJLAVtA
- API route: http://localhost:8001/api/dashboard/organizations/LDtcl7EUTeW2UERPJLAVtA/courses

