### PR TITLE
Fix using wrong macro to display usage stats

### DIFF
--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -68,6 +68,10 @@
                             <div class="is-size-5 has-text-centered">No application instances</div>
                         {% endif %}
                     </fieldset>
+                    <fieldset class="box mt-6">
+                      <legend class="label has-text-centered">Company</legend>
+                      {{ macros.company_preview(request, company) }}
+                    </fieldset>
                     <div class="box">
                         <legend class="label has-text-centered">Hierarchy</legend>
                         <div class="content">
@@ -78,11 +82,6 @@
                     </div>
                 </li>
                 <li class="tab-panel" data-section-id="usage">
-                    <fieldset class="box mt-6">
-                      <legend class="label has-text-centered">Company</legend>
-                      {{ macros.company_preview(request, company) }}
-                    </fieldset>
-
                     <fieldset class="box">
                         <legend class="label has-text-centered">Usage report</legend>
                         <form method="POST"

--- a/lms/templates/admin/organization/usage.html.jinja2
+++ b/lms/templates/admin/organization/usage.html.jinja2
@@ -8,11 +8,6 @@
     </fieldset>
 
     <fieldset class="box mt-6">
-      <legend class="label has-text-centered">Company</legend>
-      {{ macros.organization_preview(request, company) }}
-    </fieldset>
-
-    <fieldset class="box mt-6">
         <div class="columns">
             <div class="column is-half">{{ macros.disabled_text_field("Since", since.strftime("%Y-%m-%d") ) }}</div>
             <div class="column is-half">{{ macros.disabled_text_field("Until", until.strftime("%Y-%m-%d") ) }}</div>

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -210,13 +210,7 @@ class AdminOrganizationViews:
             )
             report = []
 
-        return {
-            "org": org,
-            "since": since,
-            "until": until,
-            "report": report,
-            "company": self.hubspot_service.get_company(org.public_id),
-        }
+        return {"org": org, "since": since, "until": until, "report": report}
 
     def _get_org_or_404(self, id_) -> Organization:
         if org := self.organization_service.get_by_id(id_):

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -242,9 +242,7 @@ class TestAdminOrganizationViews:
         organization_service.usage_report.assert_not_called()
 
     @pytest.mark.usefixtures("with_valid_params_for_usage")
-    def test_usage_flashes_if_service_raises(
-        self, views, organization_service, hubspot_service
-    ):
+    def test_usage_flashes_if_service_raises(self, views, organization_service):
         organization_service.usage_report.side_effect = ValueError
         since = datetime(2023, 1, 1)
         until = datetime(2023, 12, 31)
@@ -252,16 +250,10 @@ class TestAdminOrganizationViews:
         result = views.usage()
 
         org = organization_service.get_by_id.return_value
-        assert result == {
-            "org": org,
-            "company": hubspot_service.get_company.return_value,
-            "since": since,
-            "until": until,
-            "report": [],
-        }
+        assert result == {"org": org, "since": since, "until": until, "report": []}
 
     @pytest.mark.usefixtures("with_valid_params_for_usage")
-    def test_usage(self, organization_service, views, hubspot_service):
+    def test_usage(self, organization_service, views):
         since = datetime(2023, 1, 1)
         until = datetime(2023, 12, 31)
 
@@ -272,7 +264,6 @@ class TestAdminOrganizationViews:
         organization_service.usage_report.assert_called_once_with(org, since, until)
         assert result == {
             "org": org,
-            "company": hubspot_service.get_company.return_value,
             "since": since,
             "until": until,
             "report": organization_service.usage_report.return_value,


### PR DESCRIPTION
Fixes: https://hypothesis.sentry.io/issues/5434938179/?referrer=slack&notification_uuid=affb1058-729f-4bc5-92d4-af014cdad2dc&alert_rule_id=4849653&alert_type=issue

Instead of just using the right macro in the usage page, just move the company info to the main tab.