### PR TITLE
Navigate in dashboard tables when "confirming" a row

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -25,6 +25,8 @@ type AssignmentsTableRow = {
   replies: number;
 };
 
+const assignmentURL = (id: number) => urlPath`/assignments/${String(id)}`;
+
 /**
  * Activity in a list of assignments that are part of a specific course
  */
@@ -93,10 +95,7 @@ export default function CourseActivity() {
               return <div className="text-right">{stats[field]}</div>;
             } else if (field === 'title') {
               return (
-                <RouterLink
-                  href={urlPath`/assignments/${String(stats.id)}`}
-                  asChild
-                >
+                <RouterLink href={assignmentURL(stats.id)} asChild>
                   <Link underline="always" variant="text">
                     {stats.title}
                   </Link>
@@ -109,6 +108,7 @@ export default function CourseActivity() {
               formatDateTime(new Date(stats.last_activity))
             );
           }}
+          navigateOnConfirmRow={stats => assignmentURL(stats.id)}
         />
       </CardContent>
     </Card>

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -3,6 +3,7 @@ import { DataTable } from '@hypothesis/frontend-shared';
 import { useOrderedRows } from '@hypothesis/frontend-shared';
 import type { OrderDirection } from '@hypothesis/frontend-shared/lib/types';
 import { useMemo, useState } from 'preact/hooks';
+import { useLocation } from 'wouter-preact';
 
 export type OrderableActivityTableProps<T> = Pick<
   DataTableProps<T>,
@@ -10,6 +11,12 @@ export type OrderableActivityTableProps<T> = Pick<
 > & {
   columnNames: Partial<Record<keyof T, string>>;
   defaultOrderField: keyof T;
+
+  /**
+   * Allows to define a URL to navigate to when a row is confirmed via
+   * double-click/Enter key press.
+   */
+  navigateOnConfirmRow?: (row: T) => string;
 };
 
 /**
@@ -34,6 +41,7 @@ export default function OrderableActivityTable<T>({
   defaultOrderField,
   rows,
   columnNames,
+  navigateOnConfirmRow,
   ...restOfTableProps
 }: OrderableActivityTableProps<T>) {
   const [order, setOrder] = useState<Order<keyof T>>({
@@ -65,6 +73,7 @@ export default function OrderableActivityTable<T>({
       }, {}),
     [columnNames],
   );
+  const [, navigate] = useLocation();
 
   return (
     <DataTable
@@ -75,6 +84,11 @@ export default function OrderableActivityTable<T>({
       orderableColumns={orderableColumns}
       order={order}
       onOrderChange={setOrder}
+      onConfirmRow={
+        navigateOnConfirmRow
+          ? row => navigate(navigateOnConfirmRow(row))
+          : undefined
+      }
       {...restOfTableProps}
     />
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -16,6 +16,8 @@ export type OrganizationActivityProps = {
   organizationPublicId: string;
 };
 
+const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
+
 /**
  * List of courses that belong to a specific organization
  */
@@ -44,12 +46,13 @@ export default function OrganizationActivity({
           columnNames={{ title: 'Course Title' }}
           defaultOrderField="title"
           renderItem={stats => (
-            <RouterLink href={urlPath`/courses/${String(stats.id)}`} asChild>
+            <RouterLink href={courseURL(stats.id)} asChild>
               <Link underline="always" variant="text">
                 {stats.title}
               </Link>
             </RouterLink>
           )}
+          navigateOnConfirmRow={stats => courseURL(stats.id)}
         />
       </CardContent>
     </Card>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -186,6 +186,18 @@ describe('CourseActivity', () => {
     });
   });
 
+  [12, 35, 1, 500].forEach(id => {
+    it('builds expected href for row confirmation', () => {
+      const wrapper = createComponent();
+      const href = wrapper
+        .find('OrderableActivityTable')
+        .props()
+        .navigateOnConfirmRow({ id });
+
+      assert.equal(href, `/assignments/${id}`);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 
-import OrderableActivityTable from '../OrderableActivityTable';
+import OrderableActivityTable, { $imports } from '../OrderableActivityTable';
 
 describe('OrderableActivityTable', () => {
   const rows = [
@@ -23,8 +23,23 @@ describe('OrderableActivityTable', () => {
       replies: 100,
     },
   ];
+  let fakeNavigate;
 
-  function createComponent(defaultOrderField = 'display_name') {
+  beforeEach(() => {
+    fakeNavigate = sinon.stub();
+
+    $imports.$mock({
+      'wouter-preact': {
+        useLocation: sinon.stub().returns(['', fakeNavigate]),
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  function createComponent({ navigateOnConfirmRow } = {}) {
     return mount(
       <OrderableActivityTable
         rows={rows}
@@ -34,7 +49,8 @@ describe('OrderableActivityTable', () => {
           annotations: 'Annotations',
           replies: 'Replies',
         }}
-        defaultOrderField={defaultOrderField}
+        defaultOrderField="display_name"
+        navigateOnConfirmRow={navigateOnConfirmRow}
       />,
     );
   }
@@ -149,5 +165,15 @@ describe('OrderableActivityTable', () => {
       assert.deepEqual(getOrder(), orderToSet);
       assert.deepEqual(getRows(), expectedStudents);
     });
+  });
+
+  it('navigates when a row is confirmed', () => {
+    const navigateOnConfirmRow = sinon.stub().returns('/foo/bar');
+    const wrapper = createComponent({ navigateOnConfirmRow });
+
+    wrapper.find('DataTable').props().onConfirmRow();
+
+    assert.called(navigateOnConfirmRow);
+    assert.calledWith(fakeNavigate, '/foo/bar');
   });
 });

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -93,6 +93,18 @@ describe('OrganizationActivity', () => {
     });
   });
 
+  [12, 35, 1, 500].forEach(id => {
+    it('builds expected href for row confirmation', () => {
+      const wrapper = createComponent();
+      const href = wrapper
+        .find('OrderableActivityTable')
+        .props()
+        .navigateOnConfirmRow({ id });
+
+      assert.equal(href, `/courses/${id}`);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Allow navigating to the corresponding course or assignment when "confirming" a dashboard activity table row (double-clicking or pressing <kbd>Enter</kbd> when the row is focused).

https://github.com/hypothesis/lms/assets/2719332/ec89da2f-c9d5-4436-b728-c9781e813595

### Testing steps

1. Check out this branch.
2. Open a an assignment dashboard.
3. Navigate one level up, to the course view.
4. Double-click any of the assignment rows. You should be taken to that assignment's view.
5. Go back to the course view again, then use the <kbd>Tab</kbd> key to focus elements until the first row is focused.
6. Using the arrow keys, move focus to any assignment row, then press <kbd>Enter</kbd>. You should be taken to that assignment's view.

The same should work in the home view.