### PR TITLE
Fix usage report scheduling to ignore already existing reports

### DIFF
--- a/lms/tasks/organization.py
+++ b/lms/tasks/organization.py
@@ -55,7 +55,7 @@ def schedule_monthly_deal_report(limit: int, backfill: int = 0) -> None:
                             since,
                             until,
                         )
-                        return
+                        continue
 
                     generate_usage_report.delay(
                         organization.id,

--- a/tests/unit/lms/tasks/organization_test.py
+++ b/tests/unit/lms/tasks/organization_test.py
@@ -93,9 +93,15 @@ class TestScheduleMonthlyDealReport:
                 current_deal_services_end=date(2022, 12, 31),
             ),
         ]
-        organization_usage_report_service.get.return_value = None
+        organization_usage_report_service.get.side_effect = [
+            factories.OrganizationUsageReport(),  # First report already exists, it should not have an effect on limit
+            None,  # Second needs to be generated, limit will stop here
+            None,  # Third won't be generated
+        ]
         organization_usage_report_service.monthly_report_dates.return_value = [
-            (date(2022, 1, 1), date(2022, 12, 31))
+            (date(2022, 1, 1), date(2022, 12, 31)),
+            (date(2022, 1, 1), date(2022, 11, 30)),
+            (date(2022, 1, 1), date(2022, 10, 31)),
         ]
 
         schedule_monthly_deal_report(limit=1)


### PR DESCRIPTION
Don't stop the process after finding the first existing report. Continue until we reach `limit` new reports.