### PR TITLE
Handle Canvas Studio collections with null `name` field

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -28,7 +28,7 @@ class CanvasStudioCollectionsSchema(RequestsResponseSchema):
             unknown = EXCLUDE
 
         id = fields.Integer(required=True)
-        name = fields.Str(required=True)
+        name = fields.Str(required=True, allow_none=True)
         type = fields.Str(required=True)
         created_at = fields.Str(required=False)
 
@@ -227,12 +227,13 @@ class CanvasStudioService:
                 user_collection = collection
                 continue
 
+            collection_id = collection["id"]
             files.append(
                 {
                     "type": "Folder",
-                    "display_name": collection["name"],
+                    "display_name": collection["name"] or f"Collection {collection_id}",
                     "updated_at": collection["created_at"],
-                    "id": str(collection["id"]),
+                    "id": str(collection_id),
                     "contents": {
                         "path": self._request.route_url(
                             "canvas_studio_api.collections.media.list",

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -113,6 +113,15 @@ class TestCanvasStudioService:
             },
             {
                 "type": "Folder",
+                "display_name": "Collection 10",
+                "updated_at": "2024-03-01",
+                "id": "10",
+                "contents": {
+                    "path": "http://example.com/api/canvas_studio/collections/10/media"
+                },
+            },
+            {
+                "type": "Folder",
                 "display_name": "More videos",
                 "updated_at": "2024-02-01",
                 "id": "8",
@@ -337,6 +346,8 @@ class TestCanvasStudioService:
                 make_collection(1, "", "user", "2024-02-01"),
                 make_collection(9, "And more videos", "some_type", "2024-02-01"),
                 make_collection(8, "More videos", "some_type", "2024-02-01"),
+                # See https://github.com/hypothesis/lms/issues/6352.
+                make_collection(10, None, "course_wide", "2024-03-01"),
             ]
 
         def handler(url, allow_redirects=True):


### PR DESCRIPTION
We previously found cases where collections had an empty name, but it turns out the name field can be `null` as well. Adjust the validation schema to allow for this. Unfortunately there isn't another field in the same response that contains an alternative name, so just generate a fallback for now.

Fixes https://github.com/hypothesis/lms/issues/6352.