### PR TITLE
Navigate in dashboard tables when clicking or confirming row

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -95,7 +95,9 @@ export default function CourseActivity() {
                   href={urlPath`/assignments/${String(stats.id)}`}
                   asChild
                 >
-                  <Link>{stats.title}</Link>
+                  <Link underline="always" variant="text">
+                    {stats.title}
+                  </Link>
                 </RouterLink>
               );
             }
@@ -105,6 +107,7 @@ export default function CourseActivity() {
               formatDateTime(new Date(stats.last_activity))
             );
           }}
+          navigateTo={stats => urlPath`/assignments/${String(stats.id)}`}
         />
       </CardContent>
     </Card>

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -3,6 +3,7 @@ import { DataTable } from '@hypothesis/frontend-shared';
 import { useOrderedRows } from '@hypothesis/frontend-shared';
 import type { OrderDirection } from '@hypothesis/frontend-shared/lib/types';
 import { useMemo, useState } from 'preact/hooks';
+import { useLocation } from 'wouter-preact';
 
 export type OrderableActivityTableProps<T> = Pick<
   DataTableProps<T>,
@@ -10,6 +11,12 @@ export type OrderableActivityTableProps<T> = Pick<
 > & {
   columnNames: Partial<Record<keyof T, string>>;
   defaultOrderField: keyof T;
+
+  /**
+   * Allows to define a URL to navigate to when a row is clicked or confirmed
+   * via Enter key.
+   */
+  navigateTo?: (row: T) => string;
 };
 
 /**
@@ -34,6 +41,7 @@ export default function OrderableActivityTable<T>({
   defaultOrderField,
   rows,
   columnNames,
+  navigateTo,
   ...restOfTableProps
 }: OrderableActivityTableProps<T>) {
   const [order, setOrder] = useState<Order<keyof T>>({
@@ -65,6 +73,7 @@ export default function OrderableActivityTable<T>({
       }, {}),
     [columnNames],
   );
+  const [, navigate] = useLocation();
 
   return (
     <DataTable
@@ -75,6 +84,8 @@ export default function OrderableActivityTable<T>({
       orderableColumns={orderableColumns}
       order={order}
       onOrderChange={setOrder}
+      onConfirmRow={navigateTo ? row => navigate(navigateTo(row)) : undefined}
+      onSelectRow={navigateTo ? row => navigate(navigateTo(row)) : undefined}
       {...restOfTableProps}
     />
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -45,9 +45,12 @@ export default function OrganizationActivity({
           defaultOrderField="title"
           renderItem={stats => (
             <RouterLink href={urlPath`/courses/${String(stats.id)}`} asChild>
-              <Link>{stats.title}</Link>
+              <Link underline="always" variant="text">
+                {stats.title}
+              </Link>
             </RouterLink>
           )}
+          navigateTo={stats => urlPath`/courses/${String(stats.id)}`}
         />
       </CardContent>
     </Card>


### PR DESCRIPTION
This PR updates dashboard tables which include links to other sections, so that navigation happens both when clicking the link itself (which is preserved for accessibility purposes), but also when clicking the whole row or pressing <kbd>Enter</kbd> while it's focused.

Additionally, this PR changes a bit the style of links in tables, to be more subtle and closer to the designs:

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/43d24071-27e4-4588-ac82-a8045016c057)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/1c699d57-9b61-447f-bb7b-7d0affac82ea)
