### PR TITLE
Use h_userid instead of User to check membership to assignments

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -204,9 +204,11 @@ class AssignmentService:
     def get_by_id(self, id_: int) -> Assignment | None:
         return self._db.query(Assignment).filter_by(id=id_).one_or_none()
 
-    def is_member(self, assignment: Assignment, user: User) -> bool:
+    def is_member(self, assignment: Assignment, h_userid: str) -> bool:
         """Check if a user is a member of an assignment."""
-        return bool(assignment.membership.filter_by(user=user).first())
+        return bool(
+            assignment.membership.join(User).filter(User.h_userid == h_userid).first()
+        )
 
     def get_members(
         self, assignment, role_type: RoleType, role_scope: RoleScope

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -236,8 +236,8 @@ class TestAssignmentService:
 
         db_session.flush()
 
-        assert svc.is_member(assignment, user)
-        assert not svc.is_member(assignment, other_user)
+        assert svc.is_member(assignment, user.h_userid)
+        assert not svc.is_member(assignment, other_user.h_userid)
 
     def test_get_members(self, svc, db_session):
         factories.User()  # User not in assignment


### PR DESCRIPTION
This allow rows in User with the same h_userid (ie the same user in different installs) to be equivalent for memberships checks.


## Testing

Not reproducing the bug in local but here is how to check the fix in prod after merging:

- Login in canvas as `eng+canvasteacher@hypothes.is`
- Launch the dashboard from any (prod) assignment
- Open https://lms.hypothes.is/dashboard/organizations/us.lms.org.x9L8IC7tRRa2-rYITOx_yQ/courses/10057035
- You should get just one assignment that you should be able to click thru.


