### PR TITLE
Make all dashboard API endpoints return a JSON object response

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -17,11 +17,19 @@ class APICourse(TypedDict):
     title: str
 
 
+class APICourses(TypedDict):
+    courses: list[APICourse]
+
+
 class APIStudentStats(TypedDict):
     display_name: str
     annotations: int
     replies: int
     last_activity: str | None
+
+
+class APIStudents(TypedDict):
+    students: list[APIStudentStats]
 
 
 class AssignmentStats(TypedDict):
@@ -35,6 +43,10 @@ class APIAssignment(TypedDict):
     title: str
     course: APICourse
     stats: NotRequired[AssignmentStats]
+
+
+class APIAssignments(TypedDict):
+    assignments: list[APIAssignment]
 
 
 class DashboardRoutes(TypedDict):

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -164,7 +164,9 @@ export type Course = {
 /**
  * Response for `/api/dashboard/organizations/{organization_public_id}` call.
  */
-export type Courses = Course[];
+export type CoursesResponse = {
+  courses: Course[];
+};
 
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}` call.
@@ -182,7 +184,9 @@ export type StudentStats = BaseDashboardStats & {
   display_name: string;
 };
 
-export type StudentsStats = StudentStats[];
+export type StudentsResponse = {
+  students: StudentStats[];
+};
 
 /**
  * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
@@ -191,4 +195,6 @@ export type AssignmentStats = Assignment & {
   stats: BaseDashboardStats;
 };
 
-export type AssignmentsStats = AssignmentStats[];
+export type AssignmentsResponse = {
+  assignments: AssignmentStats[];
+};

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -7,7 +7,7 @@ import {
 import classnames from 'classnames';
 import { useParams } from 'wouter-preact';
 
-import type { Assignment, StudentsStats } from '../../api-types';
+import type { Assignment, StudentsResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
@@ -25,7 +25,7 @@ export default function AssignmentActivity() {
   const assignment = useAPIFetch<Assignment>(
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
-  const students = useAPIFetch<StudentsStats>(
+  const students = useAPIFetch<StudentsResponse>(
     replaceURLParams(routes.assignment_stats, { assignment_id: assignmentId }),
   );
 
@@ -65,7 +65,7 @@ export default function AssignmentActivity() {
           emptyMessage={
             students.error ? 'Could not load students' : 'No students found'
           }
-          rows={students.data ?? []}
+          rows={students.data?.students ?? []}
           columnNames={{
             display_name: 'Student',
             annotations: 'Annotations',

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 import { useParams, Link as RouterLink } from 'wouter-preact';
 
-import type { AssignmentsStats, Course } from '../../api-types';
+import type { AssignmentsResponse, Course } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
@@ -35,7 +35,7 @@ export default function CourseActivity() {
   const course = useAPIFetch<Course>(
     replaceURLParams(routes.course, { course_id: courseId }),
   );
-  const assignments = useAPIFetch<AssignmentsStats>(
+  const assignments = useAPIFetch<AssignmentsResponse>(
     replaceURLParams(routes.course_assignment_stats, {
       course_id: courseId,
     }),
@@ -43,7 +43,7 @@ export default function CourseActivity() {
 
   const rows: AssignmentsTableRow[] = useMemo(
     () =>
-      (assignments.data ?? []).map(({ id, title, stats }) => ({
+      (assignments.data?.assignments ?? []).map(({ id, title, stats }) => ({
         id,
         title,
         ...stats,

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -6,7 +6,7 @@ import {
 } from '@hypothesis/frontend-shared';
 import { Link as RouterLink } from 'wouter-preact';
 
-import type { Courses } from '../../api-types';
+import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
@@ -24,7 +24,7 @@ export default function OrganizationActivity({
 }: OrganizationActivityProps) {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
-  const courses = useAPIFetch<Courses>(
+  const courses = useAPIFetch<CoursesResponse>(
     replaceURLParams(routes.organization_courses, {
       organization_public_id: organizationPublicId,
     }),
@@ -40,7 +40,7 @@ export default function OrganizationActivity({
           emptyMessage={
             courses.error ? 'Could not load courses' : 'No courses found'
           }
-          rows={courses.data ?? []}
+          rows={courses.data?.courses ?? []}
           columnNames={{ title: 'Course Title' }}
           defaultOrderField="title"
           renderItem={stats => (

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -38,7 +38,7 @@ describe('AssignmentActivity', () => {
     fakeUseAPIFetch = sinon.stub().callsFake(url => ({
       isLoading: false,
       data: url.endsWith('stats')
-        ? students
+        ? { students }
         : {
             title: 'The title',
             course: {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -46,7 +46,7 @@ describe('CourseActivity', () => {
   beforeEach(() => {
     fakeUseAPIFetch = sinon.stub().callsFake(url => ({
       isLoading: false,
-      data: url.endsWith('stats') ? assignments : { title: 'The title' },
+      data: url.endsWith('stats') ? { assignments } : { title: 'The title' },
     }));
     fakeConfig = {
       dashboard: {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -24,7 +24,7 @@ describe('OrganizationActivity', () => {
   let fakeConfig;
 
   beforeEach(() => {
-    fakeUseAPIFetch = sinon.stub().resolves(courses);
+    fakeUseAPIFetch = sinon.stub().resolves({ courses });
     fakeConfig = {
       dashboard: {
         routes: {

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -1,6 +1,6 @@
 from pyramid.view import view_config
 
-from lms.js_config_types import APIAssignment, APICourse, APIStudentStats
+from lms.js_config_types import APIAssignment, APICourse, APIStudents, APIStudentStats
 from lms.models import RoleScope, RoleType
 from lms.security import Permissions
 from lms.services.h_api import HAPI
@@ -33,7 +33,7 @@ class AssignmentViews:
         renderer="json",
         permission=Permissions.DASHBOARD_VIEW,
     )
-    def assignment_stats(self) -> list[APIStudentStats]:
+    def assignment_stats(self) -> APIStudents:
         """Fetch the stats for one particular assignment."""
         assignment = get_request_assignment(self.request, self.assignment_service)
         stats = self.h_api.get_assignment_stats(
@@ -72,4 +72,4 @@ class AssignmentViews:
                     }
                 )
 
-        return student_stats
+        return {"students": student_stats}

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -2,7 +2,9 @@ from pyramid.view import view_config
 
 from lms.js_config_types import (
     APIAssignment,
+    APIAssignments,
     APICourse,
+    APICourses,
     AssignmentStats,
 )
 from lms.security import Permissions
@@ -24,12 +26,16 @@ class CourseViews:
         renderer="json",
         permission=Permissions.DASHBOARD_VIEW,
     )
-    def get_organization_courses(self) -> list[APICourse]:
+    def get_organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
         courses = self.course_service.search(
             limit=None, organization_ids=[org.id], user=self.request.user
         )
-        return [APICourse(id=course.id, title=course.lms_name) for course in courses]
+        return {
+            "courses": [
+                APICourse(id=course.id, title=course.lms_name) for course in courses
+            ]
+        }
 
     @view_config(
         route_name="api.dashboard.course",
@@ -50,7 +56,7 @@ class CourseViews:
         renderer="json",
         permission=Permissions.DASHBOARD_VIEW,
     )
-    def course_stats(self) -> list[APIAssignment]:
+    def course_stats(self) -> APIAssignments:
         course = get_request_course(self.request, self.course_service)
 
         stats = self.h_api.get_course_stats(
@@ -84,4 +90,4 @@ class CourseViews:
                 )
             )
 
-        return assignment_stats
+        return {"assignments": assignment_stats}

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -68,26 +68,28 @@ class TestAssignmentViews:
             [g.authority_provided_id for g in assignment.groupings],
             assignment.resource_link_id,
         )
-        assert response == [
-            {
-                "display_name": student.display_name,
-                "annotations": sentinel.annotations,
-                "replies": sentinel.replies,
-                "last_activity": sentinel.last_activity,
-            },
-            {
-                "display_name": student_no_annos.display_name,
-                "annotations": 0,
-                "replies": 0,
-                "last_activity": None,
-            },
-            {
-                "display_name": f"Student {student_no_annos_no_name.user_id[:10]}",
-                "annotations": 0,
-                "replies": 0,
-                "last_activity": None,
-            },
-        ]
+        assert response == {
+            "students": [
+                {
+                    "display_name": student.display_name,
+                    "annotations": sentinel.annotations,
+                    "replies": sentinel.replies,
+                    "last_activity": sentinel.last_activity,
+                },
+                {
+                    "display_name": student_no_annos.display_name,
+                    "annotations": 0,
+                    "replies": 0,
+                    "last_activity": None,
+                },
+                {
+                    "display_name": f"Student {student_no_annos_no_name.user_id[:10]}",
+                    "annotations": 0,
+                    "replies": 0,
+                    "last_activity": None,
+                },
+            ]
+        }
 
     @pytest.fixture
     def views(self, pyramid_request):

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -30,7 +30,9 @@ class TestCourseViews:
             user=pyramid_request.user,
         )
 
-        assert response == [{"id": c.id, "title": c.lms_name} for c in courses]
+        assert response == {
+            "courses": [{"id": c.id, "title": c.lms_name} for c in courses]
+        }
 
     def test_course(self, views, pyramid_request, course_service):
         pyramid_request.matchdict["course_id"] = sentinel.id
@@ -80,34 +82,36 @@ class TestCourseViews:
         h_api.get_course_stats.assert_called_once_with(
             [course.authority_provided_id, section.authority_provided_id]
         )
-        assert response == [
-            {
-                "id": assignment.id,
-                "title": assignment.title,
-                "course": {
-                    "id": course.id,
-                    "title": course.lms_name,
+        assert response == {
+            "assignments": [
+                {
+                    "id": assignment.id,
+                    "title": assignment.title,
+                    "course": {
+                        "id": course.id,
+                        "title": course.lms_name,
+                    },
+                    "stats": {
+                        "annotations": sentinel.annotations,
+                        "replies": sentinel.replies,
+                        "last_activity": sentinel.last_activity,
+                    },
                 },
-                "stats": {
-                    "annotations": sentinel.annotations,
-                    "replies": sentinel.replies,
-                    "last_activity": sentinel.last_activity,
+                {
+                    "id": assignment_with_no_annos.id,
+                    "title": assignment_with_no_annos.title,
+                    "course": {
+                        "id": course.id,
+                        "title": course.lms_name,
+                    },
+                    "stats": {
+                        "annotations": 0,
+                        "replies": 0,
+                        "last_activity": None,
+                    },
                 },
-            },
-            {
-                "id": assignment_with_no_annos.id,
-                "title": assignment_with_no_annos.title,
-                "course": {
-                    "id": course.id,
-                    "title": course.lms_name,
-                },
-                "stats": {
-                    "annotations": 0,
-                    "replies": 0,
-                    "last_activity": None,
-                },
-            },
-        ]
+            ]
+        }
 
     @pytest.fixture
     def views(self, pyramid_request):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6325

This PR refactors three dashboard API endpoints that were returning arrays, so that they instead returns JSON objects with a single prop.

This will allow us to extend the responses in a non-breaking way in future, if we need to add extra properties, like pagination and such.