### PR TITLE
Option to generate usage report from a celery task

### DIFF
--- a/lms/migrations/versions/73f0011260e4_usage_report.py
+++ b/lms/migrations/versions/73f0011260e4_usage_report.py
@@ -1,0 +1,44 @@
+"""Create the usage_report table.
+
+Revision ID: 73f0011260e4
+Revises: 329313b38de1
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "73f0011260e4"
+down_revision = "329313b38de1"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organization_usage_report",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("tag", sa.String(), nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("since", sa.Date(), nullable=True),
+        sa.Column("until", sa.Date(), nullable=True),
+        sa.Column("unique_users", sa.Integer(), nullable=True),
+        sa.Column("report", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk__organization_usage_report__organization_id__organization"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__organization_usage_report")),
+        sa.UniqueConstraint("key", name=op.f("uq__organization_usage_report__key")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("organization_usage_report")

--- a/lms/migrations/versions/73f0011260e4_usage_report.py
+++ b/lms/migrations/versions/73f0011260e4_usage_report.py
@@ -1,7 +1,7 @@
 """Create the usage_report table.
 
 Revision ID: 73f0011260e4
-Revises: 329313b38de1
+Revises: b512a5cf64ed
 """
 
 import sqlalchemy as sa
@@ -9,7 +9,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "73f0011260e4"
-down_revision = "329313b38de1"
+down_revision = "b512a5cf64ed"
 
 
 def upgrade() -> None:

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -28,6 +28,7 @@ from lms.models.lti_role import LTIRole, LTIRoleOverride, RoleScope, RoleType
 from lms.models.lti_user import LTIUser, display_name
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization
+from lms.models.organization_usage import OrganizationUsageReport
 from lms.models.rsa_key import RSAKey
 from lms.models.task_done import TaskDone
 from lms.models.user import User

--- a/lms/models/hubspot.py
+++ b/lms/models/hubspot.py
@@ -1,9 +1,10 @@
 from datetime import date
 
 from sqlalchemy import BigInteger
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 
 from lms.db import Base
+from lms.models.organization import Organization
 
 
 class HubSpotCompany(Base):
@@ -19,3 +20,9 @@ class HubSpotCompany(Base):
     lms_organization_id: Mapped[str | None]
     current_deal_services_start: Mapped[date | None]
     current_deal_services_end: Mapped[date | None]
+
+    organization: Mapped[Organization] = relationship(
+        "Organization",
+        primaryjoin=lambda: foreign(Organization.public_id)
+        == HubSpotCompany.lms_organization_id,
+    )

--- a/lms/models/organization_usage.py
+++ b/lms/models/organization_usage.py
@@ -33,5 +33,5 @@ class OrganizationUsageReport(CreatedUpdatedMixin, Base):
     """Actual report, in JSON format."""
 
     @classmethod
-    def generate_key(cls, organization, tag, report_start, report_end):
+    def generate_key(cls, organization, tag: str, report_start: date, report_end: date):
         return f"{organization.public_id}-{tag}-{report_start}-{report_end}"

--- a/lms/models/organization_usage.py
+++ b/lms/models/organization_usage.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+from sqlalchemy import ForeignKey, Integer
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lms.db import Base
+from lms.models._mixins import CreatedUpdatedMixin
+from lms.models.organization import Organization
+
+
+class OrganizationUsageReport(CreatedUpdatedMixin, Base):
+    __tablename__ = "organization_usage_report"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+
+    organization_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organization.id", ondelete="cascade")
+    )
+    organization: Mapped[Organization] = relationship(backref="reports")
+
+    tag: Mapped[str] = mapped_column()
+
+    key: Mapped[str] = mapped_column(unique=True)
+    """Key that idenfities this report"""
+
+    since: Mapped[date | None]
+    until: Mapped[date | None]
+
+    unique_users: Mapped[int | None] = mapped_column()
+
+    report: Mapped[list[dict] | None] = mapped_column(JSONB())
+    """Actual report, in JSON format."""
+
+    @classmethod
+    def generate_key(cls, organization, tag, report_start, report_end):
+        return f"{organization.public_id}-{tag}-{report_start}-{report_end}"

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -33,6 +33,7 @@ from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.moodle import MoodleAPIClient
 from lms.services.organization import InvalidPublicId, OrganizationService
+from lms.services.organization_usage_report import OrganizationUsageReportService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -127,6 +128,10 @@ def includeme(config):
     config.register_service_factory("lms.services.event.factory", iface=EventService)
     config.register_service_factory(
         "lms.services.organization.service_factory", iface=OrganizationService
+    )
+    config.register_service_factory(
+        "lms.services.organization_usage_report.service_factory",
+        iface=OrganizationUsageReportService,
     )
     config.register_service_factory(
         "lms.services.d2l_api.d2l_api_client_factory", iface=D2LAPIClient

--- a/lms/services/hubspot/service.py
+++ b/lms/services/hubspot/service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from hubspot import HubSpot
 from sqlalchemy import select
@@ -74,7 +74,7 @@ class HubSpotService:
         )
 
 
-def date_or_timestamp(value: str | int | None) -> str | None:
+def date_or_timestamp(value: str | int | None) -> date | None:
     """
     Format either timestamp or already formatted dates as YYYY-MM-DD.
 
