### PR TITLE
Expose logged-in LMS user basic details to the FE via config

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -572,6 +572,9 @@ class JSConfig:
             config["debug"]["tags"].append(
                 "role:instructor" if self._lti_user.is_instructor else "role:learner"
             )
+            config["user"] = {
+                "display_name": self._lti_user.display_name,
+            }
 
         return config
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -276,6 +276,11 @@ export type ConfigObject = {
   debug?: DebugInfo;
   product: Product;
 
+  // Only present when an LTI user is logged-in
+  user?: {
+    display_name: string;
+  };
+
   // Only present in "basic-lti-launch" mode.
   canvas: {
     // Only present in Canvas.

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -173,6 +173,9 @@ class TestEnableLTILaunchMode:
             },
             "mode": "basic-lti-launch",
             "rpcServer": {"allowedOrigins": ["http://localhost:5000"]},
+            "user": {
+                "display_name": lti_user.display_name,
+            },
         }
 
     @pytest.mark.usefixtures("grouping_plugin")


### PR DESCRIPTION
A requirement for the LMS dashboard is that we display the logged-in user display name in the header.

This PR adds a new config entry which exposes the most basic user details for the FE to display. It currently includes only the  `display_name`.

This information is not used yet. It will be used as part of https://github.com/hypothesis/lms/pull/6372

### Testing steps.

1. Launch an assignment
2. Open the browser console, and inspect generated HTML.
3. In the LMS iframe, we generate a `<script />qq tag with `class="js-config"`. It should include a block like this:
    ```json
    {
      "user": {
        "display_name": "Hypothesis 101 Teacher"
      }
    } 
    ```