### PR TITLE
Update to latest wouter-preact with improved useParams()

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -5,7 +5,7 @@ import {
   SettingsIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { Link as RouterLink, Route, Switch, useParams } from 'wouter-preact';
+import { Link as RouterLink, Route, Switch } from 'wouter-preact';
 
 import { useConfig } from '../../config';
 import AssignmentActivity from './AssignmentActivity';
@@ -15,9 +15,6 @@ import OrganizationActivity from './OrganizationActivity';
 
 export default function DashboardApp() {
   const { dashboard } = useConfig(['dashboard']);
-  const { organizationPublicId } = useParams<{
-    organizationPublicId: string;
-  }>();
 
   return (
     <div className="flex flex-col min-h-screen gap-5">
@@ -71,9 +68,7 @@ export default function DashboardApp() {
               <CourseActivity />
             </Route>
             <Route path="">
-              <OrganizationActivity
-                organizationPublicId={organizationPublicId}
-              />
+              <OrganizationActivity />
             </Route>
           </Switch>
         </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
-import { Link as RouterLink } from 'wouter-preact';
+import { Link as RouterLink, useParams } from 'wouter-preact';
 
 import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
@@ -8,10 +8,6 @@ import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
 import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
-
-export type OrganizationActivityProps = {
-  organizationPublicId: string;
-};
 
 type CoursesTableRow = {
   id: number;
@@ -25,11 +21,13 @@ const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
 /**
  * List of courses that belong to a specific organization
  */
-export default function OrganizationActivity({
-  organizationPublicId,
-}: OrganizationActivityProps) {
+export default function OrganizationActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
+  const { organizationPublicId } = useParams<{
+    organizationPublicId: string;
+  }>();
+
   const courses = useAPIFetch<CoursesResponse>(
     replaceURLParams(routes.organization_courses, {
       organization_public_id: organizationPublicId,

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -66,7 +66,7 @@ describe('OrganizationActivity', () => {
   function createComponent() {
     return mount(
       <Config.Provider value={fakeConfig}>
-        <OrganizationActivity organizationPublicId="abc" />
+        <OrganizationActivity />
       </Config.Provider>,
     );
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sass": "^1.76.0",
     "tailwindcss": "^3.3.3",
     "tiny-emitter": "^2.1.0",
-    "wouter-preact": "^3.1.3"
+    "wouter-preact": "^3.3.0"
   },
   "devDependencies": {
     "@hypothesis/frontend-testing": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7267,7 +7267,7 @@ __metadata:
     tailwindcss: ^3.3.3
     tiny-emitter: ^2.1.0
     typescript: ^5.2.2
-    wouter-preact: ^3.1.3
+    wouter-preact: ^3.3.0
   languageName: unknown
   linkType: soft
 
@@ -10686,15 +10686,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wouter-preact@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "wouter-preact@npm:3.1.3"
+"wouter-preact@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "wouter-preact@npm:3.3.0"
   dependencies:
     mitt: ^3.0.1
     regexparam: ^3.0.0
   peerDependencies:
     preact: ^10.0.0
-  checksum: 82784b2710088cd122323c8d061697941723bf30e9cc051fff9c05ea0ef91465ae8d0b5008339fc02dbfb7eb822adbea119fb6f71730dcc476d215c7e55bb182
+  checksum: e23804152a953b89bdda3f04f31f60d2d5a3934e951da3a50a81fdd3aa2fd1de338778e99b249c2f80cd951c2cc9eb278afa5b650678f4a87a9f02a0310e2dc2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In previous wouter-preact versions, calling `useParams()` in a nested route would only return the params for that specific route and not any potential parent.

Starting with v3.3, this is no longer the case, which allow us to simplify a bit some logic we had in `DashboardApp` where we had to call `useParams()` in order to pass a param down to `OrganizationActivity`.

Now we can call `useParams()` directly in `OrganizationActivity`, as we do in other dashboard activity components.

See the release notes for reference https://github.com/molefrog/wouter/releases/tag/v3.3.0