### PR TITLE
Filter courses by permissions when listing them at the organization level

### DIFF
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -31,7 +31,10 @@ class CourseViews:
     def organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
         courses = self.course_service.get_organization_courses(
-            org, h_userid=self.request.user.h_userid if self.request.user else None
+            org,
+            h_userid=self.request.user.h_userid if self.request.user else None,
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.INSTRUCTOR,
         )
         courses_assignment_counts = self.course_service.get_courses_assignments_count(
             courses

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -30,11 +30,9 @@ class CourseViews:
     )
     def organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
-        courses = self.course_service.get_organization_courses(
+        courses = self.course_service.get_organization_courses_for_instructor(
             org,
             h_userid=self.request.user.h_userid if self.request.user else None,
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.INSTRUCTOR,
         )
         courses_assignment_counts = self.course_service.get_courses_assignments_count(
             courses

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -308,12 +308,35 @@ class TestCourseService:
     def test_search_by_h_userid(self, svc, db_session):
         user = factories.User()
         course = factories.Course()
+        assignment = factories.Assignment()
         factories.Course.create_batch(10)
-        factories.GroupingMembership(grouping=course, user=user)
+        factories.AssignmentGrouping(grouping=course, assignment=assignment)
+        factories.AssignmentMembership(
+            assignment=assignment, user=user, lti_role=factories.LTIRole()
+        )
         # Ensure ids are written
         db_session.flush()
 
         result = svc.search(h_userid=user.h_userid)
+
+        assert result == [course]
+
+    def test_search_by_h_userid_and_role(self, svc, db_session):
+        user = factories.User()
+        course = factories.Course()
+        lti_role = factories.LTIRole()
+        assignment = factories.Assignment()
+        factories.Course.create_batch(10)
+        factories.AssignmentGrouping(grouping=course, assignment=assignment)
+        factories.AssignmentMembership(
+            assignment=assignment, user=user, lti_role=lti_role
+        )
+        # Ensure ids are written
+        db_session.flush()
+
+        result = svc.search(
+            h_userid=user.h_userid, role_scope=lti_role.scope, role_type=lti_role.type
+        )
 
         assert result == [course]
 

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -2,6 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
+from lms.models import RoleScope, RoleType
 from lms.views.dashboard.api.course import CourseViews
 from tests import factories
 
@@ -27,6 +28,8 @@ class TestCourseViews:
         course_service.get_organization_courses.assert_called_once_with(
             organization=org,
             h_userid=pyramid_request.user.h_userid,
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.INSTRUCTOR,
         )
         course_service.get_courses_assignments_count.assert_called_once_with(
             course_service.get_organization_courses.return_value

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -2,7 +2,6 @@ from unittest.mock import sentinel
 
 import pytest
 
-from lms.models import RoleScope, RoleType
 from lms.views.dashboard.api.course import CourseViews
 from tests import factories
 
@@ -16,7 +15,7 @@ class TestCourseViews:
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
         organization_service.get_by_public_id.return_value = org
-        course_service.get_organization_courses.return_value = courses
+        course_service.get_organization_courses_for_instructor.return_value = courses
         pyramid_request.matchdict["organization_public_id"] = sentinel.public_id
         db_session.flush()
 
@@ -25,14 +24,11 @@ class TestCourseViews:
         organization_service.get_by_public_id.assert_called_once_with(
             sentinel.public_id
         )
-        course_service.get_organization_courses.assert_called_once_with(
-            organization=org,
-            h_userid=pyramid_request.user.h_userid,
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.INSTRUCTOR,
+        course_service.get_organization_courses_for_instructor.assert_called_once_with(
+            organization=org, h_userid=pyramid_request.user.h_userid
         )
         course_service.get_courses_assignments_count.assert_called_once_with(
-            course_service.get_organization_courses.return_value
+            course_service.get_organization_courses_for_instructor.return_value
         )
 
         assert response == {


### PR DESCRIPTION
This PR:

- [x] Filters organization course the current instructor has access
- [x] Includes any courses from install where current user is and admin.


### TODO

- [ ] Apply admin filter for course assignments
- [ ] Apply admin check for is_member for organizations
- [ ] Apply admin check for is_member for courses
- [ ] Apply admin check for is_member for assignments