@@ -84,7 +84,7 @@ def date_or_timestamp(value: str | int | None) -> str | None:
     if not value:
         return None
     try:
-        return datetime.fromtimestamp(int(value) / 1000).strftime("%Y-%m-%d")
+        return date.fromtimestamp(int(value) / 1000)
     except ValueError:
-        # Date is already formatted, return it verbatim
-        return str(value)
+        # Date is already formatted, return it as a date object
+        return datetime.strptime(str(value), "%Y-%m-%d").date()

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -1,38 +1,22 @@
 import base64
 import uuid
-from dataclasses import asdict, dataclass
-from datetime import datetime
 from logging import getLogger
 
 import sqlalchemy as sa
-from sqlalchemy import Date, func, select
-from sqlalchemy.orm import Session, aliased
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from lms.db import full_text_match
 from lms.models import (
     ApplicationInstance,
     Course,
     GroupInfo,
-    Grouping,
     GroupingMembership,
     Organization,
-    OrganizationUsageReport,
     User,
 )
-from lms.services.h_api import HAPI
 
 LOG = getLogger(__name__)
-
-
-@dataclass
-class UsageReportRow:
-    name: str | None
-    email: str | None
-    h_userid: str
-
-    course_name: str
-    course_created: datetime
-    authority_provided_id: str
 
 
 class InvalidOrganizationParent(Exception):
@@ -46,9 +30,8 @@ class InvalidPublicId(Exception):
 class OrganizationService:
     """A service for dealing with organization actions."""
 
-    def __init__(self, db_session: Session, h_api: HAPI, region_code: str):
+    def __init__(self, db_session: Session, region_code: str):
         self._db_session = db_session
-        self._h_api = h_api
         self._region_code = region_code
 
     def get_by_id(self, id_: int) -> Organization | None:
@@ -263,124 +246,6 @@ class OrganizationService:
 
         return organization
 
-    def generate_usage_report(
-        self, organization_id: int, tag: str, since: datetime, until: datetime
-    ):
-        """Generate and store an usage report for one organization."""
-        organization = self.get_by_id(organization_id)
-        assert organization
-        report_key = OrganizationUsageReport.generate_key(
-            organization, tag, since, until
-        )
-
-        if (
-            report := self._db_session.query(OrganizationUsageReport)
-            .filter_by(key=report_key)
-            .one_or_none()
-        ):
-            LOG.debug("Report already exists, skipping generation. %s", report_key)
-            return report
-
-        report = OrganizationUsageReport(
-            organization=organization,
-            key=report_key,
-            since=since,
-            until=until,
-            tag=tag,
-        )
-        self._db_session.add(report)
-
-        report_rows = self.usage_report(organization, since, until)
-
-        report.unique_users = len({r.h_userid for r in report_rows})
-        report.report = [asdict(r) for r in report_rows]
-
-        return report
-
-    def usage_report(
-        self,
-        organization: Organization,
-        since: datetime,
-        until: datetime,
-    ):
-        # Organizations that are children of the current one.
-        # It includes the current org ID.
-        organization_children = self.get_hierarchy_ids(
-            organization.id, include_parents=False
-        )
-        # All the groups that can hold annotations (courses and segments) from this org
-        groups_from_org = self._db_session.scalars(
-            select(Grouping.authority_provided_id)
-            .join(ApplicationInstance)
-            .where(
-                ApplicationInstance.organization_id.in_(organization_children),
-                # If a group was created after the date we are interested, exclude it
-                Grouping.created <= until,
-            )
-        ).all()
-
-        if not groups_from_org:
-            raise ValueError(f"No courses found for {organization.public_id}")
-
-        # Of those groups, get the ones that do have annotations in the time period
-        groups_with_annos = [
-            group.authority_provided_id
-            for group in self._h_api.get_groups(groups_from_org, since, until)
-        ]
-        if not groups_with_annos:
-            raise ValueError(
-                f"No courses with activity found for {organization.public_id}"
-            )
-
-        # Based on those groups generate the usage report based on the definition of unique user:
-        # Users that belong to a course in which there are annotations in the time period
-        parent = aliased(Grouping)
-        query = (
-            select(
-                User.display_name.label("name"),
-                User.email.label("email"),
-                User.h_userid.label("h_userid"),
-                Grouping.lms_name.label("course_name"),
-                func.date_trunc("day", Grouping.created)
-                .cast(Date)
-                .label("course_created"),
-                Grouping.authority_provided_id,
-            )
-            .select_from(User)
-            .join(GroupingMembership)
-            .join(Grouping)
-            .distinct()
-            .where(
-                Grouping.authority_provided_id.in_(
-                    # The report is based in courses so we query either
-                    # groupings with no parent (courses) or the parents of segments (courses)
-                    select(
-                        func.coalesce(
-                            parent.authority_provided_id, Grouping.authority_provided_id
-                        )
-                    )
-                    .select_from(Grouping)
-                    .outerjoin(parent, Grouping.parent_id == parent.id)
-                    .where(Grouping.authority_provided_id.in_(groups_with_annos))
-                ),
-                # We can't exactly know the state of membership in the past but we can
-                # know if someone was added to the group after the date we are interested
-                GroupingMembership.created <= until,
-            )
-        )
-        return [
-            UsageReportRow(
-                # Students might have name but they never have email
-                name=row.name if row.email else "<STUDENT>",
-                email=row.email if row.email else "<STUDENT>",
-                h_userid=row.h_userid,
-                course_name=row.course_name,
-                course_created=row.course_created.isoformat(),
-                authority_provided_id=row.authority_provided_id,
-            )
-            for row in self._db_session.execute(query).all()
-        ]
-
     def _move_organization_parent(self, organization: Organization, parent_public_id):
         """Change an organizations parent, without creating loops."""
 
