### PR TITLE
Explicitly return date objects instead of string in hubspot integration

### DIFF
--- a/lms/services/hubspot/service.py
+++ b/lms/services/hubspot/service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from hubspot import HubSpot
 from sqlalchemy import select
@@ -74,7 +74,7 @@ class HubSpotService:
         )
 
 
-def date_or_timestamp(value: str | int | None) -> str | None:
+def date_or_timestamp(value: str | int | None) -> date | None:
     """
     Format either timestamp or already formatted dates as YYYY-MM-DD.
 
@@ -84,7 +84,7 @@ def date_or_timestamp(value: str | int | None) -> str | None:
     if not value:
         return None
     try:
-        return datetime.fromtimestamp(int(value) / 1000).strftime("%Y-%m-%d")
+        return date.fromtimestamp(int(value) / 1000)
     except ValueError:
-        # Date is already formatted, return it verbatim
-        return str(value)
+        # Date is already formatted, return it as a date object
+        return datetime.strptime(str(value), "%Y-%m-%d").date()

--- a/tests/unit/lms/services/hubspot/service_test.py
+++ b/tests/unit/lms/services/hubspot/service_test.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from unittest.mock import Mock, create_autospec, sentinel
 
 import pytest
@@ -5,6 +6,7 @@ import pytest
 from lms.models import HubSpotCompany
 from lms.services.hubspot import HubSpotService
 from lms.services.hubspot._client import HubSpotClient
+from lms.services.hubspot.service import date_or_timestamp
 from tests import factories
 
 
@@ -45,6 +47,17 @@ class TestHubSpotService:
         company = db_session.query(HubSpotCompany).one()
         assert company.name == "COMPANY"
         assert company.hubspot_id == 100
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("2024-12-31", date(2024, 12, 31)),
+            (datetime(2024, 12, 31).timestamp() * 1000, date(2024, 12, 31)),
+        ],
+    )
+    def test_date_or_timestamp(self, expected, value):
+        assert expected == date_or_timestamp(value)
 
     def test_factory(self, pyramid_request, db_session, HubSpotClient, HubSpot):
         svc = HubSpotService.factory(sentinel.context, pyramid_request)


### PR DESCRIPTION
While this worked before as postgres cast them to dates anyway it makes the python code clearer and more explicit.