### PR TITLE
Migration for unique teachers in reports

### DIFF
--- a/lms/migrations/versions/da01fe01c324_usage_report_teachers.py
+++ b/lms/migrations/versions/da01fe01c324_usage_report_teachers.py
@@ -1,0 +1,22 @@
+"""Add usage report teachers column.
+
+Revision ID: da01fe01c324
+Revises: 73f0011260e4
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "da01fe01c324"
+down_revision = "73f0011260e4"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organization_usage_report",
+        sa.Column("unique_teachers", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organization_usage_report", "unique_teachers")


### PR DESCRIPTION
Calculate the number of unique users per report, this can be calculated using the existing data of the reports which allows us to backfill the data.

In theory we could also calculate this on the fly (ie on metabase) but having the number in the DB makes it easier to do graphs etc.


## Deploy

- Merge and deploy this PR
- Run the migration once deployed
- Merge and deploy https://github.com/hypothesis/lms/pull/6373
- Merge and deploy https://github.com/hypothesis/lms/pull/6374
- Run the migration 