### PR TITLE
Add course metrics to OrganizationActivity table

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -161,11 +161,20 @@ export type Course = {
   title: string;
 };
 
+export type CourseMetrics = {
+  assignments: number;
+  last_launched: string | null;
+};
+
+export type CourseWithMetrics = Course & {
+  course_metrics: CourseMetrics;
+};
+
 /**
  * Response for `/api/dashboard/organizations/{organization_public_id}` call.
  */
 export type CoursesResponse = {
-  courses: Course[];
+  courses: CourseWithMetrics[];
 };
 
 /**
@@ -190,13 +199,13 @@ export type StudentsResponse = {
   students: StudentStats[];
 };
 
-/**
- * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
- */
-export type AssignmentStats = Assignment & {
+export type AssignmentWithMetrics = Assignment & {
   annotation_metrics: AnnotationMetrics;
 };
 
+/**
+ * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
+ */
 export type AssignmentsResponse = {
-  assignments: AssignmentStats[];
+  assignments: AssignmentWithMetrics[];
 };

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -28,9 +28,14 @@ export type OrderableActivityTableProps<T> = Pick<
  * recent values first.
  */
 const descendingOrderColumns: readonly string[] = [
+  // Annotation metrics
   'last_activity',
   'annotations',
   'replies',
+
+  // Course metrics
+  'last_launched',
+  'assignments',
 ];
 
 /**


### PR DESCRIPTION
Use the new course_metrics data returned for every course in the list of courses, and display it in the organization activity table.

Before:

![image](https://github.com/hypothesis/lms/assets/2719332/16daec9c-3261-41f3-ad07-f66cd4f3cf59)

After:

![image](https://github.com/hypothesis/lms/assets/2719332/f042ca3f-998c-4848-b8ce-704ddbb10822)
