### PR TITLE
Add a feature flag to control which ID we use for grading in LTI1.3

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -55,6 +55,7 @@ class ApplicationSettings(JSONSettings):
         ),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
         JSONSetting("hypothesis", "instructor_dashboard", asbool),
+        JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
     )
 
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -114,6 +114,7 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox('Enable instructor dashboard', 'hypothesis', 'instructor_dashboard') }}
+                            {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/126


Depending of when we recorded the "GradingInfos", when the LTI upgrade was made and whether or not the LMS provides the old IDs after an upgrade we might need to use one parameter or another.

We introduce a feature flag to control this behaviour for now instead of trying to make backwards incompatible changes.

## Testing

Unfortunately I've not been able to reproduce this exact scenario in a local environment. 

