### PR TITLE
Remove hardcoded top padding in ErrorDisplay

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BookPicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/BookPicker.tsx
@@ -311,6 +311,7 @@ export default function BookPicker({
       )}
       {error && (
         <ErrorDisplay
+          classes="pt-4"
           description={
             step === 'select-book'
               ? 'Unable to fetch books'

--- a/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorDisplay.tsx
@@ -109,6 +109,9 @@ export type ErrorDisplayProps = {
    * Wether or not to show the standard link to our support page
    */
   displaySupportLink?: boolean;
+
+  /** Extra CSS classes to append to the error display wrapper */
+  classes?: string | string[];
 };
 
 /**
@@ -119,21 +122,15 @@ export default function ErrorDisplay({
   description = '',
   error,
   displaySupportLink = true,
+  classes,
 }: ErrorDisplayProps) {
   const message = formatErrorMessage(error, /* prefix */ description);
 
   const { debug } = useConfig();
 
   return (
-    <Scroll
-      classes={classnames(
-        // FIXME This class can be removed once the Modal in LMSFilePicker
-        // has been updated to latest frontend-shared components.
-        // Now it is needed to overwrite a style set on the modal itself.
-        '!mt-0',
-      )}
-    >
-      <div className="pt-4 space-y-4">
+    <Scroll classes={classes}>
+      <div className="space-y-4">
         {message && <p data-testid="error-message">{toSentence(message)}</p>}
 
         {children}

--- a/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
+++ b/lms/static/scripts/frontend_apps/components/ErrorModal.tsx
@@ -124,6 +124,7 @@ export default function ErrorModal({
     >
       {error && (
         <ErrorDisplay
+          classes="pt-4"
           description={description}
           error={error}
           displaySupportLink={displaySupportLink}

--- a/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
+++ b/lms/static/scripts/frontend_apps/components/LMSFilePicker.tsx
@@ -435,6 +435,7 @@ export default function LMSFilePicker({
 
       {dialogState.state === 'error' && (
         <ErrorDisplay
+          classes="pt-4"
           description={`There was a problem fetching ${documentType}s`}
           error={dialogState.error}
         />


### PR DESCRIPTION
While working on something else, I noticed a couple potential improvements in the `ErrorDisplay` component.

* While inspecting the DOM, I noticed there was a `!mt-0` class set in the Scroll container, but I didn't see any other implicit margin that could justify setting that.
    Then I saw a comment in code mentioning it was a workaround that could be removed after updating frontend-shared. We have updated it multiple times since the comment was created, so I assume it is now safe to remove.
* `ErrorDisplay`'s first non-Scroll element had a hardcoded top padding via `pt-4` tailwind class.
    In order to use this component outside of `ErrorModal`s, it's more convenient to not have that padding, and let consuming code control that, so I have added a `classes` prop, and passed the padding from places where `ErrorDisplay` is currently used.

### Testing steps

There should be no visual differences. You can fake an error by applying this diff in `BasicLTILaunchApp`:

```diff
diff --git a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
index f3c2abe91..f22cea92a 100644
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -188,7 +188,7 @@ export default function BasicLTILaunchApp() {
     try {
       const { via_url: contentURL } = await apiCall<{ via_url: string }>({
         authToken: authToken,
-        path: viaAPICallInfo.path,
+        path: 'foo',
       });
       setContentURL(contentURL);
       success = true;
```

1. Then try to launch an assignment that requires API calls, like a Canvas-file one.
2. Open the assignment in a new window.
3. Reduce the viewport's height by resizing the window or opening the browser's dev console.
4. Check the error area is still scrollable, and the top padding looks the same as before.