### PR TITLE
Handle Canvas Studio admin token lookup when LMS has multiple installs

### DIFF
--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 from typing import Literal, Mapping, NotRequired, Type, TypedDict
 from urllib.parse import urlencode, urljoin, urlparse, urlunparse
@@ -20,6 +21,8 @@ from lms.services.exceptions import (
 from lms.services.oauth_http import OAuthHTTPService
 from lms.services.oauth_http import factory as oauth_http_factory
 from lms.validation._base import RequestsResponseSchema
+
+LOG = logging.getLogger(__name__)
 
 
 class PaginationSchema(Schema):
@@ -570,6 +573,13 @@ class CanvasStudioService:
 
         admin_user = self._request.db.scalars(admin_user_query).first()
         if not admin_user:
+            ai_id = self._request.lti_user.application_instance.id
+            LOG.debug(
+                "Canvas Studio admin auth missing. application instance: %s, admin email: %s, guid: %s",
+                ai_id,
+                admin_email,
+                guid,
+            )
             raise HTTPBadRequest(
                 "The Canvas Studio admin needs to authenticate the Hypothesis integration"
             )

--- a/lms/services/oauth2_token.py
+++ b/lms/services/oauth2_token.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from sqlalchemy.orm.exc import NoResultFound
 
 from lms.db import LockType, try_advisory_transaction_lock
-from lms.models import OAuth2Token
+from lms.models import ApplicationInstance, OAuth2Token
 from lms.models.oauth2_token import Service
 from lms.services.exceptions import OAuth2TokenError
 
@@ -84,9 +84,14 @@ class OAuth2TokenService:
         try_advisory_transaction_lock(self._db, LockType.OAUTH2_TOKEN_REFRESH, token.id)
 
 
-def oauth2_token_service_factory(_context, request, user_id: str | None = None):
+def oauth2_token_service_factory(
+    _context,
+    request,
+    application_instance: ApplicationInstance | None = None,
+    user_id: str | None = None,
+):
     return OAuth2TokenService(
         request.db,
-        request.lti_user.application_instance,
+        application_instance or request.lti_user.application_instance,
         user_id or request.lti_user.user_id,
     )

--- a/lms/services/oauth_http.py
+++ b/lms/services/oauth_http.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from marshmallow import fields
 
 from lms.db import CouldNotAcquireLock
+from lms.models.application_instance import ApplicationInstance
 from lms.models.oauth2_token import Service
 from lms.services.exceptions import (
     ConcurrentTokenRefreshError,
@@ -170,7 +171,11 @@ class OAuthHTTPService:
 
 
 def factory(
-    _context, request, service: Service = Service.LMS, user_id: str | None = None
+    _context,
+    request,
+    service: Service = Service.LMS,
+    application_instance: ApplicationInstance | None = None,
+    user_id: str | None = None,
 ) -> OAuthHTTPService:
     """
     Create an `OAuthHTTPService`.
@@ -180,10 +185,16 @@ def factory(
     :param user_id:
         The LTI user ID of the user whose API tokens should be used. Defaults
         to the LTI user from the current request.
+    :param application_instance:
+        Use API tokens associated with this application instance. Defaults to
+        the application instance associated with the current request.
     """
-    if user_id:
+    if user_id or application_instance:
         oauth2_token_svc = oauth2_token_service_factory(
-            _context, request, user_id=user_id
+            _context,
+            request,
+            application_instance=application_instance,
+            user_id=user_id,
         )
     else:
         oauth2_token_svc = request.find_service(name="oauth2_token")

--- a/tests/unit/lms/services/oauth_http_test.py
+++ b/tests/unit/lms/services/oauth_http_test.py
@@ -339,7 +339,32 @@ class TestFactory:
     ):
         service = factory(sentinel.context, pyramid_request, user_id="custom_user_id")
         oauth2_token_service_factory.assert_called_once_with(
-            sentinel.context, pyramid_request, "custom_user_id"
+            sentinel.context,
+            pyramid_request,
+            application_instance=None,
+            user_id="custom_user_id",
+        )
+        OAuthHTTPService.assert_called_once_with(
+            http_service, oauth2_token_service_factory.return_value, Service.LMS
+        )
+        assert service == OAuthHTTPService.return_value
+
+    def test_with_custom_application_instance(
+        self,
+        OAuthHTTPService,
+        pyramid_request,
+        http_service,
+        oauth2_token_service_factory,
+    ):
+        mock_ai = sentinel.application_instance
+        service = factory(
+            sentinel.context, pyramid_request, application_instance=mock_ai
+        )
+        oauth2_token_service_factory.assert_called_once_with(
+            sentinel.context,
+            pyramid_request,
+            application_instance=mock_ai,
+            user_id=None,
         )
         OAuthHTTPService.assert_called_once_with(
             http_service, oauth2_token_service_factory.return_value, Service.LMS


### PR DESCRIPTION
Handle the case where the same Canvas Studio OAuth client is reused for multiple installs at the same LMS, and the Canvas Studio admin has authenticated using while using a different install than the one being used to launch a Canvas Studio assignment.

Previously admin-authenticated API requests to Canvas Studio used tokens associated with the same application instance as the current LTI user.  In this commit that is changed to find a `(user, application_instance)` combination for a user who has the correct email, belongs to the same LMS, and has authenticated with Canvas Studio. If there are multiple matches, because the admin has authenticated in multiple installs, we pick the most recent.

This solution is something of a workaround for the fact that OAuth tokens in our LMS app do not correspond 1:1 with records in the external LMS. In the external LMS, tokens are keyed by `(oauth_client_id, user_id)`. Our `oauth2_token` table however is keyed by `(application_instance_id, user_id)`, and it is possible to configure multiple app instances using the same OAuth client ID.

Fixes https://github.com/hypothesis/lms/issues/6356.

----

**Testing:**

1. Configure application instances 8 (http://localhost:8001/admin/instances/8/) and 102 (http://localhost:8001/admin/instances/102) to use the same Canvas Studio OAuth client. These AIs are the LTI 1.1 and LTI 1.3 installs within our test Canvas instance. They have the same GUID.
2. Log in as the Canvas Studio admin, open the assignment at https://hypothesis.instructure.com/courses/125/assignments/6473, which uses AI 8, and authenticate
3. Log out of Canvas and back in as a non-admin user. The assignment should launch successfully
4. Go to the assignment at https://hypothesis.instructure.com/courses/319/assignments/6944, which uses AI 102. This should also launch successfully