### PR TITLE
Add new API endpoint to list students

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -36,7 +36,12 @@ class APICourse(TypedDict):
 
 
 class APIStudent(TypedDict):
-    id: str
+    h_userid: str
+    """ID of the student in H."""
+
+    lms_id: str
+    """ID of the student in the LMS."""
+
     display_name: str | None
 
     annotation_metrics: NotRequired[AnnotationMetrics]

--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -64,6 +64,8 @@ class APIAssignments(TypedDict):
 class APIStudents(TypedDict):
     students: list[APIStudent]
 
+    pagination: NotRequired[Pagination]
+
 
 class DashboardRoutes(TypedDict):
     assignment: str

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
@@ -32,7 +32,7 @@ class User(CreatedUpdatedMixin, Base):
     )
     application_instance = sa.orm.relationship("ApplicationInstance")
 
-    user_id = sa.Column(sa.Unicode, nullable=False)
+    user_id: Mapped[str] = mapped_column(sa.Unicode, nullable=False)
     """The user id provided by the LTI parameters."""
 
     roles = sa.Column(sa.Unicode, nullable=True)

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -38,11 +38,11 @@ class User(CreatedUpdatedMixin, Base):
     roles = sa.Column(sa.Unicode, nullable=True)
     """The roles provided by the LTI parameters."""
 
-    h_userid = sa.Column(sa.Unicode, nullable=False)
+    h_userid: Mapped[str] = mapped_column(sa.Unicode)
     """The H userid which is created from LTI provided values."""
 
-    email = mapped_column(sa.Unicode, nullable=True)
+    email: Mapped[str | None] = mapped_column(sa.Unicode)
     """Email address of the user"""
 
-    display_name = mapped_column(sa.Unicode, nullable=True)
+    display_name: Mapped[str | None] = mapped_column(sa.Unicode)
     """The user's display name."""

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -278,3 +278,4 @@ def includeme(config):  # noqa: PLR0915
         "/api/dashboard/courses/{course_id}/assignments/stats",
     )
     config.add_route("api.dashboard.assignments", "/api/dashboard/assignments")
+    config.add_route("api.dashboard.students", "/api/dashboard/students")

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from sqlalchemy import Select, select
+from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import Select
 
@@ -99,12 +99,12 @@ class UserService:
         role_scope: RoleScope,
         role_type: RoleType,
         instructor_h_userid: str | None = None,