@@ -466,6 +331,5 @@ def service_factory(_context, request) -> OrganizationService:
 
     return OrganizationService(
         db_session=request.db,
-        h_api=request.find_service(HAPI),
         region_code=request.registry.settings["region_code"],
     )

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -1,6 +1,6 @@
 import base64
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from logging import getLogger
 
@@ -16,6 +16,7 @@ from lms.models import (
     Grouping,
     GroupingMembership,
     Organization,
+    OrganizationUsageReport,
     User,
 )
 from lms.services.h_api import HAPI
@@ -262,6 +263,40 @@ class OrganizationService:
 
         return organization
 
+    def generate_usage_report(
+        self, organization_id: int, tag: str, since: datetime, until: datetime
+    ):
+        """Generate and store an usage report for one organization."""
+        organization = self.get_by_id(organization_id)
+        assert organization
+        report_key = OrganizationUsageReport.generate_key(
+            organization, tag, since, until
+        )
+
+        if (
+            report := self._db_session.query(OrganizationUsageReport)
+            .filter_by(key=report_key)
+            .one_or_none()
+        ):
+            LOG.debug("Report already exists, skipping generation. %s", report_key)
+            return report
+
+        report = OrganizationUsageReport(
+            organization=organization,
+            key=report_key,
+            since=since,
+            until=until,
+            tag=tag,
+        )
+        self._db_session.add(report)
+
+        report_rows = self.usage_report(organization, since, until)
+
+        report.unique_users = len({r.h_userid for r in report_rows})
+        report.report = [asdict(r) for r in report_rows]
+
+        return report
+
     def usage_report(
         self,
         organization: Organization,
@@ -340,7 +375,7 @@ class OrganizationService:
                 email=row.email if row.email else "<STUDENT>",
                 h_userid=row.h_userid,
                 course_name=row.course_name,
-                course_created=row.course_created,
+                course_created=row.course_created.isoformat(),
                 authority_provided_id=row.authority_provided_id,
             )
             for row in self._db_session.execute(query).all()

