### PR TITLE
Manage dashboard admins in the admin pages

### DIFF
--- a/lms/migrations/versions/f8ff7e49cbbf_dashboard_admin_table.py
+++ b/lms/migrations/versions/f8ff7e49cbbf_dashboard_admin_table.py
@@ -1,0 +1,45 @@
+"""Create the dashboard_admin table.
+
+Revision ID: f8ff7e49cbbf
+Revises: 8e203ad93a58
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f8ff7e49cbbf"
+
+down_revision = "1337584e2b07"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dashboard_admin",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("created_by", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk__dashboard_admin__organization_id__organization"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__dashboard_admin")),
+        sa.UniqueConstraint(
+            "organization_id",
+            "email",
+            name=op.f("uq__dashboard_admin__organization_id"),
+        ),
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    op.drop_table("dashboard_admin")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -5,6 +5,7 @@ from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import AssignmentMembership
 from lms.models.course import LegacyCourse
 from lms.models.course_groups_exported_from_h import CourseGroupsExportedFromH
+from lms.models.dashboard_admin import DashboardAdmin
 from lms.models.event import Event, EventData, EventType, EventUser
 from lms.models.exceptions import ReusedConsumerKey
 from lms.models.file import File

--- a/lms/models/dashboard_admin.py
+++ b/lms/models/dashboard_admin.py
@@ -1,0 +1,34 @@
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from lms.db import Base
+from lms.models._mixins import CreatedUpdatedMixin
+from lms.models.organization import Organization
+
+
+class DashboardAdmin(CreatedUpdatedMixin, Base):
+    """LMS users that are given full admin access to the dashboards."""
+
+    __tablename__ = "dashboard_admin"
+    __table_args__ = (sa.UniqueConstraint("organization_id", "email"),)
+
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
+
+    created_by: Mapped[str] = mapped_column(nullable=False)
+
+    email: Mapped[str] = mapped_column(nullable=False)
+    """Email of the LMS user that have admin access to `organization`.
+
+    We don't use user_id or h_userid to allow:
+
+        - Easier comunication with LMS admins
+        - The possiblity of adding a user without a previous launch.
+    """
+
+    organization_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("organization.id", ondelete="cascade"), nullable=False
+    )
+
+    organization: Mapped[Organization] = sa.orm.relationship(
+        "Organization", backref=sa.orm.backref("dashboard_admins")
+    )

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -208,12 +208,16 @@ def includeme(config):  # noqa: PLR0915
     config.add_route("admin.organization", "/admin/orgs/{id_}")
     config.add_route(
         "admin.organization.section",
-        "/admin/orgs/{id_}/{section:info|usage|danger}",
+        "/admin/orgs/{id_}/{section:info|usage|danger|dashboard-admins}",
     )
     config.add_route("admin.organization.toggle", "/admin/orgs/{id_}/toggle")
     config.add_route("admin.organizations", "/admin/orgs")
     config.add_route("admin.organization.move_org", "/admin/orgs/{id_}/move_org")
     config.add_route("admin.organization.new", "/admin/org/new")
+    config.add_route(
+        "admin.organization.dashboard_admins.delete",
+        "/admin/org{id_}/dashboard-admins/{dashboard_admin_id}/delete",
+    )
 
     config.add_route("admin.registrations", "/admin/registrations/")
     config.add_route("admin.registrations.search", "/admin/registrations/search")

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -26,6 +26,9 @@
                 <li data-section-id="usage">
                     <a>Usage report</a>
                 </li>
+                <li data-section-id="dashboard-admins">
+                    <a>Dashboard admins</a>
+                </li>
                 <li data-section-id="danger">
                     <a>Danger Zone</a>
                 </li>
@@ -94,6 +97,55 @@
                                 <input type="submit" class="button is-primary" value="Generate" />
                             </div>
                         </form>
+                    </fieldset>
+                </li>
+                <li class="tab-panel" data-section-id="dashboard-admins">
+                    <fieldset class="box">
+                        <legend class="label has-text-centered">Dashboard admins</legend>
+                        <form method="POST"
+                              action="{{ request.route_url("admin.organization.section", id_=org.id, section="dashboard-admins") }}">
+                            <div class="columns">
+                                <div class="column">{{ macros.form_text_field(request, "Email", "email") }}</div>
+                            </div>
+                            <div class="has-text-right mb-6">
+                                <input type="submit" class="button is-primary" value="Add admin" />
+                            </div>
+                        </form>
+                    </fieldset>
+                    <fieldset class="box">
+                      {% if org.dashboard_admins %}
+                      <form method="POST">
+                      <div class="container">
+                          <div class="table-container">
+                              <table class="table is-fullwidth">
+                                  <thead>
+                                      <tr>
+                                          <th>Email</th>
+                                          <th>Created by</th>
+                                          <th></th>
+                                      </tr>
+                                  </thead>
+                                  <tbody>
+                                      {% for admin in org.dashboard_admins %}
+                                          <tr>
+                                              <td><b>{{admin.email}}</b></td>
+                                              <td>{{admin.created_by}}</td>
+                                              <td>
+                                                <input type="submit"
+                                                     formaction="{{ request.route_url("admin.organization.dashboard_admins.delete", id_=org.id, dashboard_admin_id=admin.id) }}"
+                                                     class="button is-danger"
+                                                     value="Delete" />
+                                              </td>
+                                          </tr>
+                                      {% endfor %}
+                                  </tbody>
+                              </table>
+                          </div>
+                      </div>
+                      </form>
+                      {% else %}
+                      <div class="has-text-centered">No dashboard admins</div>
+                      {% endif %}
                     </fieldset>
                 </li>
                 <li class="tab-panel" data-section-id="danger">


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6378


This PR adds a table/model and admin pages to handle manual access to some schools admins to the dashboards.

**This PR doesn't yet take into consideration those admins to give access to the dashboards.**


### Testing

- Apply the migration


```
dev run-test-pre: PYTHONHASHSEED='2402316231'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade headINFO  [alembic.runtime.migration] Context impl PostgresqlImpl.INFO  [alembic.runtime.migration] Will assume transactional DDL.INFO  [alembic.runtime.migration] Running upgrade 1337584e2b07 -> f8ff7e49cbbf, Create the dashboard_admin table.
```

- Play with the admin pages at  http://localhost:8001/admin/orgs/1/dashboard-admins
- Add a new email to the org
- Remove the email


