### PR TITLE
Match changes in H's API to allow filtering by multiple assignments

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -6,9 +6,6 @@ from sqlalchemy import Select, Text, column, func, select
 from lms.db import full_text_match
 from lms.models import (
     ApplicationInstance,
-    Assignment,
-    AssignmentGrouping,
-    AssignmentMembership,
     Course,
     CourseGroupsExportedFromH,
     Grouping,
@@ -168,55 +165,6 @@ class CourseService:
             .order_by(Course.lms_name, Course.id)
         )
 
-    def _deduplicated_course_assigments_query(self, courses: list[Course]):
-        # Get all assignment IDs we recorded from this course
-        raw_course_assignemnts = select(AssignmentGrouping.assignment_id).where(
-            AssignmentGrouping.grouping_id.in_([c.id for c in courses])
-        )
-
-        # Get a list of deduplicated assignments based on raw_course_assignments,
-        # this will contain assignments that belong (now) to other courses
-        return (
-            select(AssignmentGrouping.assignment_id, AssignmentGrouping.grouping_id)
-            .distinct(AssignmentGrouping.assignment_id)
-            .join(Grouping)
-            .where(
-                # Only look at courses, otherwise courses and sections will deduplicate each other
-                Grouping.type == "course",
-                # Use the previous query to look only at the potential candidates
-                AssignmentGrouping.assignment_id.in_(raw_course_assignemnts),
-            )
-            # Deduplicate them based on the updated column, take the last one (together with the distinct clause)
-            .order_by(
-                AssignmentGrouping.assignment_id, AssignmentGrouping.updated.desc()
-            )
-        )
-
-    def get_courses_assignments_count(self, courses: list[Course]) -> dict[int, int]:
-        """Get the number of assignments a given list of courses has.
-
-        This tries to be efficient making just one DB query.
-        """
-        deduplicated_course_assignments = self._deduplicated_course_assigments_query(
-            courses
-        ).subquery()
-
-        # For each course, calculate the assignment counts in one single query
-        rr = self._db.execute(
-            select(
-                AssignmentGrouping.grouping_id,
-                func.count(deduplicated_course_assignments.c.assignment_id),
-            )
-            .where(
-                AssignmentGrouping.assignment_id
-                == deduplicated_course_assignments.c.assignment_id,
-                AssignmentGrouping.grouping_id
-                == deduplicated_course_assignments.c.grouping_id,
-            )
-            .group_by(AssignmentGrouping.grouping_id)
-        )
-        return {row.grouping_id: row.count for row in rr}
-
     def get_by_context_id(self, context_id, raise_on_missing=False) -> Course | None:
         """
         Get a course (if one exists) by the GUID and context id.
@@ -313,37 +261,6 @@ class CourseService:
         return bool(
             course.memberships.join(User).filter(User.h_userid == h_userid).first()
         )
-
-    def get_assignments(
-        self, course: Course, h_userid: str | None = None
-    ) -> list[Assignment]:
-        """
-        Get a list of assignments that belong to `course`.
-
-        Use course.assignments to get the full view of the data, this method deduplicates assignments.
-
-        :param course: course for which list assignments.
-        :param h_userid: return only assignments h_userid is a member of.
-        """
-        deduplicated_course_assignments = self._deduplicated_course_assigments_query(
-            [course]
-        ).subquery()
-
-        assignments_query = select(Assignment).where(
-            # Get only assignment from the candidates above
-            Assignment.id == deduplicated_course_assignments.c.assignment_id,
-            # Only those that belong to the course we are interested in
-            deduplicated_course_assignments.c.grouping_id == course.id,
-        )
-
-        if h_userid:
-            assignments_query = (
-                assignments_query.join(AssignmentMembership)
-                .join(User)
-                .where(User.h_userid == h_userid)
-            )
-
-        return self._db.scalars(assignments_query).all()
 
     def _get_authority_provided_id(self, context_id):
         return self._grouping_service.get_authority_provided_id(

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -174,11 +174,11 @@ class HAPI:
         group_authority_ids: list[str],
         group_by: str,
         h_userids: list[str] | None = None,
-        resource_link_id: str | None = None,
+        resource_link_ids: list[str] | None = None,
     ):
         filters = {
             "groups": group_authority_ids,
-            "assignment_id": resource_link_id,
+            "assignment_ids": resource_link_ids,
         }
         if h_userids:
             filters["h_userids"] = h_userids

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -25,6 +25,7 @@ class CourseViews:
         self.h_api = request.find_service(HAPI)
         self.organization_service = request.find_service(OrganizationService)
         self.dashboard_service = request.find_service(name="dashboard")
+        self.assignment_service = request.find_service(name="assignment")
 
     @view_config(
         route_name="api.dashboard.courses",
@@ -61,8 +62,10 @@ class CourseViews:
                 h_userid=self.request.user.h_userid if self.request.user else None,
             )
         ).all()
-        courses_assignment_counts = self.course_service.get_courses_assignments_count(
-            courses
+        courses_assignment_counts = (
+            self.assignment_service.get_courses_assignments_count(
+                [c.id for c in courses]
+            )
         )
 
         return {

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -89,7 +89,7 @@ class UserViews:
         stats = self.h_api.get_annotation_counts(
             [g.authority_provided_id for g in assignment.groupings],
             group_by="user",
-            resource_link_id=assignment.resource_link_id,
+            resource_link_ids=[assignment.resource_link_id],
             h_userids=request_h_userids,
         )
         # Organize the H stats by userid for quick access

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -138,13 +138,13 @@ class TestHAPI:
                 {
                     "group_authority_ids": ["group_1", "group_2"],
                     "group_by": "user",
-                    "resource_link_id": "assignment_id",
+                    "resource_link_ids": ["assignment_id"],
                 },
                 {
                     "group_by": "user",
                     "filter": {
                         "groups": ["group_1", "group_2"],
-                        "assignment_id": "assignment_id",
+                        "assignment_ids": ["assignment_id"],
                     },
                 },
             ),
@@ -152,14 +152,14 @@ class TestHAPI:
                 {
                     "group_authority_ids": ["group_1", "group_2"],
                     "group_by": "user",
-                    "resource_link_id": "assignment_id",
+                    "resource_link_ids": ["assignment_id"],
                     "h_userids": ["user_1", "user_2"],
                 },
                 {
                     "group_by": "user",
                     "filter": {
                         "groups": ["group_1", "group_2"],
-                        "assignment_id": "assignment_id",
+                        "assignment_ids": ["assignment_id"],
                         "h_userids": ["user_1", "user_2"],
                     },
                 },

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -58,7 +58,7 @@ class TestAssignmentViews:
         self,
         views,
         pyramid_request,
-        course_service,
+        assignment_service,
         h_api,
         db_session,
         dashboard_service,
@@ -71,13 +71,12 @@ class TestAssignmentViews:
 
         assignment = factories.Assignment()
         assignment_with_no_annos = factories.Assignment()
-
-        course_service.get_assignments.return_value = [
-            assignment,
-            assignment_with_no_annos,
-        ]
         users = factories.User.create_batch(5)
         db_session.flush()
+
+        assignment_service.get_assignments.return_value = select(Assignment).where(
+            Assignment.id.in_([assignment.id, assignment_with_no_annos.id])
+        )
         user_service.get_users.return_value = (
             select(User).where(User.id.in_([u.id for u in users])).order_by(User.id)
         )

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -8,7 +8,11 @@ from lms.views.dashboard.api.course import CourseViews
 from tests import factories
 
 pytestmark = pytest.mark.usefixtures(
-    "course_service", "h_api", "organization_service", "dashboard_service"
+    "course_service",
+    "h_api",
+    "organization_service",
+    "dashboard_service",
+    "assignment_service",
 )
 
 
@@ -33,7 +37,13 @@ class TestCourseViews:
         }
 
     def test_get_organization_courses(
-        self, course_service, pyramid_request, views, db_session, dashboard_service
+        self,
+        course_service,
+        pyramid_request,
+        views,
+        db_session,
+        dashboard_service,
+        assignment_service,
     ):
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
@@ -51,7 +61,9 @@ class TestCourseViews:
             organization=org,
             h_userid=pyramid_request.user.h_userid,
         )
-        course_service.get_courses_assignments_count.assert_called_once_with(courses)
+        assignment_service.get_courses_assignments_count.assert_called_once_with(
+            [c.id for c in courses]
+        )
 
         assert response == {
             "courses": [
@@ -59,7 +71,7 @@ class TestCourseViews:
                     "id": c.id,
                     "title": c.lms_name,
                     "course_metrics": {
-                        "assignments": course_service.get_courses_assignments_count.return_value.get.return_value,
+                        "assignments": assignment_service.get_courses_assignments_count.return_value.get.return_value,
                         "last_launched": c.updated.isoformat(),
                     },
                 }

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -99,7 +99,7 @@ class TestUserViews:
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],
             group_by="user",
-            resource_link_id=assignment.resource_link_id,
+            resource_link_ids=[assignment.resource_link_id],
             h_userids=sentinel.h_userids,
         )
         expected = {


### PR DESCRIPTION
Requires and needs to be deployed together with: https://github.com/hypothesis/h/pull/8795

This is just a name change (pluralizing) and type change str vs list[str]. 

It doesn't introduce a new filter option on any LMS endpoint but filtering by multiple assignments should be easier to implement  after this change.


### Testing

Sanity check all three levels of the dashboards.