### PR TITLE
Deduplicate assignments with DISTINCT

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -246,7 +246,7 @@ class AssignmentService:
                 AssignmentGrouping.grouping_id == course_id
             )
 
-        return assignments_query.order_by(Assignment.title, Assignment.id)
+        return assignments_query.order_by(Assignment.title, Assignment.id).distinct()
 
 
 def factory(_context, request):

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -280,11 +280,16 @@ class TestAssignmentService:
         factories.AssignmentMembership.create(
             assignment=assignment, user=user, lti_role=lti_role
         )
+        # Other membership record, with a different role
+        factories.AssignmentMembership.create(
+            assignment=assignment, user=user, lti_role=factories.LTIRole()
+        )
+
         db_session.flush()
 
-        assert (
-            db_session.scalars(svc.get_assignments(user.h_userid)).one() == assignment
-        )
+        assert db_session.scalars(svc.get_assignments(user.h_userid)).all() == [
+            assignment
+        ]
 
     @pytest.fixture
     def svc(self, db_session, misc_plugin):


### PR DESCRIPTION
For courses and users we have a deduplicating step that looks at an unique column and deduplicates based on that.

As we don't record duplicate assignments in the database we don't have that explicit deduplicate step but we do still have to apply DISTINCT as we are joining with other tables.