### PR TITLE
Ensure last_activity renders as empty string when it's null

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -96,11 +96,13 @@ export default function AssignmentActivity() {
           renderItem={(stats, field) => {
             if (['annotations', 'replies'].includes(field)) {
               return <div className="text-right">{stats[field]}</div>;
+            } else if (field === 'last_activity') {
+              return stats.last_activity
+                ? formatDateTime(new Date(stats.last_activity))
+                : '';
             }
 
-            return field === 'last_activity' && stats.last_activity
-              ? formatDateTime(new Date(stats.last_activity))
-              : stats[field] ?? `Student ${stats.id.substring(0, 10)}`;
+            return stats[field] ?? `Student ${stats.id.substring(0, 10)}`;
           }}
         />
       </CardContent>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -128,9 +128,24 @@ describe('AssignmentActivity', () => {
       fieldName: 'last_activity',
       expectedValue: formatDateTime(new Date('2024-01-01T10:35:18')),
     },
-  ].forEach(({ fieldName, expectedValue }) => {
+    // Render last_activity when it's null
+    {
+      fieldName: 'last_activity',
+      expectedValue: '',
+      studentStats: { last_activity: null },
+    },
+    // Render display_name when it's null
+    {
+      fieldName: 'display_name',
+      expectedValue: 'Student e4ca30ee27',
+      studentStats: {
+        id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
+        display_name: null,
+      },
+    },
+  ].forEach(({ fieldName, expectedValue, studentStats }) => {
     it('renders every field as expected', () => {
-      const studentStats = {
+      const fallbackStudentStats = {
         display_name: 'Jane Doe',
         last_activity: '2024-01-01T10:35:18',
         annotations: 37,
@@ -141,31 +156,11 @@ describe('AssignmentActivity', () => {
       const item = wrapper
         .find('OrderableActivityTable')
         .props()
-        .renderItem(studentStats, fieldName);
+        .renderItem(studentStats ?? fallbackStudentStats, fieldName);
       const value = typeof item === 'string' ? item : mount(item).text();
 
       assert.equal(value, expectedValue);
     });
-  });
-
-  it('renders fallback for students without display_name', () => {
-    const student = {
-      id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
-      display_name: null,
-      annotation_metrics: {
-        last_activity: null,
-        annotations: 0,
-        replies: 0,
-      },
-    };
-    const wrapper = createComponent();
-
-    const item = wrapper
-      .find('OrderableActivityTable')
-      .props()
-      .renderItem(student, 'display_name');
-
-    assert.equal(item, 'Student e4ca30ee27');
   });
 
   it(


### PR DESCRIPTION
Fix a bug where student's last activity would render the same fallback value we use for students without a display name, when the last activity was null.

This was caused by an incorrect combined condition.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/ebc9980d-147f-4600-8ef8-bd7850da88b1)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/0b9acbb0-4d66-43c1-a099-b8ceb22c714d)
