### PR TITLE
Allow route modules to define what parts of the loader don't need to be awaited

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -9,31 +9,30 @@ import { Link as RouterLink } from 'wouter-preact';
 import type { CoursesResponse } from '../../api-types';
 import { apiCall, urlPath } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
-import type { LoaderOptions } from '../ComponentWithLoaderWrapper';
+import type { RouteModule } from '../ComponentWithLoaderWrapper';
 import OrderableActivityTable from './OrderableActivityTable';
 
-export function loader({
+export const loader: RouteModule['loader'] = ({
   config: { dashboard, api },
   params: { organizationId },
   signal,
-}: LoaderOptions) {
+}) => {
   const { routes } = dashboard;
   const { authToken } = api;
 
-  return apiCall<CoursesResponse>({
-    path: replaceURLParams(routes.organization_courses, {
-      organization_public_id: organizationId,
+  return {
+    awaitable: apiCall<CoursesResponse>({
+      path: replaceURLParams(routes.organization_courses, {
+        organization_public_id: organizationId,
+      }),
+      authToken,
+      signal,
     }),
-    authToken,
-    signal,
-  });
-}
-
-export type OrganizationActivityLoadResult = Awaited<ReturnType<typeof loader>>;
+  };
+};
 
 export type OrganizationActivityProps = {
-  loaderResult: OrganizationActivityLoadResult;
-  params: { organizationId: string };
+  loaderResult: CoursesResponse;
 };
 
 const courseURL = (id: number) => urlPath`/courses/${String(id)}`;


### PR DESCRIPTION
This is a continuation of https://github.com/hypothesis/lms/pull/6342 and https://github.com/hypothesis/lms/pull/6357, which enhances the route loaders so that, instead of returning a promise, they return an object with this shape:

```ts
type LoaderResult = {
  awaitable: Promise<unknown>;
  rest: Record<string, Promise<unknown>;
}
```

This tells the component orchestrating route transitions that the `awaitable` promise needs to be settled before rendering the new route's component, but the rest can be passed verbatim, and let the component itself handle errors and loading state by wrapping them in `useFetch`.