### PR TITLE
Update dashboard API type definitions

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -147,7 +147,7 @@ export type YouTubeVideoInfo = {
  * Dashboard-related API types
  */
 
-export type BaseDashboardStats = {
+export type AnnotationMetrics = {
   last_activity: string | null;
   annotations: number;
   replies: number;
@@ -180,8 +180,10 @@ export type Assignment = {
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
  */
-export type StudentStats = BaseDashboardStats & {
-  display_name: string;
+export type StudentStats = {
+  id: string;
+  display_name: string | null;
+  annotation_metrics: AnnotationMetrics;
 };
 
 export type StudentsResponse = {
@@ -192,7 +194,7 @@ export type StudentsResponse = {
  * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
  */
 export type AssignmentStats = Assignment & {
-  stats: BaseDashboardStats;
+  annotation_metrics: AnnotationMetrics;
 };
 
 export type AssignmentsResponse = {

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -5,6 +5,7 @@ import {
   CardTitle,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
 import type { Assignment, StudentsResponse } from '../../api-types';
@@ -14,6 +15,14 @@ import { formatDateTime } from '../../utils/date';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import OrderableActivityTable from './OrderableActivityTable';
+
+type StudentsTableRow = {
+  id: string;
+  display_name: string | null;
+  last_activity: string | null;
+  annotations: number;
+  replies: number;
+};
 
 /**
  * Activity in a list of students that are part of a specific assignment
@@ -30,6 +39,17 @@ export default function AssignmentActivity() {
   );
 
   const title = `Assignment: ${assignment.data?.title}`;
+  const rows: StudentsTableRow[] = useMemo(
+    () =>
+      (students.data?.students ?? []).map(
+        ({ id, display_name, annotation_metrics }) => ({
+          id,
+          display_name,
+          ...annotation_metrics,
+        }),
+      ),
+    [students.data],
+  );
 
   return (
     <Card>
@@ -65,7 +85,7 @@ export default function AssignmentActivity() {
           emptyMessage={
             students.error ? 'Could not load students' : 'No students found'
           }
-          rows={students.data?.students ?? []}
+          rows={rows}
           columnNames={{
             display_name: 'Student',
             annotations: 'Annotations',
@@ -80,7 +100,7 @@ export default function AssignmentActivity() {
 
             return field === 'last_activity' && stats.last_activity
               ? formatDateTime(new Date(stats.last_activity))
-              : stats[field];
+              : stats[field] ?? `Student ${stats.id.substring(0, 10)}`;
           }}
         />
       </CardContent>

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -43,11 +43,13 @@ export default function CourseActivity() {
 
   const rows: AssignmentsTableRow[] = useMemo(
     () =>
-      (assignments.data?.assignments ?? []).map(({ id, title, stats }) => ({
-        id,
-        title,
-        ...stats,
-      })),
+      (assignments.data?.assignments ?? []).map(
+        ({ id, title, annotation_metrics }) => ({
+          id,
+          title,
+          ...annotation_metrics,
+        }),
+      ),
     [assignments.data],
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -13,21 +13,27 @@ describe('AssignmentActivity', () => {
   const students = [
     {
       display_name: 'b',
-      last_activity: '2020-01-01T00:00:00',
-      annotations: 8,
-      replies: 0,
+      annotation_metrics: {
+        last_activity: '2020-01-01T00:00:00',
+        annotations: 8,
+        replies: 0,
+      },
     },
     {
       display_name: 'a',
-      last_activity: '2020-01-02T00:00:00',
-      annotations: 3,
-      replies: 20,
+      annotation_metrics: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 3,
+        replies: 20,
+      },
     },
     {
       display_name: 'c',
-      last_activity: '2020-01-02T00:00:00',
-      annotations: 5,
-      replies: 100,
+      annotation_metrics: {
+        last_activity: '2020-01-02T00:00:00',
+        annotations: 5,
+        replies: 100,
+      },
     },
   ];
 
@@ -140,6 +146,26 @@ describe('AssignmentActivity', () => {
 
       assert.equal(value, expectedValue);
     });
+  });
+
+  it('renders fallback for students without display_name', () => {
+    const student = {
+      id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
+      display_name: null,
+      annotation_metrics: {
+        last_activity: null,
+        annotations: 0,
+        replies: 0,
+      },
+    };
+    const wrapper = createComponent();
+
+    const item = wrapper
+      .find('OrderableActivityTable')
+      .props()
+      .renderItem(student, 'display_name');
+
+    assert.equal(item, 'Student e4ca30ee27');
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -14,7 +14,7 @@ describe('CourseActivity', () => {
     {
       id: 2,
       title: 'b',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-01T00:00:00',
         annotations: 8,
         replies: 0,
@@ -23,7 +23,7 @@ describe('CourseActivity', () => {
     {
       id: 1,
       title: 'a',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-02T00:00:00',
         annotations: 3,
         replies: 20,
@@ -32,7 +32,7 @@ describe('CourseActivity', () => {
     {
       id: 3,
       title: 'c',
-      stats: {
+      annotation_metrics: {
         last_activity: '2020-01-02T00:00:00',
         annotations: 5,
         replies: 100,


### PR DESCRIPTION
Add FE changes for https://github.com/hypothesis/lms/pull/6341

The changes involve:

* Adjusting API type definitions to match the BE ones.
* Implement the same display_name fallback logic that the BE was previously doing.

In a follow-up PR we can enhance the falling-back logic, and add more information about what that means.

We will also need to improve the ordering so that items where display_name is null, are always in the bottom of the list.

### Testing steps

This PR should not introduce any visual changes, so the only possible testing is a sanity check on the dashboard, to verify that's the case.