### PR TITLE
Create filters component for dashboard activity pages

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -183,21 +183,21 @@ export type CoursesResponse = {
 export type Assignment = {
   id: number;
   title: string;
-  course: Course;
+  course: Course; // TODO Optional?
 };
 
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
  */
-export type StudentStats = {
+export type Student = {
   h_userid: string;
   lms_id: string;
   display_name: string | null;
-  annotation_metrics: AnnotationMetrics;
+  annotation_metrics: AnnotationMetrics; // TODO Optional?
 };
 
 export type StudentsResponse = {
-  students: StudentStats[];
+  students: Student[];
 };
 
 export type AssignmentWithMetrics = Assignment & {

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardFilters.tsx
@@ -1,0 +1,108 @@
+import { MultiSelect } from '@hypothesis/frontend-shared';
+
+import type { Assignment, Course, Student } from '../../api-types';
+import { useConfig } from '../../config';
+import { useAPIFetch } from '../../utils/api';
+
+export type DashboardFiltersProps = {
+  selectedCourses?: Course[];
+  onCoursesChange?: (newCourses: Course[]) => void;
+  selectedAssignments?: Assignment[];
+  onAssignmentsChange?: (newAssignments: Assignment[]) => void;
+  selectedStudents?: Student[];
+  onStudentsChange?: (newStudents: Student[]) => void;
+};
+
+const noop = () => {};
+
+export default function DashboardFilters({
+  selectedCourses = [],
+  onCoursesChange = noop,
+  selectedAssignments = [],
+  onAssignmentsChange = noop,
+  selectedStudents = [],
+  onStudentsChange = noop,
+}: DashboardFiltersProps) {
+  const { dashboard } = useConfig(['dashboard']);
+  const { routes } = dashboard;
+
+  const courses = useAPIFetch<{ courses: Course[] }>(routes.courses);
+  const assignments = useAPIFetch<{ assignments: Assignment[] }>(
+    routes.assignments,
+  );
+  const students = useAPIFetch<{ students: Student[] }>(routes.students);
+
+  return (
+    <div className="flex gap-2 md:w-1/2">
+      <MultiSelect
+        disabled={courses.isLoading}
+        value={selectedCourses}
+        onChange={onCoursesChange}
+        buttonContent={
+          courses.isLoading ? (
+            <>Loading...</>
+          ) : selectedCourses.length === 0 ? (
+            <>All courses</>
+          ) : selectedCourses.length === 1 ? (
+            selectedCourses[0].title
+          ) : (
+            <>{selectedCourses.length} courses</>
+          )
+        }
+      >
+        {courses.data?.courses.map(course => (
+          <MultiSelect.Option key={`course_${course.id}`} value={course}>
+            {course.title}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+      <MultiSelect
+        disabled={assignments.isLoading}
+        value={selectedAssignments}
+        onChange={onAssignmentsChange}
+        buttonContent={
+          assignments.isLoading ? (
+            <>Loading...</>
+          ) : selectedAssignments.length === 0 ? (
+            <>All assignments</>
+          ) : selectedAssignments.length === 1 ? (
+            selectedAssignments[0].title
+          ) : (
+            <>{selectedAssignments.length} assignments</>
+          )
+        }
+      >
+        {assignments.data?.assignments.map(assignment => (
+          <MultiSelect.Option
+            key={`assignment_${assignment.id}`}
+            value={assignment}
+          >
+            {assignment.title}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+      <MultiSelect
+        disabled={students.isLoading}
+        value={selectedStudents}
+        onChange={onStudentsChange}
+        buttonContent={
+          students.isLoading ? (
+            <>Loading...</>
+          ) : selectedStudents.length === 0 ? (
+            <>All students</>
+          ) : selectedStudents.length === 1 ? (
+            selectedStudents[0].display_name
+          ) : (
+            <>{selectedStudents.length} students</>
+          )
+        }
+      >
+        {students.data?.students.map(student => (
+          <MultiSelect.Option key={student.lms_id} value={student}>
+            {student.display_name}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -6,6 +6,7 @@ import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
+import DashboardFilters from './DashboardFilters';
 import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
 
@@ -46,6 +47,7 @@ export default function OrganizationActivity() {
   return (
     <div className="flex flex-col gap-y-5">
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
+      <DashboardFilters />
       <OrderableActivityTable
         loading={courses.isLoading}
         title="Courses"


### PR DESCRIPTION
This PR adds a reusable component which wraps the filtering dropdowns for dashboard activity pages.

![image](https://github.com/hypothesis/lms/assets/2719332/891a624f-77bd-4972-ac80-9fa7f430715d)

### Out of this PR's scope

* Loading paginated data on scroll. It currently loads only the first page.
* Logic when selection changes.