### PR TITLE
Adapt HAPI to talk to the refactored query-builder style H API

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -13,7 +13,10 @@ from lms.models import (
     CourseGroupsExportedFromH,
     Grouping,
     GroupingMembership,
+    LTIRole,
     Organization,
+    RoleScope,
+    RoleType,
     User,
 )
 from lms.product import Product
@@ -328,6 +331,24 @@ class CourseService:
             )
 
         return self._db.scalars(assignments_query).all()
+
+    def get_members(
+        self, course: Course, role_type: RoleType, role_scope: RoleScope
+    ) -> list[User]:
+        return self._db.scalars(
+            select(User)
+            .join(AssignmentMembership, User.id == AssignmentMembership.user_id)
+            .join(LTIRole)
+            .join(
+                AssignmentGrouping,
+                AssignmentMembership.assignment_id == AssignmentGrouping.assignment_id,
+            )
+            .where(
+                AssignmentGrouping.grouping_id == course.id,
+                LTIRole.scope == role_scope,
+                LTIRole.type == role_type,
+            )
+        ).all()
 
     def _get_authority_provided_id(self, context_id):
         return self._grouping_service.get_authority_provided_id(

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -169,32 +169,24 @@ class HAPI:
                     authority_provided_id=group["authority_provided_id"]
                 )
 
-    def get_assignment_stats(
-        self, group_authority_ids: list[str], resource_link_id: str
+    def get_annotation_counts(
+        self,
+        group_authority_ids: list[str],
+        group_by: str,
+        h_userids: list[str] | None = None,
+        resource_link_id: str | None = None,
     ):
-        response = self._api_request(
-            "POST",
-            path="bulk/stats/users",
-            body=json.dumps(
-                {
-                    "filter": {
-                        "groups": group_authority_ids,
-                        "assignment_id": resource_link_id,
-                    }
-                }
-            ),
-            headers={
-                "Content-Type": "application/vnd.hypothesis.v1+json",
-            },
-            stream=False,
-        )
-        return response.json()
+        filters = {
+            "groups": group_authority_ids,
+            "assignment_id": resource_link_id,
+        }
+        if h_userids:
+            filters["h_userids"] = h_userids
 
-    def get_course_stats(self, group_authority_ids: list[str]):
         response = self._api_request(
             "POST",
-            path="bulk/stats/assignments",
-            body=json.dumps({"filter": {"groups": group_authority_ids}}),
+            path="bulk/lms/annotations",
+            body=json.dumps({"group_by": group_by, "filter": filters}),
             headers={
                 "Content-Type": "application/vnd.hypothesis.v1+json",
             },

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -42,11 +42,11 @@ class AssignmentViews:
     def assignment_stats(self) -> APIStudents:
         """Fetch the stats for one particular assignment."""
         assignment = get_request_assignment(self.request, self.assignment_service)
-        stats = self.h_api.get_assignment_stats(
+        stats = self.h_api.get_annotation_counts(
             [g.authority_provided_id for g in assignment.groupings],
-            assignment.resource_link_id,
+            group_by="user",
+            resource_link_id=assignment.resource_link_id,
         )
-
         # Organize the H stats by userid for quick access
         stats_by_user = {s["userid"]: s for s in stats}
         students: list[APIStudent] = []

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -132,13 +132,16 @@ class TestHAPI:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "method,url,args,payload",
+        "kwargs,payload",
         [
             (
-                "get_assignment_stats",
-                "https://h.example.com/private/api/bulk/stats/users",
-                (["group_1", "group_2"], "assignment_id"),
                 {
+                    "group_authority_ids": ["group_1", "group_2"],
+                    "group_by": "user",
+                    "resource_link_id": "assignment_id",
+                },
+                {
+                    "group_by": "user",
                     "filter": {
                         "groups": ["group_1", "group_2"],
                         "assignment_id": "assignment_id",
@@ -146,23 +149,31 @@ class TestHAPI:
                 },
             ),
             (
-                "get_course_stats",
-                "https://h.example.com/private/api/bulk/stats/assignments",
-                (["group_1", "group_2"],),
                 {
-                    "filter": {"groups": ["group_1", "group_2"]},
+                    "group_authority_ids": ["group_1", "group_2"],
+                    "group_by": "user",
+                    "resource_link_id": "assignment_id",
+                    "h_userids": ["user_1", "user_2"],
+                },
+                {
+                    "group_by": "user",
+                    "filter": {
+                        "groups": ["group_1", "group_2"],
+                        "assignment_id": "assignment_id",
+                        "h_userids": ["user_1", "user_2"],
+                    },
                 },
             ),
         ],
     )
-    def test_get_stats_endpoints(self, h_api, http_service, method, url, args, payload):
+    def test_get_annotation_counts(self, h_api, http_service, kwargs, payload):
         http_service.request.return_value = factories.requests.Response(raw="{}")
 
-        getattr(h_api, method)(*args)
+        h_api.get_annotation_counts(**kwargs)
 
         http_service.request.assert_called_once_with(
             method="POST",
-            url=url,
+            url="https://h.example.com/private/api/bulk/lms/annotations",
             auth=("TEST_CLIENT_ID", "TEST_CLIENT_SECRET"),
             headers={
                 "Content-Type": "application/vnd.hypothesis.v1+json",

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -59,14 +59,15 @@ class TestAssignmentViews:
             },
         ]
 
-        h_api.get_assignment_stats.return_value = stats
+        h_api.get_annotation_counts.return_value = stats
 
         response = views.assignment_stats()
 
         assignment_service.get_by_id.assert_called_once_with(sentinel.id)
-        h_api.get_assignment_stats.assert_called_once_with(
+        h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],
-            assignment.resource_link_id,
+            group_by="user",
+            resource_link_id=assignment.resource_link_id,
         )
         expected = {
             "students": [

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -75,6 +75,7 @@ class TestCourseViews:
             assignment,
             assignment_with_no_annos,
         ]
+        course_service.get_members.return_value = factories.User.create_batch(5)
 
         db_session.flush()
 
@@ -88,12 +89,14 @@ class TestCourseViews:
             },
         ]
 
-        h_api.get_course_stats.return_value = stats
+        h_api.get_annotation_counts.return_value = stats
 
         response = views.course_assignments()
 
-        h_api.get_course_stats.assert_called_once_with(
-            [course.authority_provided_id, section.authority_provided_id]
+        h_api.get_annotation_counts.assert_called_once_with(
+            [course.authority_provided_id, section.authority_provided_id],
+            group_by="assignment",
+            h_userids=[u.h_userid for u in course_service.get_members.return_value],
         )
         assert response == {
             "assignments": [


### PR DESCRIPTION
Requires: https://github.com/hypothesis/h/pull/8756


## Deploying

At this stage I reckon is fine to merge both the H and this PR at roughly the same time and live with some time in the API.


## Test 

- Checkout [this branch in H](https://github.com/hypothesis/h/pull/8756)
- Open the dashboard at the org, course and assignment level.
- At the course level, only counts by learners are counted, the number at the  course level should be the sum of the count at the assignment level.


