### PR TITLE
Add help text for unknown students

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -95,15 +95,29 @@ export default function AssignmentActivity() {
         ]}
         defaultOrderField="display_name"
         renderItem={(stats, field) => {
-          if (['annotations', 'replies'].includes(field)) {
-            return <div className="text-right">{stats[field]}</div>;
-          } else if (field === 'last_activity') {
-            return stats.last_activity
-              ? formatDateTime(new Date(stats.last_activity))
-              : '';
+          switch (field) {
+            case 'annotations':
+            case 'replies':
+              return <div className="text-right">{stats[field]}</div>;
+            case 'last_activity':
+              return stats.last_activity
+                ? formatDateTime(new Date(stats.last_activity))
+                : '';
+            case 'display_name':
+              return (
+                stats.display_name ?? (
+                  <span className="flex flex-col gap-1.5">
+                    <span className="italic">Unknown</span>
+                    <span className="text-xs text-grey-7">
+                      This student launched the assignment but didn{"'"}t
+                      annotate yet
+                    </span>
+                  </span>
+                )
+              );
+            default:
+              return '';
           }
-
-          return stats[field] ?? `Student ${stats.id.substring(0, 10)}`;
         }}
       />
     </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -128,6 +128,8 @@ describe('AssignmentActivity', () => {
       fieldName: 'last_activity',
       expectedValue: formatDateTime(new Date('2024-01-01T10:35:18')),
     },
+    // Render "unknown" field name
+    { fieldName: 'id', expectedValue: '' },
     // Render last_activity when it's null
     {
       fieldName: 'last_activity',
@@ -137,7 +139,8 @@ describe('AssignmentActivity', () => {
     // Render display_name when it's null
     {
       fieldName: 'display_name',
-      expectedValue: 'Student e4ca30ee27',
+      expectedValue:
+        "UnknownThis student launched the assignment but didn't annotate yet",
       studentStats: {
         id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
         display_name: null,


### PR DESCRIPTION
Proposal on how to slightly improve the experience when we have students in the assignment activity page which launched the assignment but didn't annotate.

So far we were displaying a placeholder composed out of "Student" prefix followed by the first 10 characters of the ID.

> [!NOTE]  
> For assignments newer than May 9th, 2024, this will never happen, as we now capture their display name during assignment launch, not when they first annotate.

![image](https://github.com/hypothesis/lms/assets/2719332/0e529397-0ff8-420e-a7ee-870f15afce97)