-    ) -> Select[User]:
+    ) -> Select[tuple[User]]:
         """
         Get a query to fetch users.
 
         :param role_scope: return only users with this LTI role scope.
-        :param role_scope: return only users with this LTI role type.
+        :param role_type: return only users with this LTI role type.
         :param instructor_h_userid: return only users that belongs to courses/assignments where the user instructor_h_userid is an instructor.
         """
         query = (

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -190,7 +190,8 @@ export type Assignment = {
  * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
  */
 export type StudentStats = {
-  id: string;
+  h_userid: string;
+  lms_id: string;
   display_name: string | null;
   annotation_metrics: AnnotationMetrics;
 };

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -10,7 +10,7 @@ import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
 
 type StudentsTableRow = {
-  id: string;
+  lms_id: string;
   display_name: string | null;
   last_activity: string | null;
   annotations: number;
@@ -35,8 +35,8 @@ export default function AssignmentActivity() {
   const rows: StudentsTableRow[] = useMemo(
     () =>
       (students.data?.students ?? []).map(
-        ({ id, display_name, annotation_metrics }) => ({
-          id,
+        ({ lms_id, display_name, annotation_metrics }) => ({
+          lms_id,
           display_name,
           ...annotation_metrics,
         }),

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -24,7 +24,7 @@ class ListAssignmentsSchema(PaginationParametersMixin):
     """Query parameters to fetch a list of assignments."""
 
     course_id = fields.Integer(required=False, validate=validate.Range(min=1))
-    """Return assignments that belong to the course with this ID."""
+    """Filter assignments that belong to the course with this ID."""
 
 
 class AssignmentViews:

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -24,7 +24,7 @@ class ListAssignmentsSchema(PaginationParametersMixin):
     """Query parameters to fetch a list of assignments."""
 
     course_id = fields.Integer(required=False, validate=validate.Range(min=1))
-    """Filter assignments that belong to the course with this ID."""
+    """Return assignments that belong to the course with this ID."""
 
 
 class AssignmentViews:
@@ -103,7 +103,8 @@ class AssignmentViews:
                 # We seen this student in H, get all the data from there
                 students.append(
                     APIStudent(
-                        id=user.user_id,
+                        h_userid=user.h_userid,
+                        lms_id=user.user_id,
                         display_name=s["display_name"],
                         annotation_metrics=AnnotationMetrics(
                             annotations=s["annotations"],
@@ -117,7 +118,8 @@ class AssignmentViews:
                 # use LMS DB's data and set 0s for all annotation related fields.
                 students.append(
                     APIStudent(
-                        id=user.user_id,
+                        h_userid=user.h_userid,
+                        lms_id=user.user_id,
                         display_name=user.display_name,
                         annotation_metrics=AnnotationMetrics(
                             annotations=0, replies=0, last_activity=None

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -41,7 +41,10 @@ class UserViews:
 
         return {
             "students": [
-                APIStudent(id=s.user_id, display_name=s.display_name) for s in students
+                APIStudent(
+                    h_userid=s.h_userid, lms_id=s.user_id, display_name=s.display_name
+                )
+                for s in students
             ],
             "pagination": pagination,
         }

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -1,0 +1,47 @@
+import logging
+
+from pyramid.view import view_config
+
+from lms.js_config_types import APIStudent, APIStudents
+from lms.models import RoleScope, RoleType, User
+from lms.security import Permissions
+from lms.services import UserService
+from lms.views.dashboard.pagination import PaginationParametersMixin, get_page
+
+LOG = logging.getLogger(__name__)
+
+
+class ListUsersSchema(PaginationParametersMixin):
+    """Query parameters to fetch a list of users."""
+
+
+class UserViews:
+    def __init__(self, request) -> None:
+        self.request = request
+        self.user_service: UserService = request.find_service(UserService)
+
+    @view_config(
+        route_name="api.dashboard.students",
+        request_method="GET",
+        renderer="json",
+        permission=Permissions.DASHBOARD_VIEW,
+        schema=ListUsersSchema,
+    )
+    def students(self) -> APIStudents:
+        students_query = self.user_service.get_users(
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.LEARNER,
+            instructor_h_userid=self.request.user.h_userid
+            if self.request.user
+            else None,
+        )
+        students, pagination = get_page(
+            self.request, students_query, [User.display_name, User.id]
+        )
+
+        return {
+            "students": [
+                APIStudent(id=s.user_id, display_name=s.display_name) for s in students
+            ],
+            "pagination": pagination,
+        }

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -74,6 +74,7 @@ class TestUserService:
     def test_get_users(self, service, db_session):
         assignment = factories.Assignment()
         student = factories.User()
+        factories.User(h_userid=student.h_userid)  # Duplicated student
         teacher = factories.User()
         factories.AssignmentMembership.create(
             assignment=assignment,

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -95,7 +95,8 @@ class TestAssignmentViews:
         expected = {
             "students": [
                 {
-                    "id": student.user_id,
+                    "h_userid": student.h_userid,
+                    "lms_id": student.user_id,
                     "display_name": student.display_name,
                     "annotation_metrics": {
                         "annotations": sentinel.annotations,
@@ -104,7 +105,8 @@ class TestAssignmentViews:
                     },
                 },
                 {
-                    "id": student_no_annos.user_id,
+                    "h_userid": student_no_annos.h_userid,
+                    "lms_id": student_no_annos.user_id,
                     "display_name": student_no_annos.display_name,
                     "annotation_metrics": {
                         "annotations": 0,
@@ -113,7 +115,8 @@ class TestAssignmentViews:
                     },
                 },
                 {
-                    "id": student_no_annos_no_name.user_id,
+                    "h_userid": student_no_annos_no_name.h_userid,
+                    "lms_id": student_no_annos_no_name.user_id,
                     "display_name": None,
                     "annotation_metrics": {
                         "annotations": 0,

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -1,0 +1,42 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.js_config_types import APIStudent
+from lms.models import RoleScope, RoleType, User
+from lms.views.dashboard.api.user import UserViews
+from tests import factories
+
+
+class TestUserViews:
+    def test_get_students(self, user_service, pyramid_request, views, get_page):
+        students = factories.User.create_batch(5)
+        get_page.return_value = students, sentinel.pagination
+
+        response = views.students()
+
+        user_service.get_users.assert_called_once_with(
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.LEARNER,
+            instructor_h_userid=pyramid_request.user.h_userid,
+        )
+        get_page.assert_called_once_with(
+            pyramid_request,
+            user_service.get_users.return_value,
+            [User.display_name, User.id],
+        )
+        assert response == {
+            "students": [
+                APIStudent({"id": c.user_id, "display_name": c.display_name})
+                for c in students
+            ],
+            "pagination": sentinel.pagination,
+        }
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return UserViews(pyramid_request)
+
+    @pytest.fixture
+    def get_page(self, patch):
+        return patch("lms.views.dashboard.api.user.get_page")

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -27,7 +27,13 @@ class TestUserViews:
         )
         assert response == {
             "students": [
-                APIStudent({"id": c.user_id, "display_name": c.display_name})
+                APIStudent(
+                    {
+                        "h_userid": c.h_userid,
+                        "lms_id": c.user_id,
+                        "display_name": c.display_name,
+                    }
+                )
                 for c in students
             ],
             "pagination": sentinel.pagination,


### PR DESCRIPTION
For: https://github.com/hypothesis/lms/issues/6393


### Example response

```
{
  "students": [
    {
      "id": "2a8a99bc095a8438a594cd57c1f4f0341951e360",
      "display_name": "Hypothesis 101 Student"
    }
  ],
  "pagination": {
    "next": "http://localhost:8001/api/dashboard/students?limit=1&cursor=%5B%22Hypothesis+101+Student%22%2C+71%5D"
  }
}
```



### Testing

- Make sure you have an authorization cookie from the LMS admin pages visiting http://localhost:8001/admin/
- Open http://localhost:8001/api/dashboard/students
- Play with the limit parameter, eg: http://localhost:8001/api/dashboard/students?limit=1
- Follow the `next` parameter in the response.