### PR TITLE
Revert extra logging on assignment endpoint

### DIFF
--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -1,5 +1,3 @@
-import logging
-
 from marshmallow import fields, validate
 from pyramid.view import view_config
 
@@ -16,8 +14,6 @@ from lms.security import Permissions
 from lms.services.h_api import HAPI
 from lms.views.dashboard.base import get_request_assignment
 from lms.views.dashboard.pagination import PaginationParametersMixin, get_page
-
-LOG = logging.getLogger(__name__)
 
 
 class ListAssignmentsSchema(PaginationParametersMixin):
@@ -79,18 +75,11 @@ class AssignmentViews:
     def assignment_stats(self) -> APIStudents:
         """Fetch the stats for one particular assignment."""
         assignment = get_request_assignment(self.request, self.assignment_service)
-        LOG.debug(
-            "Fetching stats from H for groups: %s and assignemnt %s",
-            [g.authority_provided_id for g in assignment.groupings],
-            assignment.resource_link_id,
-        )
         stats = self.h_api.get_annotation_counts(
             [g.authority_provided_id for g in assignment.groupings],
             group_by="user",
             resource_link_id=assignment.resource_link_id,
         )
-        LOG.debug("Recieved stats from H %s", stats)
-
         # Organize the H stats by userid for quick access
         stats_by_user = {s["userid"]: s for s in stats}
         students: list[APIStudent] = []


### PR DESCRIPTION
We found the issue, a problem with staging data in the DB.

We don't need this extra logging here for now.