### PR TITLE
Handle `canvas_submission_max_attempts` error in frontend

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -40,6 +40,7 @@ function canDismissError(e: ErrorState) {
   return [
     'error-reporting-submission',
     'canvas_submission_course_not_available',
+    'canvas_submission_max_attempts',
   ].includes(e);
 }
 

--- a/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
+++ b/lms/static/scripts/frontend_apps/components/LaunchErrorDialog.tsx
@@ -657,6 +657,28 @@ export default function LaunchErrorDialog({
         </ErrorModal>
       );
 
+    case 'canvas_submission_max_attempts':
+      return (
+        <ErrorModal
+          {...defaultProps}
+          onRetry={undefined}
+          title="Grading submission failed"
+        >
+          <p>
+            Your annotation was saved, but Hypothesis could not record a new
+            submission for grading. Hypothesis has already recorded the maximum
+            number of allowed submissions for this assignment.
+          </p>
+          <p>
+            See{' '}
+            <ExternalLink href="https://web.hypothes.is/help/grading-student-annotations-in-canvas/#when-does-canvas-report-a-student-hypothesis-submission-for-grading">
+              this article
+            </ExternalLink>{' '}
+            for an explanation of when Hypothesis creates submissions.
+          </p>
+        </ErrorModal>
+      );
+
     case 'error-reporting-submission':
       return (
         <ErrorModal

--- a/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LaunchErrorDialog-test.js
@@ -270,6 +270,11 @@ describe('LaunchErrorDialog', () => {
       expectedText: 'This may be because the course has ended',
       expectedTitle: 'Grading submission failed',
     },
+    {
+      errorState: 'canvas_submission_max_attempts',
+      expectedText: 'maximum number of allowed submissions',
+      expectedTitle: 'Grading submission failed',
+    },
   ].forEach(
     ({
       errorState,

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -24,6 +24,7 @@ export type LTILaunchServerErrorCode =
   | 'canvas_studio_media_not_found'
   | 'canvas_studio_admin_token_refresh_failed'
   | 'canvas_submission_course_not_available'
+  | 'canvas_submission_max_attempts'
   | 'd2l_file_not_found_in_course_instructor'
   | 'd2l_file_not_found_in_course_student'
   | 'd2l_group_set_empty'
@@ -173,6 +174,7 @@ export function isLTILaunchServerError(error: ErrorLike): error is APIError {
       'canvas_studio_media_not_found',
       'canvas_studio_admin_token_refresh_failed',
       'canvas_submission_course_not_available',
+      'canvas_submission_max_attempts',
       'vitalsource_user_not_found',
       'vitalsource_no_book_license',
       'moodle_page_not_found_in_course',


### PR DESCRIPTION
Add a custom error message for this scenario.

See https://hypothes-is.slack.com/archives/C1MA4E9B9/p1719220175035739 for discussion around the message.

**Testing:**

Follow the steps in https://github.com/hypothesis/lms/pull/6295. You should see this error:

<img width="665" alt="Grading submission failed" src="https://github.com/hypothesis/lms/assets/2458/14d30bc4-dff5-4f57-9e98-eed2bee2bedd">