--- a/lms/services/organization_usage_report.py
+++ b/lms/services/organization_usage_report.py
@@ -1,0 +1,168 @@
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from logging import getLogger
+
+from sqlalchemy import Date, func, select
+from sqlalchemy.orm import Session, aliased
+
+from lms.models import (
+    ApplicationInstance,
+    Grouping,
+    GroupingMembership,
+    Organization,
+    OrganizationUsageReport,
+    User,
+)
+from lms.services.h_api import HAPI
+from lms.services.organization import OrganizationService
+
+LOG = getLogger(__name__)
+
+
+@dataclass
+class UsageReportRow:
+    name: str | None
+    email: str | None
+    h_userid: str
+
+    course_name: str
+    course_created: datetime
+    authority_provided_id: str
+
+
+class OrganizationUsageReportService:
+    def __init__(
+        self,
+        db_session: Session,
+        h_api: HAPI,
+        organization_service: OrganizationService,
+    ):
+        self._db_session = db_session
+        self._organization_service = organization_service
+        self._h_api = h_api
+
+    def generate_usage_report(
+        self, organization_id: int, tag: str, since: datetime, until: datetime
+    ):
+        """Generate and store an usage report for one organization."""
+        organization = self._organization_service.get_by_id(organization_id)
+        assert organization
+        report_key = OrganizationUsageReport.generate_key(
+            organization, tag, since, until
+        )
+
+        if (
+            report := self._db_session.query(OrganizationUsageReport)
+            .filter_by(key=report_key)
+            .one_or_none()
+        ):
+            LOG.debug("Report already exists, skipping generation. %s", report_key)
+            return report
+
+        report = OrganizationUsageReport(
+            organization=organization,
+            key=report_key,
+            since=since,
+            until=until,
+            tag=tag,
+        )
+        self._db_session.add(report)
+
+        report_rows = self.usage_report(organization, since, until)
+
+        report.unique_users = len({r.h_userid for r in report_rows})
+        report.report = [asdict(r) for r in report_rows]
+
+        return report
+
+    def usage_report(
+        self,
+        organization: Organization,
+        since: datetime,
+        until: datetime,
+    ):
+        # Organizations that are children of the current one.
+        # It includes the current org ID.
+        organization_children = self._organization_service.get_hierarchy_ids(
+            organization.id, include_parents=False
+        )
+        # All the groups that can hold annotations (courses and segments) from this org
+        groups_from_org = self._db_session.scalars(
+            select(Grouping.authority_provided_id)
+            .join(ApplicationInstance)
+            .where(
+                ApplicationInstance.organization_id.in_(organization_children),
+                # If a group was created after the date we are interested, exclude it
+                Grouping.created <= until,
+            )
+        ).all()
+
+        if not groups_from_org:
+            raise ValueError(f"No courses found for {organization.public_id}")
+
+        # Of those groups, get the ones that do have annotations in the time period
+        groups_with_annos = [
+            group.authority_provided_id
+            for group in self._h_api.get_groups(groups_from_org, since, until)
+        ]
+        if not groups_with_annos:
+            raise ValueError(
+                f"No courses with activity found for {organization.public_id}"
+            )
+
+        # Based on those groups generate the usage report based on the definition of unique user:
+        # Users that belong to a course in which there are annotations in the time period
+        parent = aliased(Grouping)
+        query = (
+            select(
+                User.display_name.label("name"),
+                User.email.label("email"),
+                User.h_userid.label("h_userid"),
+                Grouping.lms_name.label("course_name"),
+                func.date_trunc("day", Grouping.created)
+                .cast(Date)
+                .label("course_created"),
+                Grouping.authority_provided_id,
+            )
+            .select_from(User)
+            .join(GroupingMembership)
+            .join(Grouping)
+            .distinct()
+            .where(
+                Grouping.authority_provided_id.in_(
+                    # The report is based in courses so we query either
+                    # groupings with no parent (courses) or the parents of segments (courses)
+                    select(
+                        func.coalesce(
+                            parent.authority_provided_id, Grouping.authority_provided_id
+                        )
+                    )
+                    .select_from(Grouping)
+                    .outerjoin(parent, Grouping.parent_id == parent.id)
+                    .where(Grouping.authority_provided_id.in_(groups_with_annos))
+                ),
+                # We can't exactly know the state of membership in the past but we can
+                # know if someone was added to the group after the date we are interested
+                GroupingMembership.created <= until,
+            )
+        )
+        return [
+            UsageReportRow(
+                # Students might have name but they never have email
+                name=row.name if row.email else "<STUDENT>",
+                email=row.email if row.email else "<STUDENT>",
+                h_userid=row.h_userid,
+                course_name=row.course_name,
+                course_created=row.course_created.isoformat(),
+                authority_provided_id=row.authority_provided_id,
+            )
+            for row in self._db_session.execute(query).all()
+        ]
+
+
+def service_factory(_context, request) -> OrganizationUsageReportService:
+    return OrganizationUsageReportService(
+        db_session=request.db,
+        h_api=request.find_service(HAPI),
+        organization_service=request.find_service(OrganizationService),
+    )

--- a/lms/tasks/organization.py
+++ b/lms/tasks/organization.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from lms.services import OrganizationService
+from lms.tasks.celery import app
+
+
+@app.task
+def generate_usage_report(
+    organization_id: int, tag: str, since: str, until: str
+) -> None:
+    with app.request_context() as request:
+        with request.tm:
+            request.find_service(OrganizationService).generate_usage_report(
+                organization_id,
+                tag,
+                datetime.fromisoformat(since),
+                datetime.fromisoformat(until),
+            )

--- a/lms/tasks/organization.py
+++ b/lms/tasks/organization.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lms.services import OrganizationService
+from lms.services import OrganizationUsageReportService
 from lms.tasks.celery import app
 
 
@@ -10,7 +10,7 @@ def generate_usage_report(
 ) -> None:
     with app.request_context() as request:
         with request.tm:
