### PR TITLE
Exclude _compiled_feature_steps.py from linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,10 @@ score = "no"
 [tool.ruff]
 target-version = "py311"
 line-length = 88
+exclude = [
+    "tests/bdd/steps/_compiled_feature_steps.py",
+]
+
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
This file is auto-generated by the BDD tests, and was previously ignored
by Pylint linting.
