### PR TITLE
Improve handling of grading submission errors in frontend

### DIFF
--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -5,6 +5,7 @@ import { useConfig } from '../config';
 import type { ErrorLike } from '../errors';
 import type { ErrorState } from './BasicLTILaunchApp';
 import ErrorModal from './ErrorModal';
+import type { ErrorModalProps } from './ErrorModal';
 
 export type LaunchErrorDialogProps = {
   /**
@@ -18,6 +19,9 @@ export type LaunchErrorDialogProps = {
   error: ErrorLike | null;
   /** Callback invoked when user clicks the "Try again" button */
   onRetry: () => void;
+
+  /** Callback invoked when user clicks the "Dismiss" button */
+  onDismiss?: () => void;
 };
 
 /**
@@ -62,6 +66,7 @@ export default function LaunchErrorDialog({
   busy,
   error,
   errorState,
+  onDismiss,
   onRetry,
 }: LaunchErrorDialogProps) {
   const { instructorToolbar } = useConfig();
@@ -79,7 +84,7 @@ export default function LaunchErrorDialog({
   }
 
   // Common properties for error dialog.
-  const defaultProps = {
+  const defaultProps: ErrorModalProps = {
     busy,
     extraActions,
     error,
@@ -89,6 +94,11 @@ export default function LaunchErrorDialog({
     // in future by always providing this option?
     onRetry,
   };
+
+  if (onDismiss) {
+    defaultProps.onCancel = onDismiss;
+    defaultProps.cancelLabel = 'Dismiss';
+  }
 
   switch (errorState) {
     case 'error-authorizing':
@@ -625,18 +635,42 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
-    case 'error-reporting-submission':
-      // nb. There is no retry action here as we just suggest reloading the entire
-      // page.
+    case 'canvas_submission_course_not_available':
       return (
         <ErrorModal
           {...defaultProps}
           onRetry={undefined}
-          title="Something went wrong"
+          title="Grading submission failed"
         >
           <p>
-            There was a problem submitting this Hypothesis assignment.{' '}
-            <b>To fix this problem, try reloading the page.</b>
+            Your annotation was saved, but Hypothesis could not record a
+            submission for grading.
+          </p>
+          <p>
+            This may be because the course has ended and we are no longer
+            allowed to create submissions.
+          </p>
+          <p>
+            Your instructor is not aware you have saved an annotation. You may
+            need to reach out to them.
+          </p>
+        </ErrorModal>
+      );
+
+    case 'error-reporting-submission':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Grading submission failed"
+        >
+          <p>
+            Your annotation was saved, but Hypothesis could not record a
+            submission for grading.
+          </p>
+          <p>
+            Your instructor is not aware you have saved an annotation. You may
+            need to reach out to them.
           </p>
         </ErrorModal>
       );

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -259,10 +259,16 @@ describe('LaunchErrorDialog', () => {
     },
     {
       errorState: 'error-reporting-submission',
-      expectedText: 'There was a problem submitting this Hypothesis assignment',
-      expectedTitle: 'Something went wrong',
+      expectedText:
+        'Your annotation was saved, but Hypothesis could not record a submission for grading.',
+      expectedTitle: 'Grading submission failed',
       hasRetry: false,
       withError: true,
+    },
+    {
+      errorState: 'canvas_submission_course_not_available',
+      expectedText: 'This may be because the course has ended',
+      expectedTitle: 'Grading submission failed',
     },
   ].forEach(
     ({
@@ -337,5 +343,23 @@ describe('LaunchErrorDialog', () => {
       .filterWhere(n => n.prop('data-testid') === 'edit-link');
     assert.isTrue(editLink.exists());
     assert.equal(editLink.prop('href'), '/app/content-item-selection');
+  });
+
+  it('does not allow dismissing error if `onDismiss` callback is not provided', () => {
+    const wrapper = renderDialog();
+    const errorModal = wrapper.find('ErrorModal');
+    assert.isUndefined(errorModal.prop('onCancel'));
+    assert.isUndefined(errorModal.prop('cancelLabel'));
+  });
+
+  it('allows dismissing error if `onDismiss` callback is provided', () => {
+    const onDismiss = sinon.stub();
+    const wrapper = renderDialog({ onDismiss });
+    const errorModal = wrapper.find('ErrorModal');
+
+    errorModal.prop('onCancel')();
+
+    assert.equal(errorModal.prop('cancelLabel'), 'Dismiss');
+    assert.calledOnce(onDismiss);
   });
 });

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -23,6 +23,7 @@ export type LTILaunchServerErrorCode =
   | 'canvas_studio_transcript_unavailable'
   | 'canvas_studio_media_not_found'
   | 'canvas_studio_admin_token_refresh_failed'
+  | 'canvas_submission_course_not_available'
   | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_file_not_found_in_course_student'
   | 'd2l_group_set_empty'
@@ -171,6 +172,7 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_studio_transcript_unavailable',
       'canvas_studio_media_not_found',
       'canvas_studio_admin_token_refresh_failed',
+      'canvas_submission_course_not_available',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
       'moodle_page_not_found_in_course',


### PR DESCRIPTION
This is a revised version of https://github.com/hypothesis/lms/pull/6289, to improve how grading submission errors are handled in the frontend. In addition to addressing the TODOs in that draft, I have also tweaked the wording in the error messages to try and make it a bit shorter. I also used the term "Dismiss" rather than "Close" on the button to make it clearer that it is going to dismiss just the error message rather than "close" the whole assignment.

----

Summary of changes:

 - Handle the `canvas_submission_course_not_available` error with a dedicated message and revise the wording of the existing submission error.

 - Continue to show the assignment content underneath the submission error. The error dialog already had a translucent modal backdrop, so all that was required was to move the error dialog above the content in the stacking order, and avoid hiding the content if an error occurs after it has been loaded.

 - Allow the user to dismiss submission errors, so they can continue making annotations. The option to dismiss the error is rendered as a secondary "Dismiss" action, to reduce the chances of the user dismissing it without reading the dialog.

With the testing diff from https://github.com/hypothesis/lms/pull/6289 applied, creating an annotation will fail with an error that looks like this:

<img width="718" alt="Grading submission error" src="https://github.com/hypothesis/lms/assets/2458/87d80d46-4218-434c-808b-7807fe6cec92">
