### PR TITLE
Use text-color, underline links in dashboard tables

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -95,7 +95,9 @@ export default function CourseActivity() {
                   href={urlPath`/assignments/${String(stats.id)}`}
                   asChild
                 >
-                  <Link>{stats.title}</Link>
+                  <Link underline="always" variant="text">
+                    {stats.title}
+                  </Link>
                 </RouterLink>
               );
             }

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -45,7 +45,9 @@ export default function OrganizationActivity({
           defaultOrderField="title"
           renderItem={stats => (
             <RouterLink href={urlPath`/courses/${String(stats.id)}`} asChild>
-              <Link>{stats.title}</Link>
+              <Link underline="always" variant="text">
+                {stats.title}
+              </Link>
             </RouterLink>
           )}
         />


### PR DESCRIPTION
Use text-color + underline style for links in dashboard tables.

This style is closer to the one in the designs.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/43d24071-27e4-4588-ac82-a8045016c057)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/1c699d57-9b61-447f-bb7b-7d0affac82ea)