### PR TITLE
Explicitly use h_userid to search and check membership of users to courses

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -78,7 +78,7 @@ class CourseService:
         name: str | None = None,
         limit: int = 100,
         organization_ids: list[int] | None = None,
-        user: User | None = None,
+        h_userid: str | None = None,
     ) -> list[Course]:
         query = self._db.query(Course)
 
@@ -104,12 +104,12 @@ class CourseService:
                 .filter(Organization.id.in_(organization_ids))
             )
 
-        if user:
-            # Only courses `user` belongs to
+        if h_userid:
+            # Only courses where the H's h_userid belongs to
             query = (
                 query.join(GroupingMembership)
                 .join(User)
-                .filter(User.h_userid == user.h_userid)
+                .filter(User.h_userid == h_userid)
             )
 
         return query.limit(limit).all()
@@ -208,9 +208,11 @@ class CourseService:
 
         return None
 
-    def is_member(self, course: Course, user: User) -> bool:
-        """Check if a user is a member of a course."""
-        return bool(course.memberships.filter_by(user=user).first())
+    def is_member(self, course: Course, h_userid: str) -> bool:
+        """Check if an H user is a member of a course."""
+        return bool(
+            course.memberships.join(User).filter(User.h_userid == h_userid).first()
+        )
 
     def _get_authority_provided_id(self, context_id):
         return self._grouping_service.get_authority_provided_id(

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -29,7 +29,9 @@ class CourseViews:
     def get_organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
         courses = self.course_service.search(
-            limit=None, organization_ids=[org.id], user=self.request.user
+            limit=None,
+            organization_ids=[org.id],
+            h_userid=self.request.user.h_userid if self.request.user else None,
         )
         return {
             "courses": [

--- a/lms/views/dashboard/base.py
+++ b/lms/views/dashboard/base.py
@@ -27,7 +27,7 @@ def get_request_course(request, course_service):
         # STAFF members in our admin pages can access all courses
         return course
 
-    if not course_service.is_member(course, request.user):
+    if not course_service.is_member(course, request.user.h_userid):
         raise HTTPUnauthorized()
 
     return course

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -300,7 +300,7 @@ class TestCourseService:
 
         assert result == [course]
 
-    def test_search_by_user(self, svc, db_session):
+    def test_search_by_h_userid(self, svc, db_session):
         user = factories.User()
         course = factories.Course()
         factories.Course.create_batch(10)
@@ -308,7 +308,7 @@ class TestCourseService:
         # Ensure ids are written
         db_session.flush()
 
-        result = svc.search(user=user)
+        result = svc.search(h_userid=user.h_userid)
 
         assert result == [course]
 
@@ -335,8 +335,8 @@ class TestCourseService:
 
         db_session.flush()
 
-        assert svc.is_member(course, user)
-        assert not svc.is_member(course, other_user)
+        assert svc.is_member(course, user.h_userid)
+        assert not svc.is_member(course, other_user.h_userid)
 
     @pytest.fixture
     def course(self, application_instance, grouping_service):

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -27,7 +27,7 @@ class TestCourseViews:
         course_service.search.assert_called_once_with(
             limit=None,
             organization_ids=[org.id],
-            user=pyramid_request.user,
+            h_userid=pyramid_request.user.h_userid,
         )
 
         assert response == {


### PR DESCRIPTION
The same person might have multiple "User" rows for example in different applications instances.

The h_userid value would be the same thought. Explicitly use this value instead of the full object both on the method to search for courses and to check user membership.



## Testing

Sanity check course listing by going to:

- http://localhost:8001/dashboard/organizations/LDtcl7EUTeW2UERPJLAVtA and clicking on any of the courses to exercise the is_member check.