### PR TITLE
Create index on application_instance.tool_consumer_instance_guid

### DIFF
--- a/lms/migrations/versions/1337584e2b07_ai_tool_consumer_instance_guid_index.py
+++ b/lms/migrations/versions/1337584e2b07_ai_tool_consumer_instance_guid_index.py
@@ -1,0 +1,31 @@
+"""AI.tool_consumer_instance_guid index.
+
+Revision ID: 1337584e2b07
+Revises: 8e203ad93a58
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1337584e2b07"
+down_revision = "8e203ad93a58"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        op.f("ix__application_instances_tool_consumer_instance_guid"),
+        "application_instances",
+        ["tool_consumer_instance_guid"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix__application_instances_tool_consumer_instance_guid"),
+        table_name="application_instances",
+    )

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -114,7 +114,9 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
     )
 
     # A unique identifier for the LMS instance
-    tool_consumer_instance_guid = sa.Column(sa.UnicodeText, nullable=True)
+    tool_consumer_instance_guid: Mapped[str | None] = mapped_column(
+        sa.UnicodeText, index=True
+    )
 
     # The LMS product name, e.g. "canvas" or "moodle"
     tool_consumer_info_product_family_code = sa.Column(sa.UnicodeText, nullable=True)


### PR DESCRIPTION
We already make queries based on this values (eg. in FileService) and we are introducing similar queries for Canvas Studio.


## Testing

`tox -e dev --run-command 'alembic upgrade head'`
                                         
```dev run-test-pre: PYTHONHASHSEED='4191188039'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 8e203ad93a58 -> 1337584e2b07, AI.tool_consumer_instance_guid index```

