### PR TITLE
Switch to using non-restricted `drive.file` permission for Google Drive

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
@@ -247,9 +247,21 @@ export class GooglePickerClient {
       fileId: docId,
       resource: body,
     });
-    return new Promise((resolve, reject) => {
-      // @ts-expect-error - We're missing types for this.
-      request.execute(resolve, reject);
+    const result = new Promise((resolve, reject) => {
+      // @ts-expect-error - We're missing types for this, but see
+      // https://github.com/google/google-api-javascript-client/blob/96cf6057f03c5e56179e83869828a06c47ce571b/docs/reference.md.
+      //
+      // For the types of arguments passed to resolve/reject, see
+      // https://github.com/google/google-api-javascript-client/blob/96cf6057f03c5e56179e83869828a06c47ce571b/docs/promises.md#using-promises-1.
+      request.then(resolve, reject);
     });
+
+    try {
+      await result;
+    } catch (response) {
+      throw new Error(
+        response.result?.error?.message ?? 'Unable to make file public',
+      );
+    }
   }
 }

--- a/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
+++ b/lms/static/scripts/frontend_apps/utils/google-picker-client.ts
@@ -4,7 +4,7 @@ import {
   loadIdentityServicesLibrary,
 } from './google-api-client';
 
-export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
+export const GOOGLE_DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
 /**
  * Convert a domain (example.com) into a valid web origin (https://example.com).
@@ -199,6 +199,7 @@ export class GooglePickerClient {
     const picker = new pickerLib.PickerBuilder()
       .addView(view)
       .addView(new pickerLib.DocsUploadView())
+      .setAppId(this._clientId)
       .setCallback(pickerCallback)
       .setDeveloperKey(this._developerKey)
       .setMaxItems(1)

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -342,7 +342,7 @@ describe('GooglePickerClient', () => {
 
     beforeEach(() => {
       createPermission = fakeGoogleLibs.client.drive.permissions.create;
-      const apiRequest = { execute: resolve => resolve() };
+      const apiRequest = { then: resolve => resolve() };
       createPermission.returns(apiRequest);
     });
 
@@ -394,8 +394,14 @@ describe('GooglePickerClient', () => {
       const client = createClient();
       await client.requestAuthorization();
       createPermission.returns({
-        execute: (_, reject) =>
-          reject(new Error('Changing permissions failed')),
+        then: (_, reject) =>
+          reject({
+            result: {
+              error: {
+                message: 'Changing permissions failed',
+              },
+            },
+          }),
       });
       let err;
       try {

--- a/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/google-picker-client-test.js
@@ -15,6 +15,7 @@ function createGoogleLibFakes() {
   const pickerBuilder = {
     addView: sinon.stub().returnsThis(),
     build: sinon.stub().returnsThis(),
+    setAppId: sinon.stub().returnsThis(),
     setCallback: sinon.stub().returnsThis(),
     setDeveloperKey: sinon.stub().returnsThis(),
     setMaxItems: sinon.stub().returnsThis(),
@@ -182,7 +183,7 @@ describe('GooglePickerClient', () => {
   });
 
   describe('#showPicker', () => {
-    it('requests authorization and sets token used by picker', async () => {
+    it('requests authorization and sets credentials used by picker', async () => {
       const client = createClient();
       client.showPicker();
 
@@ -190,6 +191,7 @@ describe('GooglePickerClient', () => {
 
       assert.ok(fakeTokenClient);
       const builder = fakeGoogleLibs.picker.api.PickerBuilder();
+      assert.calledWith(builder.setAppId, '12345');
       assert.calledWith(builder.setOAuthToken, 'the-access-token');
     });
 


### PR DESCRIPTION
Switch from using the sensitive/restricted
`https://www.googleapis.com/auth/drive` scope to the non-restricted `https://www.googleapis.com/auth/drive.file` scope. The latter allows our app to only access files that have been shared via the Google Drive Picker, whereas the former allows access to all files.

For this to work, the OAuth client ID needs to be passed when configuring the picker, so that the selected file is later made available for use with the Google Drive API client. See https://stackoverflow.com/a/58175142/434243.

Fixes https://github.com/hypothesis/lms/issues/1333. See also [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1718358056636239?thread_ts=1718176476.315619&cid=C4K6M7P5E).

**Testing:**

1. Go to your Google account settings and revoke Google Drive access given to "Hypothesis LMS (Development)". This is under "Security" settings.
2. Configure a new Google Drive assignment. You should see an authorization screen with different permissions than before. Note the "specific files" wording.

<img width="500" alt="Google Drive permissions" src="https://github.com/hypothesis/lms/assets/2458/de11beff-e599-4b31-86b0-f85f38cb011d">
3. Save and launch the assignment

