### PR TITLE
Return user ID for students and an empty display_name when that's not available

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -7,6 +7,12 @@ Making this a top level module to avoid circular dependency problems.
 from typing import NotRequired, TypedDict
 
 
+class AnnotationMetrics(TypedDict):
+    annotations: int
+    replies: int
+    last_activity: str | None
+
+
 class APICallInfo(TypedDict):
     path: str
     authUrl: NotRequired[str]
@@ -17,36 +23,30 @@ class APICourse(TypedDict):
     title: str
 
 
+class APIStudent(TypedDict):
+    id: int
+    display_name: str | None
+
+    annotation_metrics: NotRequired[AnnotationMetrics]
+
+
 class APICourses(TypedDict):
     courses: list[APICourse]
-
-
-class APIStudentStats(TypedDict):
-    display_name: str
-    annotations: int
-    replies: int
-    last_activity: str | None
-
-
-class APIStudents(TypedDict):
-    students: list[APIStudentStats]
-
-
-class AssignmentStats(TypedDict):
-    annotations: int
-    replies: int
-    last_activity: str | None
 
 
 class APIAssignment(TypedDict):
     id: int
     title: str
     course: APICourse
-    stats: NotRequired[AssignmentStats]
+    annotation_metrics: NotRequired[AnnotationMetrics]
 
 
 class APIAssignments(TypedDict):
     assignments: list[APIAssignment]
+
+
+class APIStudents(TypedDict):
+    students: list[APIStudent]
 
 
 class DashboardRoutes(TypedDict):

--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -24,7 +24,7 @@ class APICourse(TypedDict):
 
 
 class APIStudent(TypedDict):
