### PR TITLE
Temporary fix to URL collision on the admin pages

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -213,7 +213,7 @@ def includeme(config):  # noqa: PLR0915
     config.add_route("admin.organization.toggle", "/admin/orgs/{id_}/toggle")
     config.add_route("admin.organizations", "/admin/orgs")
     config.add_route("admin.organization.move_org", "/admin/orgs/{id_}/move_org")
-    config.add_route("admin.organization.new", "/admin/orgs")
+    config.add_route("admin.organization.new", "/admin/org/new")
 
     config.add_route("admin.registrations", "/admin/registrations/")
     config.add_route("admin.registrations.search", "/admin/registrations/search")


### PR DESCRIPTION
After settling on plurals for all the admin pages routes we created a conflict on the search and new organizations pages.

This is the quickest fix to allow organization creation again.

An alternative approach will be to include a pattern, something like [0-9]+, for all IDs that are a PK in the DB. That would allow to use a suffix in the /orgs/ namespace.


## Testing

- Go over http://localhost:8001/admin/orgs, new organization now works.