### PR TITLE
Dashboard smoother routes

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/dashboard/organizations/:organizationPublicId" nest>
+          <Route path="/dashboard/organizations/:organizationId" nest>
             <DashboardApp />
           </Route>
           <Route path="/email/preferences">

--- a/lms/static/scripts/frontend_apps/components/ComponentWithLoaderWrapper.tsx
+++ b/lms/static/scripts/frontend_apps/components/ComponentWithLoaderWrapper.tsx
@@ -1,28 +1,34 @@
-import type { ComponentChildren, FunctionComponent } from 'preact';
+import { Card, CardContent } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { useParams, useRoute } from 'wouter-preact';
 
-import type { ConfigObject } from '../config';
+import type { ConfigObject, Ensure } from '../config';
 import { useConfig } from '../config';
+import type { ErrorLike } from '../errors';
+import ErrorDisplay from './ErrorDisplay';
 
-export type ComponentWithLoaderWrapperProps = {
-  loaderModule: Promise<{
-    loader: (options: {
-      config: ConfigObject;
-      params: Record<string, string | undefined>;
-    }) => Promise<unknown>;
-    default: FunctionComponent<{ loadResult: unknown }>;
-  }>;
+export type LoaderOptions = {
+  config: Ensure<ConfigObject, 'dashboard' | 'api'>;
+  params: Record<string, string>;
+  signal: AbortSignal;
 };
 
 export default function ComponentWithLoaderWrapper() {
-  const config = useConfig();
-  const params = useParams();
+  const config = useConfig(['dashboard', 'api']);
   const [component, setComponent] = useState<ComponentChildren>();
   const [loading, setLoading] = useState(true);
-  const [isAssignment] = useRoute('/assignments/:assignmentId');
-  const [isCourse] = useRoute('/courses/:courseId');
+  const [fatalError, setFatalError] = useState<ErrorLike>();
+
+  const [isAssignment, assignmentParams] = useRoute(
+    '/assignments/:assignmentId',
+  );
+  const [isCourse, courseParams] = useRoute('/courses/:courseId');
   const [isHome] = useRoute('');
+  const globalParams = useParams();
+  const assignmentId = assignmentParams?.assignmentId ?? '';
+  const courseId = courseParams?.courseId ?? '';
+  const organizationId = globalParams.organizationId ?? '';
 
   useEffect(() => {
     const loaderModule = isAssignment
@@ -30,20 +36,43 @@ export default function ComponentWithLoaderWrapper() {
       : isCourse
         ? import('./dashboard/CourseActivity')
         : import('./dashboard/OrganizationActivity');
+    const params = { assignmentId, courseId, organizationId };
+
+    const abortController = new AbortController();
     loaderModule.then(async ({ loader, default: Component }) => {
-      // TODO Error handling
       setLoading(true);
-      const loadResult = await loader({ config, params });
-      setLoading(false);
-      setComponent(<Component loadResult={loadResult} />);
+      try {
+        const loaderResult = await loader({
+          config,
+          params,
+          signal: abortController.signal,
+        });
+        setComponent(<Component loaderResult={loaderResult} params={params} />);
+      } catch (e) {
+        setFatalError(e);
+      } finally {
+        setLoading(false);
+      }
     });
-  }, [config, isAssignment, isCourse, params]);
+
+    return () => abortController.abort();
+  }, [assignmentId, courseId, organizationId, config, isAssignment, isCourse]);
+
+  if (fatalError) {
+    return (
+      <Card>
+        <CardContent>
+          <ErrorDisplay error={fatalError} />
+        </CardContent>
+      </Card>
+    );
+  }
 
   return !component ? (
-    <>Initial loading...</>
+    <div className="text-center">Initial loading...</div>
   ) : (
     <>
-      {loading && <>Transitioning...</>}
+      {loading && <div className="text-center">Transitioning...</div>}
       {component}
     </>
   );

--- a/lms/static/scripts/frontend_apps/components/ComponentWithLoaderWrapper.tsx
+++ b/lms/static/scripts/frontend_apps/components/ComponentWithLoaderWrapper.tsx
@@ -1,0 +1,50 @@
+import type { ComponentChildren, FunctionComponent } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import { useParams, useRoute } from 'wouter-preact';
+
+import type { ConfigObject } from '../config';
+import { useConfig } from '../config';
+
+export type ComponentWithLoaderWrapperProps = {
+  loaderModule: Promise<{
+    loader: (options: {
+      config: ConfigObject;
+      params: Record<string, string | undefined>;
+    }) => Promise<unknown>;
+    default: FunctionComponent<{ loadResult: unknown }>;
+  }>;
+};
+
+export default function ComponentWithLoaderWrapper() {
+  const config = useConfig();
+  const params = useParams();
+  const [component, setComponent] = useState<ComponentChildren>();
+  const [loading, setLoading] = useState(true);
+  const [isAssignment] = useRoute('/assignments/:assignmentId');
+  const [isCourse] = useRoute('/courses/:courseId');
+  const [isHome] = useRoute('');
+
+  useEffect(() => {
+    const loaderModule = isAssignment
+      ? import('./dashboard/AssignmentActivity')
+      : isCourse
+        ? import('./dashboard/CourseActivity')
+        : import('./dashboard/OrganizationActivity');
+    loaderModule.then(async ({ loader, default: Component }) => {
+      // TODO Error handling
+      setLoading(true);
+      const loadResult = await loader({ config, params });
+      setLoading(false);
+      setComponent(<Component loadResult={loadResult} />);
+    });
+  }, [config, isAssignment, isCourse, params]);
+
+  return !component ? (
+    <>Initial loading...</>
+  ) : (
+    <>
+      {loading && <>Transitioning...</>}
+      {component}
+    </>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -9,12 +9,12 @@ import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
 import type { Assignment, StudentsResponse } from '../../api-types';
-import type { ConfigObject } from '../../config';
 import { useConfig } from '../../config';
 import { apiCall, urlPath } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
 import { useFetch } from '../../utils/fetch';
 import { replaceURLParams } from '../../utils/url';
+import type { LoaderOptions } from '../ComponentWithLoaderWrapper';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import OrderableActivityTable from './OrderableActivityTable';
 
@@ -22,15 +22,7 @@ export function loader({
   config: { dashboard, api },
   params: { assignmentId },
   signal,
-}: {
-  config: ConfigObject;
-  params: Record<string, string>;
-  signal?: AbortSignal;
-}) {
-  if (!dashboard || !api) {
-    throw new Error('Missing config!'); // TODO Handle this
-  }
-
+}: LoaderOptions) {
   const { routes } = dashboard;
   const { authToken } = api;
 
@@ -55,7 +47,7 @@ export function loader({
 export type AssignmentActivityLoadResult = Awaited<ReturnType<typeof loader>>;
 
 export type AssignmentActivityProps = {
-  loadResult?: AssignmentActivityLoadResult;
+  loaderResult: AssignmentActivityLoadResult;
 };
 
 type StudentsTableRow = {
@@ -70,33 +62,19 @@ type StudentsTableRow = {
  * Activity in a list of students that are part of a specific assignment
  */
 export default function AssignmentActivity({
-  loadResult,
+  loaderResult,
 }: AssignmentActivityProps) {
-  const config = useConfig(['dashboard', 'api']);
-  const params = useParams<{ assignmentId: string }>();
-
-  const loaderResult = useFetch<AssignmentActivityLoadResult>(
-    'assignment',
-    async signal => {
-      if (loadResult) {
-        return loadResult;
-      }
-
-      return loader({ config, params, signal });
-    },
-  );
-
-  const title = `Assignment: ${loaderResult.data?.assignment.title}`;
+  const title = `Assignment: ${loaderResult.assignment.title}`;
   const rows: StudentsTableRow[] = useMemo(
     () =>
-      (loaderResult.data?.students.students ?? []).map(
+      loaderResult.students.students.map(
         ({ id, display_name, annotation_metrics }) => ({
           id,
           display_name,
           ...annotation_metrics,
         }),
       ),
-    [loaderResult.data],
+    [loaderResult.students.students],
   );
 
   return (
@@ -108,31 +86,24 @@ export default function AssignmentActivity({
           'flex-col !gap-x-0 !items-start',
         )}
       >
-        {loaderResult.data && (
-          <div className="mb-3 mt-1 w-full">
-            <DashboardBreadcrumbs
-              links={[
-                {
-                  title: loaderResult.data.assignment.course.title,
-                  href: urlPath`/courses/${String(loaderResult.data.assignment.course.id)}`,
-                },
-              ]}
-            />
-          </div>
-        )}
+        <div className="mb-3 mt-1 w-full">
+          <DashboardBreadcrumbs
+            links={[
+              {
+                title: loaderResult.assignment.course.title,
+                href: urlPath`/courses/${String(loaderResult.assignment.course.id)}`,
+              },
+            ]}
+          />
+        </div>
         <CardTitle tagName="h2" data-testid="title">
-          {loaderResult.isLoading && 'Loading...'}
-          {loaderResult.error && 'Could not load assignment title'}
-          {loaderResult.data && title}
+          title
         </CardTitle>
       </CardHeader>
       <CardContent>
         <OrderableActivityTable
-          loading={loaderResult.isLoading}
-          title={loaderResult.isLoading ? 'Loading...' : title}
-          emptyMessage={
-            loaderResult.error ? 'Could not load students' : 'No students found'
-          }
+          title={title}
+          emptyMessage=""
           rows={rows}
           columnNames={{
             display_name: 'Student',

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -17,6 +17,10 @@ import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import OrderableActivityTable from './OrderableActivityTable';
 
+export function loader() {
+  return undefined;
+}
+
 type AssignmentsTableRow = {
   id: number;
   title: string;

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,21 +1,9 @@
 import classnames from 'classnames';
-import { Route, Switch, useParams, useRoute } from 'wouter-preact';
 
-import AssignmentActivity from './AssignmentActivity';
-import CourseActivity from './CourseActivity';
+import ComponentWithLoaderWrapper from '../ComponentWithLoaderWrapper';
 import DashboardFooter from './DashboardFooter';
-import OrganizationActivity from './OrganizationActivity';
 
 export default function DashboardApp() {
-  const { organizationPublicId } = useParams<{
-    organizationPublicId: string;
-  }>();
-  const [isAssignment] = useRoute('/assignments/:assignmentId');
-  const [isCourse] = useRoute('/courses/:courseId');
-  const [isHome] = useRoute('');
-
-  console.log({ isAssignment, isCourse, isHome });
-
   return (
     <div className="flex flex-col min-h-screen gap-5 bg-grey-2">
       <div
@@ -32,19 +20,7 @@ export default function DashboardApp() {
       </div>
       <div className="flex-grow px-3">
         <div className="mx-auto max-w-6xl">
-          <Switch>
-            <Route path="/assignments/:assignmentId">
-              <AssignmentActivity />
-            </Route>
-            <Route path="/courses/:courseId">
-              <CourseActivity />
-            </Route>
-            <Route path="">
-              <OrganizationActivity
-                organizationPublicId={organizationPublicId}
-              />
-            </Route>
-          </Switch>
+          <ComponentWithLoaderWrapper />
         </div>
       </div>
       <DashboardFooter />

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { Route, Switch, useParams } from 'wouter-preact';
+import { Route, Switch, useParams, useRoute } from 'wouter-preact';
 
 import AssignmentActivity from './AssignmentActivity';
 import CourseActivity from './CourseActivity';
@@ -10,6 +10,11 @@ export default function DashboardApp() {
   const { organizationPublicId } = useParams<{
     organizationPublicId: string;
   }>();
+  const [isAssignment] = useRoute('/assignments/:assignmentId');
+  const [isCourse] = useRoute('/courses/:courseId');
+  const [isHome] = useRoute('');
+
+  console.log({ isAssignment, isCourse, isHome });
 
   return (
     <div className="flex flex-col min-h-screen gap-5 bg-grey-2">

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -12,6 +12,10 @@ import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
 import OrderableActivityTable from './OrderableActivityTable';
 
+export function loader() {
+  return undefined;
+}
+
 export type OrganizationActivityProps = {
   organizationPublicId: string;
 };


### PR DESCRIPTION
This PR introduces a mechanism to load the data needed by a new section just before transitioning to it, allowing to keep the previous section rendered until the loading has finished.

This also provides an alternative approach to handle the initial loading, so it might replace https://github.com/hypothesis/lms/pull/6287

### How it works

In order to achieve this, every component which represents a "page" and is therefore linked to a route is now expected to fulfill a module contract, exporting two symbols:

1. A `loader` function, which returns a promise resolving the data needed by the component.
2. A default export, which is the component to render, with a single `loaderResult` prop where the result of resolving the loader will be passed.

To orchestrate everything, we introduce a new component, which replaces the standard `<Switch />` + `<Route />` router components, and uses instances of [`useRoute`](https://github.com/molefrog/wouter?tab=readme-ov-file#useroute-route-matching-and-parameters) to determine the matching route.

Once we know the matching route, we use a dynamic `import(...)` to load the corresponding module, call its `loader`, and once resolved, mount the corresponding component.

This also allow us to have three states.

1. At first there's no component loaded at all. This is the initial loading state, where we could show a global loader or splash screen. This is why I mentioned this PR could replace https://github.com/hypothesis/lms/pull/6287
2. When a component has already been loaded, we show it normally.
3. When transitioning between two routes, we keep showing previous component, with an optional subtle loading indicator of some kind, and once the new `loader` has resolved, we replace the rendered component.

### References

This approach is inspired by how some react full-stack frameworks resolve data loading. In their case data is loaded in the server and then components are hydrated with the result, but conceptually it's similar to this.

* [Remix loaders](https://remix.run/docs/en/main/route/loader): Route modules export a `loader` function and a React component. The component can get the result of executing the loader function via a `useLoaderData()` hook.
* [Next.js `getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props): Page modules export a `getServerSideProps` function and a React component. The component gets the result of calling `getServerSideProps` implicitly as props.

### Considerations and next steps

* The logic to match a module based on current route does not currently scale very well. The more routes we add, the more complex it will become.
* For every handled route, we need one call to `useRoute`. It somehow matches how the static routing config would work, via `<Route />` components, but in the second case the children to render are implicit, while in here we still need to perform extra logic on the combined results of all `useRoute` calls.
* This POC does not currently allow to render any children until loading has ended. We may want to change that and make the `loader` return an object including the mandatory promise/es to await, and others that should not block rendering children.
* The logic is currently a bit coupled with the dashboard.