-    id: int
+    id: str
     display_name: str | None
 
     annotation_metrics: NotRequired[AnnotationMetrics]

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -147,7 +147,7 @@ export type YouTubeVideoInfo = {
  * Dashboard-related API types
  */
 
-export type BaseDashboardStats = {
+export type AnnotationMetrics = {
   last_activity: string | null;
   annotations: number;
   replies: number;
@@ -180,8 +180,10 @@ export type Assignment = {
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
  */
-export type StudentStats = BaseDashboardStats & {
-  display_name: string;
+export type StudentStats = {
+  id: string;
+  display_name: string | null;
+  annotation_metrics: AnnotationMetrics;
 };
 
 export type StudentsResponse = {
@@ -192,7 +194,7 @@ export type StudentsResponse = {
  * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
  */
 export type AssignmentStats = Assignment & {
-  stats: BaseDashboardStats;
+  annotation_metrics: AnnotationMetrics;
 };
 
 export type AssignmentsResponse = {

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -5,6 +5,7 @@ import {
   CardTitle,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
 import type { Assignment, StudentsResponse } from '../../api-types';
@@ -14,6 +15,14 @@ import { formatDateTime } from '../../utils/date';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import OrderableActivityTable from './OrderableActivityTable';
+
+type StudentsTableRow = {
+  id: string;
+  display_name: string | null;
+  last_activity: string | null;
+  annotations: number;
+  replies: number;
+};
 
 /**
  * Activity in a list of students that are part of a specific assignment
@@ -30,6 +39,17 @@ export default function AssignmentActivity() {
   );
 
   const title = `Assignment: ${assignment.data?.title}`;
+  const rows: StudentsTableRow[] = useMemo(
+    () =>
+      (students.data?.students ?? []).map(
+        ({ id, display_name, annotation_metrics }) => ({
+          id,
+          display_name,
+          ...annotation_metrics,
+        }),
+      ),
+    [students.data],
+  );
 
   return (
     <Card>
@@ -65,7 +85,7 @@ export default function AssignmentActivity() {
           emptyMessage={
             students.error ? 'Could not load students' : 'No students found'
           }
-          rows={students.data?.students ?? []}
+          rows={rows}
           columnNames={{
             display_name: 'Student',
             annotations: 'Annotations',
@@ -80,7 +100,7 @@ export default function AssignmentActivity() {
 
             return field === 'last_activity' && stats.last_activity
               ? formatDateTime(new Date(stats.last_activity))
-              : stats[field];
+              : stats[field] ?? `Student ${stats.id.substring(0, 10)}`;
           }}
         />
       </CardContent>

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -43,11 +43,13 @@ export default function CourseActivity() {
 
   const rows: AssignmentsTableRow[] = useMemo(
     () =>
-      (assignments.data?.assignments ?? []).map(({ id, title, stats }) => ({
-        id,
-        title,
-        ...stats,
-      })),
+      (assignments.data?.assignments ?? []).map(
+        ({ id, title, annotation_metrics }) => ({
+          id,
+          title,
+          ...annotation_metrics,
+        }),
+      ),
     [assignments.data],
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -13,21 +13,27 @@ describe('AssignmentActivity', () => {
   const students = [
     {
       display_name: 'b',
-      last_activity: '2020-01-01T00:00:00',
-      annotations: 8,
-      replies: 0,
+      annotation_metrics: {
+        last_activity: '2020-01-01T00:00:00',
+        annotations: 8,
+        replies: 0,
+      },
     },
     {
       display_name: 'a',
-      last_activity: '2020-01-02T00:00:00',
-      annotations: 3,
-      replies: 20,
+      annotation_metrics: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 3,
+        replies: 20,
+      },
     },
     {
       display_name: 'c',
-      last_activity: '2020-01-02T00:00:00',
-      annotations: 5,
-      replies: 100,
+      annotation_metrics: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 5,
+        replies: 100,
+      },
     },
   ];
 
@@ -140,6 +146,26 @@ describe('AssignmentActivity', () => {
 
       assert.equal(value, expectedValue);
     });
+  });
+
+  it('renders fallback for students without display_name', () => {
+    const student = {
+      id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
+      display_name: null,
+      annotation_metrics: {
+        last_activity: null,
+        annotations: 0,
+        replies: 0,
+      },
+    };
+    const wrapper = createComponent();
+
+    const item = wrapper
+      .find('OrderableActivityTable')
+      .props()
+      .renderItem(student, 'display_name');
+
+    assert.equal(item, 'Student e4ca30ee27');
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -14,7 +14,7 @@ describe('CourseActivity', () => {
     {
       id: 2,
       title: 'b',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-01T00:00:00',
         annotations: 8,
         replies: 0,
@@ -23,7 +23,7 @@ describe('CourseActivity', () => {
     {
       id: 1,
       title: 'a',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-02T00:00:00',
         annotations: 3,
         replies: 20,
@@ -32,7 +32,7 @@ describe('CourseActivity', () => {
     {
       id: 3,
       title: 'c',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-02T00:00:00',
         annotations: 5,
         replies: 100,

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -28,7 +28,7 @@ class TestAssignmentViews:
 
     def test_assignment_stats(self, views, pyramid_request, assignment_service, h_api):
         # User returned by the stats endpoint
-        student = factories.User()
+        student = factories.User(display_name="Bart")
         # User with no annotations
         student_no_annos = factories.User(display_name="Homer")
         # User with no annotations and no name
@@ -68,28 +68,38 @@ class TestAssignmentViews:
             [g.authority_provided_id for g in assignment.groupings],
             assignment.resource_link_id,
         )
-        assert response == {
+        expected = {
             "students": [
                 {
+                    "id": student.user_id,
                     "display_name": student.display_name,
-                    "annotations": sentinel.annotations,
-                    "replies": sentinel.replies,
-                    "last_activity": sentinel.last_activity,
+                    "annotation_metrics": {
+                        "annotations": sentinel.annotations,
+                        "replies": sentinel.replies,
+                        "last_activity": sentinel.last_activity,
+                    },
                 },
                 {
+                    "id": student_no_annos.user_id,
                     "display_name": student_no_annos.display_name,
-                    "annotations": 0,
-                    "replies": 0,
-                    "last_activity": None,
+                    "annotation_metrics": {
+                        "annotations": 0,
+                        "replies": 0,
+                        "last_activity": None,
+                    },
                 },
                 {
-                    "display_name": f"Student {student_no_annos_no_name.user_id[:10]}",
-                    "annotations": 0,
-                    "replies": 0,
-                    "last_activity": None,
+                    "id": student_no_annos_no_name.user_id,
+                    "display_name": None,
+                    "annotation_metrics": {
+                        "annotations": 0,
+                        "replies": 0,
+                        "last_activity": None,
+                    },
                 },
             ]
         }
+        assert response == expected
 
     @pytest.fixture
     def views(self, pyramid_request):

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -91,7 +91,7 @@ class TestCourseViews:
                         "id": course.id,
                         "title": course.lms_name,
                     },
-                    "stats": {
+                    "annotation_metrics": {
                         "annotations": sentinel.annotations,
                         "replies": sentinel.replies,
                         "last_activity": sentinel.last_activity,
@@ -104,7 +104,7 @@ class TestCourseViews:
                         "id": course.id,
                         "title": course.lms_name,
                     },
-                    "stats": {
+                    "annotation_metrics": {
                         "annotations": 0,
                         "replies": 0,
                         "last_activity": None,


### PR DESCRIPTION
We started recording student names in May 9th. Before that we only have the name if the student made an annotation as the name has always been stored in H.

Refactor the response shape to include the ID and use a now common "AnnotationMetrics" for data fetched from H in both assignments and courses responses.