### PR TITLE
Call AssignmentService.is_member with the right parameter

### DIFF
--- a/lms/views/dashboard/base.py
+++ b/lms/views/dashboard/base.py
@@ -12,7 +12,7 @@ def get_request_assignment(request, assignment_service):
         # STAFF members in our admin pages can access all assignments
         return assignment
 
-    if not assignment_service.is_member(assignment, request.user):
+    if not assignment_service.is_member(assignment, request.user.h_userid):
         raise HTTPUnauthorized()
 
     return assignment

--- a/tests/unit/lms/views/dashboard/base_test.py
+++ b/tests/unit/lms/views/dashboard/base_test.py
@@ -44,6 +44,16 @@ class TestBase:
 
         assert get_request_assignment(pyramid_request, assignment_service)
 
+    def test_get_request_assignment(self, pyramid_request, assignment_service):
+        pyramid_request.matchdict["assignment_id"] = sentinel.id
+        assignment_service.is_member.return_value = True
+
+        assert get_request_assignment(pyramid_request, assignment_service)
+
+        assignment_service.is_member.assert_called_once_with(
+            assignment_service.get_by_id.return_value, pyramid_request.user.h_userid
+        )
+
     def test_get_request_course_404(
         self,
         pyramid_request,


### PR DESCRIPTION
This was shadowed in local testing while using the admin token which doesn't execute this line.


## Testing 

- Open the dashboard from an assignment (on a incognito window)
- Navigate at all three levels.