### PR TITLE
Deduplicate courses when listing organization courses

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -73,7 +73,7 @@ class Grouping(CreatedUpdatedMixin, Base):
         ),
     )
 
-    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
 
     application_instance_id = sa.Column(
         sa.Integer(),

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -15,7 +15,7 @@ class Organization(CreatedUpdatedMixin, PublicIdMixin, Base):
     public_id_model_code = "org"
     """The short code which identifies this type of model in PublicIdMixin."""
 
-    id = sa.Column(sa.Integer(), autoincrement=True, primary_key=True)
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
 
     name = sa.Column(sa.UnicodeText(), nullable=True)
     """Human readable name for the organization."""

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -28,10 +28,8 @@ class CourseViews:
     )
     def get_organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
-        courses = self.course_service.search(
-            limit=None,
-            organization_ids=[org.id],
-            h_userid=self.request.user.h_userid if self.request.user else None,
+        courses = self.course_service.get_organization_courses(
+            org, h_userid=self.request.user.h_userid if self.request.user else None
         )
         return {
             "courses": [

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -15,7 +15,7 @@ class TestCourseViews:
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
         organization_service.get_by_public_id.return_value = org
-        course_service.search.return_value = courses
+        course_service.get_organization_courses.return_value = courses
         pyramid_request.matchdict["organization_public_id"] = sentinel.id_
         db_session.flush()
 
@@ -24,9 +24,8 @@ class TestCourseViews:
         organization_service.get_by_public_id.assert_called_once_with(
             "us.lms.org.sentinel.id_"
         )
-        course_service.search.assert_called_once_with(
-            limit=None,
-            organization_ids=[org.id],
+        course_service.get_organization_courses.assert_called_once_with(
+            organization=org,
             h_userid=pyramid_request.user.h_userid,
         )
 


### PR DESCRIPTION
The same LMS course might be represented by more than one row in the grouping table, for example if we have seen it linked to more than one application instance.

Deduplicate them when asking for a list of course within an organization but still return the raw data in the search method.


## Testing

Like other similar PRs, just sanity check the list of course over:

http://localhost:8001/dashboard/organizations/LDtcl7EUTeW2UERPJLAVtA/courses/1830

In production there are duplicates here, they should disappear after merging this.

https://lms.hypothes.is/dashboard/organizations/x9L8IC7tRRa2-rYITOx_yQ


