### PR TITLE
Adjust grading API certification test to account for API changes

### DIFF
--- a/tests/functional/lti_certification/v13/grading/test_assignment_and_grading.py
+++ b/tests/functional/lti_certification/v13/grading/test_assignment_and_grading.py
@@ -43,6 +43,7 @@ class TestAssignmentAndGradingSerices:
         from lms.services.lti_grading._v13 import LTI13GradingService
         from lms.services import *
         from lms.product.plugin import MiscPlugin
+        from lms.product import Product
 
         application_instance = (
             db.query(models.ApplicationInstance)
@@ -57,7 +58,7 @@ class TestAssignmentAndGradingSerices:
             request.find_service(name="http"),
             request.find_service(JWTOAuth2TokenService),
         )
-        grading_service = LTI13GradingService(LINE_ITEM, LINE_ITEMS, ltia_service)
+        grading_service = LTI13GradingService(LINE_ITEM, LINE_ITEMS, ltia_service, product_family=Product.family.UNKNOWN, misc_plugin=MiscPlugin())
 
 
         # Create the line item here to hold the scores


### PR DESCRIPTION
We run this script once a year for the LTI1.3 certification. Adapt it to the latest set of changes since last year.