### PR TITLE
Initially order null columns last in dashboard activity tables

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -72,12 +72,27 @@ export default function AssignmentActivity() {
           students.error ? 'Could not load students' : 'No students found'
         }
         rows={rows}
-        columnNames={{
-          display_name: 'Student',
-          annotations: 'Annotations',
-          replies: 'Replies',
-          last_activity: 'Last Activity',
-        }}
+        columns={[
+          {
+            field: 'display_name',
+            label: 'Student',
+          },
+          {
+            field: 'annotations',
+            label: 'Annotations',
+            initialOrderDirection: 'descending',
+          },
+          {
+            field: 'replies',
+            label: 'Replies',
+            initialOrderDirection: 'descending',
+          },
+          {
+            field: 'last_activity',
+            label: 'Last Activity',
+            initialOrderDirection: 'descending',
+          },
+        ]}
         defaultOrderField="display_name"
         renderItem={(stats, field) => {
           if (['annotations', 'replies'].includes(field)) {

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -69,12 +69,27 @@ export default function CourseActivity() {
             : 'No assignments found'
         }
         rows={rows}
-        columnNames={{
-          title: 'Assignment',
-          annotations: 'Annotations',
-          replies: 'Replies',
-          last_activity: 'Last Activity',
-        }}
+        columns={[
+          {
+            field: 'title',
+            label: 'Assignment',
+          },
+          {
+            field: 'annotations',
+            label: 'Annotations',
+            initialOrderDirection: 'descending',
+          },
+          {
+            field: 'replies',
+            label: 'Replies',
+            initialOrderDirection: 'descending',
+          },
+          {
+            field: 'last_activity',
+            label: 'Last Activity',
+            initialOrderDirection: 'descending',
+          },
+        ]}
         defaultOrderField="title"
         renderItem={(stats, field) => {
           if (['annotations', 'replies'].includes(field)) {

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -88,7 +88,14 @@ export default function OrderableActivityTable<T>({
       rows={orderedRows}
       orderableColumns={orderableColumns}
       order={order}
-      onOrderChange={setOrder}
+      onOrderChange={order =>
+        setOrder({
+          ...order,
+          // Every column should start with nulls last, and move them first
+          // when order direction changes
+          nullsLast: order.direction === orderableColumns[order.field],
+        })
+      }
       onConfirmRow={
         navigateOnConfirmRow
           ? row => navigate(navigateOnConfirmRow(row))

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -55,11 +55,22 @@ export default function OrganizationActivity({
           courses.error ? 'Could not load courses' : 'No courses found'
         }
         rows={rows}
-        columnNames={{
-          title: 'Course Title',
-          assignments: 'Assignments',
-          last_launched: 'Last launched',
-        }}
+        columns={[
+          {
+            field: 'title',
+            label: 'Course title',
+          },
+          {
+            field: 'assignments',
+            label: 'Assignments',
+            initialOrderDirection: 'descending',
+          },
+          {
+            field: 'last_launched',
+            label: 'Last launched',
+            initialOrderDirection: 'descending',
+          },
+        ]}
         defaultOrderField="title"
         renderItem={(stats, field) => {
           if (field === 'assignments') {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrderableActivityTable-test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 
 import OrderableActivityTable, { $imports } from '../OrderableActivityTable';
 
@@ -43,12 +44,24 @@ describe('OrderableActivityTable', () => {
     return mount(
       <OrderableActivityTable
         rows={rows}
-        columnNames={{
-          display_name: 'Name',
-          last_activity: 'Last activity',
-          annotations: 'Annotations',
-          replies: 'Replies',
-        }}
+        columns={[
+          {
+            field: 'display_name',
+            label: 'Name',
+          },
+          {
+            field: 'last_activity',
+            label: 'Last activity',
+          },
+          {
+            field: 'annotations',
+            label: 'Annotations',
+          },
+          {
+            field: 'replies',
+            label: 'Replies',
+          },
+        ]}
         defaultOrderField="display_name"
         navigateOnConfirmRow={navigateOnConfirmRow}
       />,
@@ -58,6 +71,7 @@ describe('OrderableActivityTable', () => {
   [
     {
       orderToSet: { field: 'annotations', direction: 'descending' },
+      expectedNullsLast: false,
       expectedStudents: [
         {
           display_name: 'b',
@@ -81,6 +95,7 @@ describe('OrderableActivityTable', () => {
     },
     {
       orderToSet: { field: 'replies', direction: 'ascending' },
+      expectedNullsLast: true,
       expectedStudents: [
         {
           display_name: 'b',
@@ -104,6 +119,7 @@ describe('OrderableActivityTable', () => {
     },
     {
       orderToSet: { field: 'last_activity', direction: 'descending' },
+      expectedNullsLast: false,
       expectedStudents: [
         {
           display_name: 'a',
@@ -125,7 +141,7 @@ describe('OrderableActivityTable', () => {
         },
       ],
     },
-  ].forEach(({ orderToSet, expectedStudents }) => {
+  ].forEach(({ orderToSet, expectedNullsLast, expectedStudents }) => {
     it('reorders students on order change', () => {
       const wrapper = createComponent();
       const getRows = () => wrapper.find('DataTable').prop('rows');
@@ -162,7 +178,10 @@ describe('OrderableActivityTable', () => {
       ]);
 
       setOrder(orderToSet);
-      assert.deepEqual(getOrder(), orderToSet);
+      assert.deepEqual(getOrder(), {
+        ...orderToSet,
+        nullsLast: expectedNullsLast,
+      });
       assert.deepEqual(getRows(), expectedStudents);
     });
   });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.6",
     "@babel/preset-typescript": "^7.24.6",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.10.1",
+    "@hypothesis/frontend-shared": "^7.11.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.8",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,15 +1988,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@hypothesis/frontend-shared@npm:7.10.1"
+"@hypothesis/frontend-shared@npm:^7.11.0":
+  version: 7.11.0
+  resolution: "@hypothesis/frontend-shared@npm:7.11.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 758c415d8e68325a3c630122e76bd40895cafbfa00404829549380c873aed6e8fd937c27da5a0632240d547c262425b1374b75e951d498d546aa19c6894daff1
+  checksum: 12d10503b2a51a8c5d690f0f892341698465f49d3c760574a838918879a7a0151ddf0994f422515264224f6462a5b1baf1169f4f16ca6f5f9b8d7b4d8065cc4b
   languageName: node
   linkType: hard
 
@@ -7193,7 +7193,7 @@ __metadata:
     "@babel/preset-react": ^7.24.6
     "@babel/preset-typescript": ^7.24.6
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.10.1
+    "@hypothesis/frontend-shared": ^7.11.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^25.0.8


### PR DESCRIPTION
This PR uses the logic introduced in https://github.com/hypothesis/frontend-shared/pull/1587 to make columns with value null be initially ordered last, and move first when the order direction changes.

Additionally, it refactors `OrderableActivityTable` to move the decision on what's the initial order direction for every column to every individual activity table.

https://github.com/hypothesis/lms/assets/2719332/9a85da0f-10f3-4b7b-93c1-3fe619f3de51

### Testing steps

Any table where the user's last activity is null, should allow to test this behavior.

It can also be faked by making sure some null students names are returned, by applying this diff, replacing `<some-value>` with the display name of some student in your local dev database:

```diff
diff --git a/lms/views/dashboard/api/assignment.py b/lms/views/dashboard/api/assignment.py
index 444a6f45e..bb0e2aa8b 100644
--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -60,7 +60,7 @@ class AssignmentViews:
                 students.append(
                     APIStudent(
                         id=user.user_id,
-                        display_name=s["display_name"],
+                        display_name=None if s["display_name"] == "<some-value>" else s["display_name"],
                         annotation_metrics=AnnotationMetrics(
                             annotations=s["annotations"],
                             replies=s["replies"],
```

