### PR TITLE
Fix course metrics listing about signature change on get_courses

### DIFF
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -62,10 +62,12 @@ class CourseViews:
     )
     def organization_courses(self) -> APICourses:
         org = get_request_organization(self.request, self.organization_service)
-        courses = self.course_service.get_courses(
-            organization=org,
-            h_userid=self.request.user.h_userid if self.request.user else None,
-        )
+        courses = self.request.db.scalars(
+            self.course_service.get_courses(
+                organization=org,
+                h_userid=self.request.user.h_userid if self.request.user else None,
+            )
+        ).all()
         courses_assignment_counts = self.course_service.get_courses_assignments_count(
             courses
         )

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
+from sqlalchemy import select
 
 from lms.models import Course
 from lms.views.dashboard.api.course import CourseViews
@@ -35,7 +36,7 @@ class TestCourseViews:
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
         organization_service.get_by_public_id.return_value = org
-        course_service.get_courses.return_value = courses
+        course_service.get_courses.return_value = select(Course)
         pyramid_request.matchdict["organization_public_id"] = sentinel.public_id
         db_session.flush()
 
@@ -48,9 +49,7 @@ class TestCourseViews:
             organization=org,
             h_userid=pyramid_request.user.h_userid,
         )
-        course_service.get_courses_assignments_count.assert_called_once_with(
-            course_service.get_courses.return_value
-        )
+        course_service.get_courses_assignments_count.assert_called_once_with(courses)
 
         assert response == {
             "courses": [


### PR DESCRIPTION
Get courses now returns a select that needs to be executed before the results can be passed to get_courses_assignments_count.


## Testing

- Opening something like 

http://localhost:8001/dashboard/organizations/local.lms.org.LDtcl7EUTeW2UERPJLAVtA

works again.