### PR TITLE
Add route-to-module map to dashboard

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -6,13 +6,10 @@ import {
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
-import { useParams } from 'wouter-preact';
 
 import type { Assignment, StudentsResponse } from '../../api-types';
-import { useConfig } from '../../config';
 import { apiCall, urlPath } from '../../utils/api';
 import { formatDateTime } from '../../utils/date';
-import { useFetch } from '../../utils/fetch';
 import { replaceURLParams } from '../../utils/url';
 import type { LoaderOptions } from '../ComponentWithLoaderWrapper';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';


### PR DESCRIPTION
This is an extension of https://github.com/hypothesis/lms/pull/6342, but defining a way to pass a map of `route -> module` that avoids the use of multiple `useRoute` calls, and decouples the logic with the dashboard, as this map could be passed as a prop.

It also replaces dynamic imports with static ones.