### PR TITLE
Prevent concurrent OAuth token refreshes D2L, Blackboard

### DIFF
--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -96,7 +96,7 @@ class OAuthHTTPService:
         )
 
     def refresh_access_token(
-        self, token_url, redirect_uri, auth, prevent_concurrent_refreshes=False
+        self, token_url, redirect_uri, auth, prevent_concurrent_refreshes=True
     ):
         """
         Make a refresh token request and save the new token in the DB.

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -271,7 +271,6 @@ class TestOAuthHTTPService:
                 sentinel.token_url,
                 sentinel.redirect_uri,
                 sentinel.auth,
-                prevent_concurrent_refreshes=True,
             )
 
     def test_refresh_token_skips_if_token_is_current(


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/lms/pull/6322.**

Prevent concurrent OAuth token refreshes for all APIs using `OAuthHTTPService`, which in practice means D2L and Blackboard. The Canvas integration currently has a separate implementation (see https://github.com/hypothesis/lms/pull/6328).

**Testing:**

1. Open https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View in two separate tabs. Open Network tab in dev tools
2. Apply this diff:

```diff
diff --git a/lms/services/oauth_http.py b/lms/services/oauth_http.py
index 3de6a17ba..a024facd3 100644
--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -132,6 +132,9 @@ class OAuthHTTPService:
                 # skip the refresh.
                 raise ConcurrentTokenRefreshError() from exc
 
+        import time
+        time.sleep(5)
+
         try:
             return self._token_request(
                 token_url=token_url,
```

3. Invalidate all access tokens in the DB locally (`update oauth2_token set access_token = 'foo';`)
4. Reload both of the above tabs

In one of the tabs the refresh should succeed on the first try. In the other you'll see a series of 409 responses and eventually the reload should succeed.