### PR TITLE
Create usage report service

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -33,6 +33,7 @@ from lms.services.lti_user import LTIUserService
 from lms.services.ltia_http import LTIAHTTPService
 from lms.services.moodle import MoodleAPIClient
 from lms.services.organization import OrganizationService
+from lms.services.organization_usage_report import OrganizationUsageReportService
 from lms.services.region import RegionService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
@@ -128,6 +129,10 @@ def includeme(config):
     config.register_service_factory("lms.services.event.factory", iface=EventService)
     config.register_service_factory(
         "lms.services.organization.service_factory", iface=OrganizationService
+    )
+    config.register_service_factory(
+        "lms.services.organization_usage_report.service_factory",
+        iface=OrganizationUsageReportService,
     )
     config.register_service_factory("lms.services.region.factory", iface=RegionService)
     config.register_service_factory(

--- a/lms/services/organization.py
+++ b/lms/services/organization.py
@@ -1,36 +1,20 @@
-from dataclasses import asdict, dataclass
-from datetime import datetime
 from logging import getLogger
 
 import sqlalchemy as sa
-from sqlalchemy import Date, func, select
-from sqlalchemy.orm import Session, aliased
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from lms.db import full_text_match
 from lms.models import (
     ApplicationInstance,
     Course,
     GroupInfo,
-    Grouping,
     GroupingMembership,
     Organization,
-    OrganizationUsageReport,
     User,
 )
-from lms.services.h_api import HAPI
 
 LOG = getLogger(__name__)
-
-
-@dataclass
-class UsageReportRow:
-    name: str | None
-    email: str | None
-    h_userid: str
-
-    course_name: str
-    course_created: datetime
-    authority_provided_id: str
 
 
 class InvalidOrganizationParent(Exception):
@@ -40,9 +24,8 @@ class InvalidOrganizationParent(Exception):
 class OrganizationService:
     """A service for dealing with organization actions."""
 
-    def __init__(self, db_session: Session, h_api: HAPI):
+    def __init__(self, db_session: Session):
         self._db_session = db_session
-        self._h_api = h_api
 
     def get_by_id(self, id_: int) -> Organization | None:
         """
@@ -240,124 +223,6 @@ class OrganizationService:
 
         return organization
 
-    def generate_usage_report(
-        self, organization_id: int, tag: str, since: datetime, until: datetime
-    ):
-        """Generate and store an usage report for one organization."""
-        organization = self.get_by_id(organization_id)
-        assert organization
-        report_key = OrganizationUsageReport.generate_key(
-            organization, tag, since, until
-        )
-
-        if (
-            report := self._db_session.query(OrganizationUsageReport)
-            .filter_by(key=report_key)
-            .one_or_none()
-        ):
-            LOG.debug("Report already exists, skipping generation. %s", report_key)
-            return report
-
-        report = OrganizationUsageReport(
-            organization=organization,
-            key=report_key,
-            since=since,
-            until=until,
-            tag=tag,
-        )
-        self._db_session.add(report)
-
-        report_rows = self.usage_report(organization, since, until)
-
-        report.unique_users = len({r.h_userid for r in report_rows})
-        report.report = [asdict(r) for r in report_rows]
-
-        return report
-
-    def usage_report(
-        self,
-        organization: Organization,
-        since: datetime,
-        until: datetime,
-    ):
-        # Organizations that are children of the current one.
-        # It includes the current org ID.
-        organization_children = self.get_hierarchy_ids(
-            organization.id, include_parents=False
-        )
-        # All the groups that can hold annotations (courses and segments) from this org
-        groups_from_org = self._db_session.scalars(
-            select(Grouping.authority_provided_id)
-            .join(ApplicationInstance)
-            .where(
-                ApplicationInstance.organization_id.in_(organization_children),
-                # If a group was created after the date we are interested, exclude it
-                Grouping.created <= until,
-            )
-        ).all()
-
-        if not groups_from_org:
-            raise ValueError(f"No courses found for {organization.public_id}")
-
-        # Of those groups, get the ones that do have annotations in the time period
-        groups_with_annos = [
-            group.authority_provided_id
-            for group in self._h_api.get_groups(groups_from_org, since, until)
-        ]
-        if not groups_with_annos:
-            raise ValueError(
-                f"No courses with activity found for {organization.public_id}"
-            )
-
-        # Based on those groups generate the usage report based on the definition of unique user:
-        # Users that belong to a course in which there are annotations in the time period
-        parent = aliased(Grouping)
-        query = (
-            select(
-                User.display_name.label("name"),
-                User.email.label("email"),
-                User.h_userid.label("h_userid"),
-                Grouping.lms_name.label("course_name"),
-                func.date_trunc("day", Grouping.created)
-                .cast(Date)
-                .label("course_created"),
-                Grouping.authority_provided_id,
-            )
-            .select_from(User)
-            .join(GroupingMembership)
-            .join(Grouping)
-            .distinct()
-            .where(
-                Grouping.authority_provided_id.in_(
-                    # The report is based in courses so we query either
-                    # groupings with no parent (courses) or the parents of segments (courses)
-                    select(
-                        func.coalesce(
-                            parent.authority_provided_id, Grouping.authority_provided_id
-                        )
-                    )
-                    .select_from(Grouping)
-                    .outerjoin(parent, Grouping.parent_id == parent.id)
-                    .where(Grouping.authority_provided_id.in_(groups_with_annos))
-                ),
-                # We can't exactly know the state of membership in the past but we can
-                # know if someone was added to the group after the date we are interested
-                GroupingMembership.created <= until,
-            )
-        )
-        return [
-            UsageReportRow(
-                # Students might have name but they never have email
-                name=row.name if row.email else "<STUDENT>",
-                email=row.email if row.email else "<STUDENT>",
-                h_userid=row.h_userid,
-                course_name=row.course_name,
-                course_created=row.course_created.isoformat(),
-                authority_provided_id=row.authority_provided_id,
-            )
-            for row in self._db_session.execute(query).all()
-        ]
-
     def _move_organization_parent(self, organization: Organization, parent_public_id):
         """Change an organizations parent, without creating loops."""
 
@@ -441,7 +306,4 @@ class OrganizationService:
 def service_factory(_context, request) -> OrganizationService:
     """Get a new instance of OrganizationService."""
 
-    return OrganizationService(
-        db_session=request.db,
-        h_api=request.find_service(HAPI),
-    )
+    return OrganizationService(db_session=request.db)

--- a/lms/services/organization_usage_report.py
+++ b/lms/services/organization_usage_report.py
@@ -1,0 +1,168 @@
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from logging import getLogger
+
+from sqlalchemy import Date, func, select
+from sqlalchemy.orm import Session, aliased
+
+from lms.models import (
+    ApplicationInstance,
+    Grouping,
+    GroupingMembership,
+    Organization,
+    OrganizationUsageReport,
+    User,
+)
+from lms.services.h_api import HAPI
+from lms.services.organization import OrganizationService
+
+LOG = getLogger(__name__)
+
+
+@dataclass
+class UsageReportRow:
+    name: str | None
+    email: str | None
+    h_userid: str
+
+    course_name: str
+    course_created: datetime
+    authority_provided_id: str
+
+
+class OrganizationUsageReportService:
+    def __init__(
+        self,
+        db_session: Session,
+        h_api: HAPI,
+        organization_service: OrganizationService,
+    ):
+        self._db_session = db_session
+        self._organization_service = organization_service
+        self._h_api = h_api
+
+    def generate_usage_report(
+        self, organization_id: int, tag: str, since: datetime, until: datetime
+    ):
+        """Generate and store an usage report for one organization."""
+        organization = self._organization_service.get_by_id(organization_id)
+        assert organization
+        report_key = OrganizationUsageReport.generate_key(
+            organization, tag, since, until
+        )
+
+        if (
+            report := self._db_session.query(OrganizationUsageReport)
+            .filter_by(key=report_key)
+            .one_or_none()
+        ):
+            LOG.debug("Report already exists, skipping generation. %s", report_key)
+            return report
+
+        report = OrganizationUsageReport(
+            organization=organization,
+            key=report_key,
+            since=since,
+            until=until,
+            tag=tag,
+        )
+        self._db_session.add(report)
+
+        report_rows = self.usage_report(organization, since, until)
+
+        report.unique_users = len({r.h_userid for r in report_rows})
+        report.report = [asdict(r) for r in report_rows]
+
+        return report
+
+    def usage_report(
+        self,
+        organization: Organization,
+        since: datetime,
+        until: datetime,
+    ):
+        # Organizations that are children of the current one.
+        # It includes the current org ID.
+        organization_children = self._organization_service.get_hierarchy_ids(
+            organization.id, include_parents=False
+        )
+        # All the groups that can hold annotations (courses and segments) from this org
+        groups_from_org = self._db_session.scalars(
+            select(Grouping.authority_provided_id)
+            .join(ApplicationInstance)
+            .where(
+                ApplicationInstance.organization_id.in_(organization_children),
+                # If a group was created after the date we are interested, exclude it
+                Grouping.created <= until,
+            )
+        ).all()
+
+        if not groups_from_org:
+            raise ValueError(f"No courses found for {organization.public_id}")
+
+        # Of those groups, get the ones that do have annotations in the time period
+        groups_with_annos = [
+            group.authority_provided_id
+            for group in self._h_api.get_groups(groups_from_org, since, until)
+        ]
+        if not groups_with_annos:
+            raise ValueError(
+                f"No courses with activity found for {organization.public_id}"
+            )
+
+        # Based on those groups generate the usage report based on the definition of unique user:
+        # Users that belong to a course in which there are annotations in the time period
+        parent = aliased(Grouping)
+        query = (
+            select(
+                User.display_name.label("name"),
+                User.email.label("email"),
+                User.h_userid.label("h_userid"),
+                Grouping.lms_name.label("course_name"),
+                func.date_trunc("day", Grouping.created)
+                .cast(Date)
+                .label("course_created"),
+                Grouping.authority_provided_id,
+            )
+            .select_from(User)
+            .join(GroupingMembership)
+            .join(Grouping)
+            .distinct()
+            .where(
+                Grouping.authority_provided_id.in_(
+                    # The report is based in courses so we query either
+                    # groupings with no parent (courses) or the parents of segments (courses)
+                    select(
+                        func.coalesce(
+                            parent.authority_provided_id, Grouping.authority_provided_id
+                        )
+                    )
+                    .select_from(Grouping)
+                    .outerjoin(parent, Grouping.parent_id == parent.id)
+                    .where(Grouping.authority_provided_id.in_(groups_with_annos))
+                ),
+                # We can't exactly know the state of membership in the past but we can
+                # know if someone was added to the group after the date we are interested
+                GroupingMembership.created <= until,
+            )
+        )
+        return [
+            UsageReportRow(
+                # Students might have name but they never have email
+                name=row.name if row.email else "<STUDENT>",
+                email=row.email if row.email else "<STUDENT>",
+                h_userid=row.h_userid,
+                course_name=row.course_name,
+                course_created=row.course_created.isoformat(),
+                authority_provided_id=row.authority_provided_id,
+            )
+            for row in self._db_session.execute(query).all()
+        ]
+
+
+def service_factory(_context, request) -> OrganizationUsageReportService:
+    return OrganizationUsageReportService(
+        db_session=request.db,
+        h_api=request.find_service(HAPI),
+        organization_service=request.find_service(OrganizationService),
+    )

--- a/lms/tasks/organization.py
+++ b/lms/tasks/organization.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from lms.services import OrganizationService
+from lms.services import OrganizationUsageReportService
 from lms.tasks.celery import app
 
 
@@ -10,7 +10,7 @@ def generate_usage_report(
 ) -> None:
     with app.request_context() as request:
         with request.tm:
-            request.find_service(OrganizationService).generate_usage_report(
+            request.find_service(OrganizationUsageReportService).generate_usage_report(
                 organization_id,
                 tag,
                 datetime.fromisoformat(since),

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -9,7 +9,11 @@ from lms.events import AuditTrailEvent
 from lms.models import Organization
 from lms.models.public_id import InvalidPublicId
 from lms.security import Permissions
-from lms.services import HubSpotService, OrganizationService
+from lms.services import (
+    HubSpotService,
+    OrganizationService,
+    OrganizationUsageReportService,
+)
 from lms.services.organization import InvalidOrganizationParent
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
@@ -39,6 +43,10 @@ class AdminOrganizationViews:
         self.organization_service: OrganizationService = request.find_service(
             OrganizationService
         )
+        self.organization_usage_report_service: OrganizationService = (
+            request.find_service(OrganizationUsageReportService)
+        )
+
         self.hubspot_service: HubSpotService = request.find_service(HubSpotService)
 
     @view_config(
@@ -203,7 +211,9 @@ class AdminOrganizationViews:
             raise HTTPBadRequest("Usage reports can only be generated since 2023")
 
         try:
-            report = self.organization_service.usage_report(org, since, until)
+            report = self.organization_usage_report_service.usage_report(
+                org, since, until
+            )
         except ValueError as exc:
             self.request.session.flash(
                 f"There was a problem generating the report: {exc}", "errors"

--- a/tests/unit/lms/services/organization_test.py
+++ b/tests/unit/lms/services/organization_test.py
@@ -1,15 +1,12 @@
-from datetime import datetime, timedelta
-from unittest.mock import patch, sentinel
+from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
 
 from lms.models import Organization
-from lms.services.h_api import HAPI
 from lms.services.organization import (
     InvalidOrganizationParent,
     OrganizationService,
-    UsageReportRow,
     service_factory,
 )
 from tests import factories
@@ -217,151 +214,6 @@ class TestOrganizationService:
 
         assert org_with_parent.parent
 
-    def test_generate_usage_report(self, svc, org_with_parent, usage_report):
-        usage_report.return_value = [
-            UsageReportRow(
-                name="<STUDENT>",
-                email="<STUDENT>",
-                h_userid=sentinel.h_userid,
-                course_name=sentinel.lms_name,
-                course_created="2020-01-01",
-                authority_provided_id=sentinel.authority_provided_id,
-            ),
-            UsageReportRow(
-                name="<STUDENT>",
-                email="<STUDENT>",
-                h_userid=sentinel.h_userid,
-                course_name=sentinel.lms_name,
-                course_created="2020-01-01",
-                authority_provided_id=sentinel.authority_provided_id,
-            ),
-        ]
-
-        report = svc.generate_usage_report(
-            org_with_parent.id, "test", "2020-01-01", "2020-02-02"
-        )
-
-        usage_report.assert_called_once_with(
-            org_with_parent, "2020-01-01", "2020-02-02"
-        )
-
-        assert report.organization == org_with_parent
-        assert report.unique_users == 1
-        assert report.since == "2020-01-01"
-        assert report.until == "2020-02-02"
-        assert len(report.report) == 2
-
-    def test_generate_usage_report_existing_report(self, svc, org_with_parent):
-        report = factories.OrganizationUsageReport(
-            organization=org_with_parent,
-            key=f"{org_with_parent.public_id}-test-2020-01-01-2020-02-02",
-            tag="test",
-        )
-
-        assert (
-            svc.generate_usage_report(
-                org_with_parent.id, "test", "2020-01-01", "2020-02-02"
-            )
-            == report
-        )
-
-    def test_usage_report(self, svc, org_with_parent, h_api):
-        since = datetime(2023, 1, 1)
-        until = datetime(2023, 12, 31)
-
-        ai_root_org = factories.ApplicationInstance(organization=org_with_parent.parent)
-        ai_child_org = factories.ApplicationInstance(organization=org_with_parent)
-        course_root = factories.Course(
-            application_instance=ai_root_org,
-            created=since + timedelta(days=1),
-        )
-        section = factories.CanvasSection(
-            application_instance=ai_root_org,
-            parent=course_root,
-            created=since + timedelta(days=1),
-        )
-        course_child = factories.Course(
-            application_instance=ai_child_org, created=since + timedelta(days=1)
-        )
-        # Course created after the until date
-        factories.Course(
-            application_instance=ai_child_org,
-            created=until + timedelta(days=1),
-        )
-        # Annotations in one section and in the other course
-        h_api.get_groups.return_value = [
-            HAPI.HAPIGroup(authority_provided_id=group.authority_provided_id)
-            for group in [section, course_child]
-        ]
-        # Users that belong to the course
-        user_1 = factories.User(display_name="NAME", email="EMAIL")
-        user_2 = factories.User()
-        factories.GroupingMembership(
-            user=user_1, grouping=course_child, created=since + timedelta(days=1)
-        )
-        factories.GroupingMembership(
-            user=user_2, grouping=course_root, created=since + timedelta(days=1)
-        )
-
-        report = svc.usage_report(org_with_parent.parent, since, until)
-
-        h_api.get_groups.assert_called_once_with(
-            Any.list.containing(
-                [
-                    course_root.authority_provided_id,
-                    course_child.authority_provided_id,
-                    section.authority_provided_id,
-                ]
-            ),
-            since,
-            until,
-        )
-
-        # We expect to get both users belonging to each course
-        expected = [
-            UsageReportRow(
-                name=user_1.display_name,
-                email=user_1.email,
-                h_userid=user_1.h_userid,
-                course_name=course_child.lms_name,
-                course_created=course_child.created.date().isoformat(),
-                authority_provided_id=course_child.authority_provided_id,
-            ),
-            UsageReportRow(
-                name="<STUDENT>",
-                email="<STUDENT>",
-                h_userid=user_2.h_userid,
-                course_name=course_root.lms_name,
-                course_created=course_root.created.date().isoformat(),
-                authority_provided_id=course_root.authority_provided_id,
-            ),
-        ]
-        assert report == Any.list.containing(expected)
-
-    def test_usage_report_with_no_courses(self, svc, org_with_parent):
-        since = datetime(2023, 1, 1)
-        until = datetime(2023, 12, 31)
-
-        with pytest.raises(ValueError) as error:
-            svc.usage_report(org_with_parent.parent, since, until)
-
-        assert "no courses found" in str(error.value).lower()
-
-    def test_usage_report_with_no_activity(self, svc, org_with_parent, h_api):
-        since = datetime(2023, 1, 1)
-        until = datetime(2023, 12, 31)
-
-        ai_root_org = factories.ApplicationInstance(organization=org_with_parent.parent)
-        factories.Course(
-            application_instance=ai_root_org, created=since + timedelta(days=1)
-        )
-        h_api.get_groups.return_value = []
-
-        with pytest.raises(ValueError) as error:
-            svc.usage_report(org_with_parent.parent, since, until)
-
-        assert "no courses with activity" in str(error.value).lower()
-
     def test_is_member(self, svc, db_session):
         org = factories.Organization()
         ai = factories.ApplicationInstance(organization=org)
@@ -391,8 +243,8 @@ class TestOrganizationService:
         )
 
     @pytest.fixture
-    def svc(self, db_session, h_api):
-        return OrganizationService(db_session=db_session, h_api=h_api)
+    def svc(self, db_session):
+        return OrganizationService(db_session=db_session)
 
     @pytest.fixture
     def application_instance(self):
@@ -400,19 +252,12 @@ class TestOrganizationService:
             tool_consumer_instance_guid="guid", tool_consumer_instance_name="ai_name"
         )
 
-    @pytest.fixture
-    def usage_report(self, svc):
-        with patch.object(svc, "usage_report") as usage_report:
-            yield usage_report
-
 
 class TestServiceFactory:
-    def test_it(self, pyramid_request, OrganizationService, h_api):
+    def test_it(self, pyramid_request, OrganizationService):
         svc = service_factory(sentinel.context, pyramid_request)
 
-        OrganizationService.assert_called_once_with(
-            db_session=pyramid_request.db, h_api=h_api
-        )
+        OrganizationService.assert_called_once_with(db_session=pyramid_request.db)
         assert svc == OrganizationService.return_value
 
     @pytest.fixture

--- a/tests/unit/lms/tasks/organization_test.py
+++ b/tests/unit/lms/tasks/organization_test.py
@@ -7,7 +7,7 @@ import pytest
 from lms.tasks.organization import generate_usage_report
 
 
-def test_delete_expired_rows(organization_service):
+def test_generate_usage_report(organization_usage_report_service):
     generate_usage_report(
         sentinel.id,
         sentinel.tag,
@@ -15,7 +15,7 @@ def test_delete_expired_rows(organization_service):
         "2024-02-02:00:00:00",
     )
 
-    organization_service.generate_usage_report.assert_called_once_with(
+    organization_usage_report_service.generate_usage_report.assert_called_once_with(
         sentinel.id,
         sentinel.tag,
         datetime(2024, 1, 1, 0, 0, 0),

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -12,7 +12,9 @@ from tests import factories
 from tests.matchers import temporary_redirect_to
 
 
-@pytest.mark.usefixtures("organization_service", "hubspot_service")
+@pytest.mark.usefixtures(
+    "organization_service", "hubspot_service", "organization_usage_report_service"
+)
 class TestAdminOrganizationViews:
     def test_new_organization_callback(
         self, pyramid_request, organization_service, views
@@ -229,7 +231,7 @@ class TestAdminOrganizationViews:
         self,
         views,
         pyramid_request,
-        organization_service,
+        organization_usage_report_service,
         form,
         expected_error_message,
     ):
@@ -239,11 +241,13 @@ class TestAdminOrganizationViews:
         with pytest.raises(HTTPBadRequest, match=expected_error_message):
             views.usage()
 
-        organization_service.usage_report.assert_not_called()
+        organization_usage_report_service.usage_report.assert_not_called()
 
     @pytest.mark.usefixtures("with_valid_params_for_usage")
-    def test_usage_flashes_if_service_raises(self, views, organization_service):
-        organization_service.usage_report.side_effect = ValueError
+    def test_usage_flashes_if_service_raises(
+        self, views, organization_service, organization_usage_report_service
+    ):
+        organization_usage_report_service.usage_report.side_effect = ValueError
         since = datetime(2023, 1, 1)
         until = datetime(2023, 12, 31)
 
@@ -253,7 +257,9 @@ class TestAdminOrganizationViews:
         assert result == {"org": org, "since": since, "until": until, "report": []}
 
     @pytest.mark.usefixtures("with_valid_params_for_usage")
-    def test_usage(self, organization_service, views):
+    def test_usage(
+        self, organization_service, views, organization_usage_report_service
+    ):
         since = datetime(2023, 1, 1)
         until = datetime(2023, 12, 31)
 
@@ -261,12 +267,14 @@ class TestAdminOrganizationViews:
 
         organization_service.get_by_id.assert_called_once_with(sentinel.id_)
         org = organization_service.get_by_id.return_value
-        organization_service.usage_report.assert_called_once_with(org, since, until)
+        organization_usage_report_service.usage_report.assert_called_once_with(
+            org, since, until
+        )
         assert result == {
             "org": org,
             "since": since,
             "until": until,
-            "report": organization_service.usage_report.return_value,
+            "report": organization_usage_report_service.usage_report.return_value,
         }
 
     @pytest.fixture

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -44,6 +44,7 @@ from lms.services.moodle import MoodleAPIClient
 from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
+from lms.services.organization_usage_report import OrganizationUsageReportService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -91,6 +92,7 @@ __all__ = (
     "oauth2_token_service",
     "oauth_http_service",
     "organization_service",
+    "organization_usage_report_service",
     "rsa_key_service",
     "user_service",
     "user_preferences_service",
@@ -285,6 +287,11 @@ def async_oauth_http_service(mock_service):
 @pytest.fixture
 def organization_service(mock_service):
     return mock_service(OrganizationService)
+
+
+@pytest.fixture
+def organization_usage_report_service(mock_service):
+    return mock_service(OrganizationUsageReportService)
 
 
 @pytest.fixture


### PR DESCRIPTION
Move methods from organization service


This should be a pure refactor, no functional changes. `OrganizationService` was getting too long.