### PR TITLE
Fix errors setting Google Drive permissions not being reported

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
@@ -247,9 +247,21 @@ export class GooglePickerClient {
       fileId: docId,
       resource: body,
     });
-    return new Promise((resolve, reject) => {
-      // @ts-expect-error - We're missing types for this.
-      request.execute(resolve, reject);
+    const result = new Promise((resolve, reject) => {
+      // @ts-expect-error - We're missing types for this, but see
+      // https://github.com/google/google-api-javascript-client/blob/96cf6057f03c5e56179e83869828a06c47ce571b/docs/reference.md.
+      //
+      // For the types of arguments passed to resolve/reject, see
+      // https://github.com/google/google-api-javascript-client/blob/96cf6057f03c5e56179e83869828a06c47ce571b/docs/promises.md#using-promises-1.
+      request.then(resolve, reject);
     });
+
+    try {
+      await result;
+    } catch (response) {
+      throw new Error(
+        response.result?.error?.message ?? 'Unable to make file public',
+      );
+    }
   }
 }

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -342,7 +342,7 @@ describe('GooglePickerClient', () => {
 
     beforeEach(() => {
       createPermission = fakeGoogleLibs.client.drive.permissions.create;
-      const apiRequest = { execute: resolve => resolve() };
+      const apiRequest = { then: resolve => resolve() };
       createPermission.returns(apiRequest);
     });
 
@@ -394,8 +394,14 @@ describe('GooglePickerClient', () => {
       const client = createClient();
       await client.requestAuthorization();
       createPermission.returns({
-        execute: (_, reject) =>
-          reject(new Error('Changing permissions failed')),
+        then: (_, reject) =>
+          reject({
+            result: {
+              error: {
+                message: 'Changing permissions failed',
+              },
+            },
+          }),
       });
       let err;
       try {


### PR DESCRIPTION
If an error occurred when attemping to change file permissions after selecting a file from Google Drive, the LMS frontend incorrectly assumed the attempt had succeeded.

The result was that launching the assignment would then likely fail, as the PDF didn't have the necessary permissions.

This is because the `request.execute` API doesn't work as the code expected. It always invokes its first argument with the response. The `request.then` API is the correct Promise-like API. The argument passed to the rejection handler then needs to be processed to turn the result into an `Error` as expected by the calling code.

With these changes, an error in the `enablePublicViewing` API should result in an error like:

<img width="659" alt="Google Drive error handling" src="https://github.com/hypothesis/lms/assets/2458/7e7508aa-7713-4c1a-8d5e-a8771c2f4435">
 changing 