### PR TITLE
Add parameters to the students API endpoint to allow filtering

### DIFF
--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -1,5 +1,6 @@
 import logging
 
+from marshmallow import fields, validate
 from pyramid.view import view_config
 
 from lms.js_config_types import APIStudent, APIStudents
@@ -13,6 +14,12 @@ LOG = logging.getLogger(__name__)
 
 class ListUsersSchema(PaginationParametersMixin):
     """Query parameters to fetch a list of users."""
+
+    course_id = fields.Integer(required=False, validate=validate.Range(min=1))
+    """Return users that belong to the course with this ID."""
+
+    assignment_id = fields.Integer(required=False, validate=validate.Range(min=1))
+    """Return users that belong to the assignment with this ID."""
 
 
 class UserViews:
@@ -34,6 +41,8 @@ class UserViews:
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
+            course_id=self.request.parsed_params.get("course_id"),
+            assignment_id=self.request.parsed_params.get("assignment_id"),
         )
         students, pagination = get_page(
             self.request, students_query, [User.display_name, User.id]

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -95,6 +95,60 @@ class TestUserService:
 
         assert db_session.scalars(query).all() == [student]
 
+    def test_get_users_by_course_id(self, service, db_session):
+        assignment = factories.Assignment()
+        course = factories.Course()
+        student = factories.User()
+        factories.User(h_userid=student.h_userid)  # Duplicated student
+        teacher = factories.User()
+        factories.AssignmentMembership.create(
+            assignment=assignment,
+            user=student,
+            lti_role=factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER),
+        )
+        factories.AssignmentMembership.create(
+            assignment=assignment,
+            user=teacher,
+            lti_role=factories.LTIRole(
+                scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR
+            ),
+        )
+        factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        db_session.flush()
+
+        query = service.get_users(
+            role_scope=RoleScope.COURSE, role_type=RoleType.LEARNER, course_id=course.id
+        )
+
+        assert db_session.scalars(query).all() == [student]
+
+    def test_get_users_by_assigment_id(self, service, db_session):
+        assignment = factories.Assignment()
+        student = factories.User()
+        factories.User(h_userid=student.h_userid)  # Duplicated student
+        teacher = factories.User()
+        factories.AssignmentMembership.create(
+            assignment=assignment,
+            user=student,
+            lti_role=factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER),
+        )
+        factories.AssignmentMembership.create(
+            assignment=assignment,
+            user=teacher,
+            lti_role=factories.LTIRole(
+                scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR
+            ),
+        )
+        db_session.flush()
+
+        query = service.get_users(
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.LEARNER,
+            assignment_id=assignment.id,
+        )
+
+        assert db_session.scalars(query).all() == [student]
+
     def test_get_users_by_h_userid(self, service, db_session):
         # Assignment the h_userid belongs to as a teacher
         assignment = factories.Assignment()

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -10,6 +10,10 @@ from tests import factories
 
 class TestUserViews:
     def test_get_students(self, user_service, pyramid_request, views, get_page):
+        pyramid_request.parsed_params = {
+            "course_id": sentinel.course_id,
+            "assignment_id": sentinel.assignment_id,
+        }
         students = factories.User.create_batch(5)
         get_page.return_value = students, sentinel.pagination
 
@@ -19,6 +23,8 @@ class TestUserViews:
             role_scope=RoleScope.COURSE,
             role_type=RoleType.LEARNER,
             instructor_h_userid=pyramid_request.user.h_userid,
+            course_id=sentinel.course_id,
+            assignment_id=sentinel.assignment_id,
         )
         get_page.assert_called_once_with(
             pyramid_request,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6393
---

- Filter by course_id
- Filter by assignment_id


## Testing

- Fetch course and assignment IDs based on:

http://localhost:8001/api/dashboard/courses
http://localhost:8001/api/dashboard/assignments


- Play around constructing URLs to filter them like:


http://localhost:8001/api/dashboard/students?course_id=1830&assignment_id=349