-            request.find_service(OrganizationService).generate_usage_report(
+            request.find_service(OrganizationUsageReportService).generate_usage_report(
                 organization_id,
                 tag,
                 datetime.fromisoformat(since),

--- a/lms/tasks/organization.py
+++ b/lms/tasks/organization.py
@@ -1,7 +1,10 @@
-from datetime import datetime
+import logging
+from datetime import date, timedelta
 
-from lms.services import OrganizationUsageReportService
+from lms.services import HubSpotService, OrganizationUsageReportService
 from lms.tasks.celery import app
+
+LOG = logging.getLogger(__name__)
 
 
 @app.task
@@ -13,6 +16,55 @@ def generate_usage_report(
             request.find_service(OrganizationUsageReportService).generate_usage_report(
                 organization_id,
                 tag,
-                datetime.fromisoformat(since),
-                datetime.fromisoformat(until),
+                date.fromisoformat(since),
+                date.fromisoformat(until),
             )
+
+
+@app.task
+def schedule_monthly_deal_report(limit: int, backfill: int = 0) -> None:
+    """Generate monthly usage reports for organizations with active deals.
+
+    This task relies on being called from h-periodic a few times with the right limit value at the start of each month.
+
+    backfill n reports in addition to the last month report.
+    """
+    reports_scheduled = 0
+
+    with app.request_context() as request:
+        with request.tm:
+            usage_service = request.find_service(OrganizationUsageReportService)
+            hubspot_service = request.find_service(HubSpotService)
+
+            companies_with_active_deals = hubspot_service.get_companies_with_active_deals(
+                # Get active deals, now and a few days ago to account for the last billing period
+                date.today() - timedelta(days=30)
+            )
+            for company in companies_with_active_deals:
+                organization = company.organization
+
+                for since, until in usage_service.monthly_report_dates(
+                    company.current_deal_services_start,
+                    company.current_deal_services_end,
+                    backfill + 1,
+                ):
+                    if usage_service.get(organization, "monthly-deal", since, until):
+                        LOG.info(
+                            "Report already exists %s:%s:%s",
+                            organization.public_id,
+                            since,
+                            until,
+                        )
+                        return
+
+                    generate_usage_report.delay(
+                        organization.id,
+                        "monthly-deal",
+                        since.isoformat(),
+                        until.isoformat(),
+                    )
+
+                    reports_scheduled += 1
+                    if reports_scheduled >= limit:
+                        # Limit the amount of reports we generate per call to this task
+                        return

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -8,7 +8,12 @@ from webargs import fields
 from lms.events import AuditTrailEvent
 from lms.models import Organization
 from lms.security import Permissions
-from lms.services import HubSpotService, InvalidPublicId, OrganizationService
+from lms.services import (
+    HubSpotService,
+    InvalidPublicId,
+    OrganizationService,
+    OrganizationUsageReportService,
+)
 from lms.services.organization import InvalidOrganizationParent
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
@@ -38,6 +43,10 @@ class AdminOrganizationViews:
         self.organization_service: OrganizationService = request.find_service(
             OrganizationService
         )
+        self.organization_usage_report_service: OrganizationService = (
+            request.find_service(OrganizationUsageReportService)
+        )
+
         self.hubspot_service: HubSpotService = request.find_service(HubSpotService)
 
     @view_config(
@@ -202,7 +211,9 @@ class AdminOrganizationViews:
             raise HTTPBadRequest("Usage reports can only be generated since 2023")
 
         try:
-            report = self.organization_service.usage_report(org, since, until)
+            report = self.organization_usage_report_service.usage_report(
+                org, since, until
+            )
         except ValueError as exc:
             self.request.session.flash(
                 f"There was a problem generating the report: {exc}", "errors"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ disable = [
     "import-outside-toplevel",
     "too-many-statements",
     "protected-access",
+    "singleton-comparison",
 
     # Not supported by ruff
     "too-many-ancestors",

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -32,6 +32,7 @@ from tests.factories.lti_role import LTIRole, LTIRoleOverride
 from tests.factories.lti_user import LTIUser
 from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.organization import Organization
+from tests.factories.organization_usage import OrganizationUsageReport
 from tests.factories.rsa_key import RSAKey
 from tests.factories.task_done import TaskDone
 from tests.factories.user import User

--- a/tests/factories/organization_usage.py
+++ b/tests/factories/organization_usage.py
@@ -1,0 +1,9 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+OrganizationUsageReport = make_factory(
+    models.OrganizationUsageReport,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+)

--- a/tests/unit/lms/services/hubspot/service_test.py
+++ b/tests/unit/lms/services/hubspot/service_test.py
@@ -17,6 +17,25 @@ class TestHubSpotService:
 
         assert svc.get_company(org.public_id)
 
+    def test_get_companies_with_active_deals(self, svc):
+        # Companies that map to the same org, they should be ignored
+        org = factories.Organization()
+        factories.HubSpotCompany(lms_organization_id=org.public_id)
+        factories.HubSpotCompany(lms_organization_id=org.public_id)
+        # Company with deal outside the time period
+        factories.HubSpotCompany(
+            lms_organization_id=factories.Organization().public_id,
+            current_deal_services_start=date(2022, 1, 1),
+            current_deal_services_end=date(2022, 12, 31),
+        )
+        company = factories.HubSpotCompany(
+            lms_organization_id=factories.Organization().public_id,
+            current_deal_services_start=date(2023, 1, 1),
+            current_deal_services_end=date(2023, 12, 31),
+        )
+
+        assert svc.get_companies_with_active_deals(date(2023, 2, 1)) == [company]
+
     def test_get_company_multiple_mapping(self, svc):
         org = factories.Organization()
         factories.HubSpotCompany(lms_organization_id=org.public_id)

--- a/tests/unit/lms/services/hubspot/service_test.py
+++ b/tests/unit/lms/services/hubspot/service_test.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from unittest.mock import Mock, create_autospec, sentinel
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from lms.models import HubSpotCompany
 from lms.services.hubspot import HubSpotService
 from lms.services.hubspot._client import HubSpotClient
+from lms.services.hubspot.service import date_or_timestamp
 from tests import factories
 
 
@@ -45,6 +47,17 @@ class TestHubSpotService:
         company = db_session.query(HubSpotCompany).one()
         assert company.name == "COMPANY"
         assert company.hubspot_id == 100
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("2024-12-31", date(2024, 12, 31)),
+            (datetime(2024, 12, 31).timestamp() * 1000, date(2024, 12, 31)),
+        ],
+    )
+    def test_date_or_timestamp(self, expected, value):
+        assert expected == date_or_timestamp(value)
 
     def test_factory(self, pyramid_request, db_session, HubSpotClient, HubSpot):
         svc = HubSpotService.factory(sentinel.context, pyramid_request)

--- a/tests/unit/lms/services/organization_test.py
+++ b/tests/unit/lms/services/organization_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 from h_matchers import Any

--- a/tests/unit/lms/services/organization_test.py
+++ b/tests/unit/lms/services/organization_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import sentinel
+from unittest.mock import patch, sentinel
 
 import pytest
 from h_matchers import Any
@@ -222,6 +222,54 @@ class TestOrganizationService:
 
         assert org_with_parent.parent
 
+    def test_generate_usage_report(self, svc, org_with_parent, usage_report):
+        usage_report.return_value = [
+            UsageReportRow(
+                name="<STUDENT>",
+                email="<STUDENT>",
+                h_userid=sentinel.h_userid,
+                course_name=sentinel.lms_name,
+                course_created="2020-01-01",
+                authority_provided_id=sentinel.authority_provided_id,
+            ),
+            UsageReportRow(
+                name="<STUDENT>",
+                email="<STUDENT>",
+                h_userid=sentinel.h_userid,
+                course_name=sentinel.lms_name,
+                course_created="2020-01-01",
+                authority_provided_id=sentinel.authority_provided_id,
+            ),
+        ]
+
+        report = svc.generate_usage_report(
+            org_with_parent.id, "test", "2020-01-01", "2020-02-02"
+        )
+
+        usage_report.assert_called_once_with(
+            org_with_parent, "2020-01-01", "2020-02-02"
+        )
+
+        assert report.organization == org_with_parent
+        assert report.unique_users == 1
+        assert report.since == "2020-01-01"
+        assert report.until == "2020-02-02"
+        assert len(report.report) == 2
+
+    def test_generate_usage_report_existing_report(self, svc, org_with_parent):
+        report = factories.OrganizationUsageReport(
+            organization=org_with_parent,
+            key=f"{org_with_parent.public_id}-test-2020-01-01-2020-02-02",
+            tag="test",
+        )
+
+        assert (
+            svc.generate_usage_report(
+                org_with_parent.id, "test", "2020-01-01", "2020-02-02"
+            )
+            == report
+        )
+
     def test_usage_report(self, svc, org_with_parent, h_api):
         since = datetime(2023, 1, 1)
         until = datetime(2023, 12, 31)
@@ -281,7 +329,7 @@ class TestOrganizationService:
                 email=user_1.email,
                 h_userid=user_1.h_userid,
                 course_name=course_child.lms_name,
-                course_created=course_child.created.date(),
+                course_created=course_child.created.date().isoformat(),
                 authority_provided_id=course_child.authority_provided_id,
             ),
             UsageReportRow(
@@ -289,7 +337,7 @@ class TestOrganizationService:
                 email="<STUDENT>",
                 h_userid=user_2.h_userid,
                 course_name=course_root.lms_name,
-                course_created=course_root.created.date(),
+                course_created=course_root.created.date().isoformat(),
                 authority_provided_id=course_root.authority_provided_id,
             ),
         ]
@@ -356,6 +404,11 @@ class TestOrganizationService:
         return factories.ApplicationInstance(
             tool_consumer_instance_guid="guid", tool_consumer_instance_name="ai_name"
         )
+
+    @pytest.fixture
+    def usage_report(self, svc):
+        with patch.object(svc, "usage_report") as usage_report:
+            yield usage_report
 
 
 class TestServiceFactory:

--- a/tests/unit/lms/services/organization_test.py
+++ b/tests/unit/lms/services/organization_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any

--- a/tests/unit/lms/tasks/organization_test.py
+++ b/tests/unit/lms/tasks/organization_test.py
@@ -1,26 +1,110 @@
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import date
 from unittest.mock import sentinel
 
 import pytest
+from freezegun import freeze_time
 
-from lms.tasks.organization import generate_usage_report
+from lms.tasks.organization import generate_usage_report, schedule_monthly_deal_report
+from tests import factories
 
 
-def test_generate_usage_report(organization_usage_report_service):
-    generate_usage_report(
-        sentinel.id,
-        sentinel.tag,
-        "2024-01-01:00:00:00",
-        "2024-02-02:00:00:00",
-    )
+class TestGenerateUsageReport:
+    def test_generate_usage_report(self, organization_usage_report_service):
+        generate_usage_report(sentinel.id, sentinel.tag, "2024-01-01", "2024-02-02")
 
-    organization_usage_report_service.generate_usage_report.assert_called_once_with(
-        sentinel.id,
-        sentinel.tag,
-        datetime(2024, 1, 1, 0, 0, 0),
-        datetime(2024, 2, 2, 0, 0, 0),
-    )
+        organization_usage_report_service.generate_usage_report.assert_called_once_with(
+            sentinel.id, sentinel.tag, date(2024, 1, 1), date(2024, 2, 2)
+        )
+
+
+class TestScheduleMonthlyDealReport:
+    @freeze_time("2023-03-09 05:15:00")
+    def test_schedule_monthly_deal_report(
+        self, organization_usage_report_service, hubspot_service, generate_usage_report
+    ):
+        organization = factories.Organization()
+        hubspot_service.get_companies_with_active_deals.return_value = [
+            factories.HubSpotCompany(
+                organization=organization,
+                lms_organization_id=organization.public_id,
+                current_deal_services_start=date(2022, 1, 1),
+                current_deal_services_end=date(2022, 12, 31),
+            )
+        ]
+        organization_usage_report_service.get.return_value = None
+        organization_usage_report_service.monthly_report_dates.return_value = [
+            (date(2022, 1, 1), date(2023, 2, 28))
+        ]
+
+        schedule_monthly_deal_report(limit=10)
+        hubspot_service.get_companies_with_active_deals.assert_called_once_with(
+            date(2023, 2, 7)
+        )
+
+        generate_usage_report.delay.assert_called_once_with(
+            organization.id, "monthly-deal", "2022-01-01", "2023-02-28"
+        )
+
+    @freeze_time("2023-03-09 05:15:00")
+    def test_schedule_monthly_deal_report_existing_report(
+        self, organization_usage_report_service, hubspot_service, generate_usage_report
+    ):
+        organization = factories.Organization()
+        hubspot_service.get_companies_with_active_deals.return_value = [
+            factories.HubSpotCompany(
+                organization=organization,
+                lms_organization_id=organization.public_id,
+                current_deal_services_start=date(2022, 1, 1),
+                current_deal_services_end=date(2022, 12, 31),
+            )
+        ]
+        organization_usage_report_service.monthly_report_dates.return_value = [
+            (date(2022, 1, 1), date(2023, 2, 28))
+        ]
+        organization_usage_report_service.get.return_value = (
+            factories.OrganizationUsageReport()
+        )
+
+        schedule_monthly_deal_report(limit=1)
+
+        hubspot_service.get_companies_with_active_deals.assert_called_once_with(
+            date(2023, 2, 7)
+        )
+
+        generate_usage_report.delay.assert_not_called()
+
+    @freeze_time("2023-03-09 05:15:00")
+    def test_schedule_monthly_deal_report_limit(
+        self, organization_usage_report_service, hubspot_service, generate_usage_report
+    ):
+        organization = factories.Organization()
+        hubspot_service.get_companies_with_active_deals.return_value = [
+            factories.HubSpotCompany(
+                organization=organization,
+                lms_organization_id=organization.public_id,
+                current_deal_services_start=date(2022, 1, 1),
+                current_deal_services_end=date(2022, 12, 31),
+            ),
+            factories.HubSpotCompany(
+                organization=organization,
+                lms_organization_id=organization.public_id,
+                current_deal_services_start=date(2022, 1, 1),
+                current_deal_services_end=date(2022, 12, 31),
+            ),
+        ]
+        organization_usage_report_service.get.return_value = None
+        organization_usage_report_service.monthly_report_dates.return_value = [
+            (date(2022, 1, 1), date(2022, 12, 31))
+        ]
+
+        schedule_monthly_deal_report(limit=1)
+
+        generate_usage_report.delay.assert_called_once()
+
+    @pytest.fixture
+    def generate_usage_report(self, patch):
+        return patch("lms.tasks.organization.generate_usage_report")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/tasks/organization_test.py
+++ b/tests/unit/lms/tasks/organization_test.py
@@ -7,7 +7,7 @@ import pytest
 from lms.tasks.organization import generate_usage_report
 
 
-def test_delete_expired_rows(organization_service):
+def test_generate_usage_report(organization_usage_report_service):
     generate_usage_report(
         sentinel.id,
         sentinel.tag,
@@ -15,7 +15,7 @@ def test_delete_expired_rows(organization_service):
         "2024-02-02:00:00:00",
     )
 
-    organization_service.generate_usage_report.assert_called_once_with(
+    organization_usage_report_service.generate_usage_report.assert_called_once_with(
         sentinel.id,
         sentinel.tag,
         datetime(2024, 1, 1, 0, 0, 0),

--- a/tests/unit/lms/tasks/organization_test.py
+++ b/tests/unit/lms/tasks/organization_test.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+from datetime import datetime
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.tasks.organization import generate_usage_report
+
+
+def test_delete_expired_rows(organization_service):
+    generate_usage_report(
+        sentinel.id,
+        sentinel.tag,
+        "2024-01-01:00:00:00",
+        "2024-02-02:00:00:00",
+    )
+
+    organization_service.generate_usage_report.assert_called_once_with(
+        sentinel.id,
+        sentinel.tag,
+        datetime(2024, 1, 1, 0, 0, 0),
+        datetime(2024, 2, 2, 0, 0, 0),
+    )
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.organization.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -44,6 +44,7 @@ from lms.services.moodle import MoodleAPIClient
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
+from lms.services.organization_usage_report import OrganizationUsageReportService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -91,6 +92,7 @@ __all__ = (
     "oauth2_token_service",
     "oauth_http_service",
     "organization_service",
+    "organization_usage_report_service",
     "rsa_key_service",
     "user_service",
     "user_preferences_service",
@@ -285,6 +287,11 @@ def async_oauth_http_service(mock_service):
 @pytest.fixture
 def organization_service(mock_service):
     return mock_service(OrganizationService)
+
+
+@pytest.fixture
+def organization_usage_report_service(mock_service):
+    return mock_service(OrganizationUsageReportService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Store the results in the DB for:

- Retrieval of the report without having to do the query work
- Option to graph the results in metabase over a period of time.

This commit add the option to generate these in an async (celery) task
but not code uses it yet.

The plan is to write a second  task that schedules periodic reports for
ongoing company deals.


## Deploy

- Remember to run migration in production


## Testing

- Apply migration


```
tox -e dev --run-command 'alembic upgrade head'
```


- In `make shell` kick off a job

```
from datetime import datetime, timedelta
from lms.tasks.organization import generate_usage_report

org_public_id = "us.lms.org.LDtcl7EUTeW2UERPJLAVtA"

generate_usage_report.delay(db.query(models.Organization).filter_by(public_id=org_public_id).one().id, "testing", (datetime.now() - timedelta(days=365)).isoformat(), datetime.now().date().isoformat())
```

- Check the job finished, in the `make dev` logs


```
Task lms.tasks.organization.generate_usage_report[1b603b4c-7f06-45ac-9429-d84f8d00873b] received
lms.tasks.organization.generate_usage_report[1b603b4c-7f06-45ac-9429-d84f8d00873b] Task lms.tasks.organization.generate_usage_report[1b603b4c-7f06-45ac-9429-d84f8d00873b] succeeded in 0.20881368702976033s: None
```

- And finally check the new reports stored in the DB, in the same `make shell`


```
db.query(models.OrganizationUsageReport).first().__dict__


{'_sa_instance_state': <sqlalchemy.orm.state.InstanceState at 0x7595e24c0860>, 'since': datetime.date(2023, 6, 5),
 'created': datetime.datetime(2024, 6, 4, 7, 53, 4, 669763), 'updated': datetime.datetime(2024, 6, 4, 7, 53, 4, 669763),
 'until': datetime.date(2023, 6, 5), 'tag': 'testing',
 'organization_id': 1, 'key': '1-testing-2023-06-05 09:53:04.513550-2024-06-04 00:00:00',
 'report': [{'name': 'DISPLAY NAME TEACHER',   'email': 'eng+canvasteacher@hypothes.is',
   'h_userid': 'acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is',   'course_name': 'Developer Test Course with Sections Enabled',
   'course_created': '2024-04-18',   'authority_provided_id': '653e9620a656a954c684942f6443fa3e3410c03a'},
  {'name': 'DISPLAY NAME TEACHER',   'email': 'eng+canvasteacher@hypothes.is',
   'h_userid': 'acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is',   'course_name': 'LTI 1.3 Testing',
   'course_created': '2024-04-18',   'authority_provided_id': '3394ac098caa5997ed3d87023befb9f7e9ea4a38'},
  {'name': '<STUDENT>',   'email': '<STUDENT>',
   'h_userid': 'acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is',   'course_name': 'Developer Test Course with Sections Enabled',
   'course_created': '2024-04-18',   'authority_provided_id': '653e9620a656a954c684942f6443fa3e3410c03a'},
  {'name': '<STUDENT>',   'email': '<STUDENT>',
   'h_userid': 'acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is',   'course_name': 'LTI 1.3 Testing',
   'course_created': '2024-04-18',   'authority_provided_id': '3394ac098caa5997ed3d87023befb9f7e9ea4a38'},
  {'name': 'Michael Admin',   'email': 'mdiroberts+canvasadmin@hypothes.is',
   'h_userid': 'acct:8652fe5b4ab4820743c9b7640f3aea@lms.hypothes.is',   'course_name': 'Developer Test Course with Sections Enabled',
   'course_created': '2024-04-18',   'authority_provided_id': '653e9620a656a954c684942f6443fa3e3410c03a'},
  {'name': '<STUDENT>',   'email': '<STUDENT>',
   'h_userid': 'acct:c2cd2d06fc04ff4f0799e8e17c8c27@lms.hypothes.is',   'course_name': 'LTI 1.3 Testing',
   'course_created': '2024-04-18',   'authority_provided_id': '3394ac098caa5997ed3d87023befb9f7e9ea4a38'}],
 'id': 1, 'unique_users': 4}
```






