### PR TITLE
Task to export calculated numbers of the monthly reports back to HubSpot

### DIFF
--- a/lms/services/hubspot/_client.py
+++ b/lms/services/hubspot/_client.py
@@ -1,4 +1,21 @@
+import csv
+import json
+import os
+from datetime import date
+from enum import StrEnum
+from logging import getLogger
+from tempfile import NamedTemporaryFile
+
 from hubspot import HubSpot
+
+LOG = getLogger(__name__)
+
+
+class HubSpotObjectTypeID(StrEnum):
+    """Possible HubSpot objectTypeId values."""
+
+    # From: https://developers.hubspot.com/docs/api/crm/imports
+    COMPANY = "0-2"
 
 
 class HubSpotClient:
@@ -17,6 +34,65 @@ class HubSpotClient:
             "current_deal__services_end",
         ]
         yield from self._get_objects(self._api_client.crm.companies, fields)
+
+    def import_billables(self, billables: list[tuple[str, int, int]], date_: date):
+        """Import the given billables into HubSpot.
+
+        :param billables: a list of (hubspot_company_id, num_unique_teachers, num_unique_users) tuples
+        :param date_: date of the billable calculation.
+        """
+        with NamedTemporaryFile(mode="w", suffix=".csv") as csv_file:
+            writer = csv.writer(csv_file)
+            for row in billables:
+                writer.writerow(row)
+            # Ensure all rows are written to disk before we start to upload
+            csv_file.flush()
+
+            files = [
+                {
+                    "fileName": os.path.basename(csv_file.name),
+                    "fileFormat": "CSV",
+                    "fileImportPage": {
+                        "hasHeader": False,
+                        "columnMappings": [
+                            {
+                                "columnObjectTypeId": HubSpotObjectTypeID.COMPANY,
+                                "columnName": "hs_object_id",
+                                "propertyName": "hs_object_id",
+                                "idColumnType": "HUBSPOT_OBJECT_ID",
+                            },
+                            {
+                                "columnObjectTypeId": HubSpotObjectTypeID.COMPANY,
+                                "columnName": "billable_teachers_this_contract_year",
+                                "propertyName": "billable_teachers_this_contract_year",
+                                "idColumnType": None,
+                            },
+                            {
+                                "columnObjectTypeId": HubSpotObjectTypeID.COMPANY,
+                                "columnName": "billable_users_this_contract_year",
+                                "propertyName": "billable_users_this_contract_year",
+                                "idColumnType": None,
+                            },
+                        ],
+                    },
+                }
+            ]
+
+            import_request = {
+                "name": f"contract_year_import_{date_.isoformat()}",
+                "files": files,
+                "dateFormat": "YEAR_MONTH_DAY",
+            }
+
+            LOG.debug(
+                "Creating HubSpot company import with %d rows",
+                len(billables),
+            )
+            return self._api_client.crm.imports.core_api.create(
+                import_request=json.dumps(import_request),
+                files=[csv_file.name],
+                async_req=False,
+            )
 
     @classmethod
     def _get_objects(cls, accessor, fields: list[str]):

--- a/lms/tasks/hubspot.py
+++ b/lms/tasks/hubspot.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from lms.services import HubSpotService
 from lms.tasks.celery import app
 
@@ -10,3 +12,12 @@ def refresh_hubspot_data():
             hs = request.find_service(HubSpotService)
 
             hs.refresh_companies()
+
+
+@app.task
+def export_companies_contract_billables():
+    with app.request_context() as request:  # pylint: disable=no-member
+        with request.tm:
+            hs = request.find_service(HubSpotService)
+
+            hs.export_companies_contract_billables(date.today())

--- a/tests/unit/lms/services/hubspot/_client_test.py
+++ b/tests/unit/lms/services/hubspot/_client_test.py
@@ -1,4 +1,6 @@
-from unittest.mock import create_autospec
+import json
+from datetime import date
+from unittest.mock import create_autospec, sentinel
 
 import pytest
 from hubspot import HubSpot
@@ -21,9 +23,70 @@ class TestHubSpotClient:
         )
         assert companies == list(api_client.crm.companies.get_all.return_value)
 
+    def test_import_billables(self, api_client, svc, csv, NamedTemporaryFile):
+        svc.import_billables(
+            [(sentinel.id, sentinel.teachers, sentinel.users)], date(2024, 1, 1)
+        )
+
+        NamedTemporaryFile.assert_called_once_with(mode="w", suffix=".csv")
+        csv.writer.assert_called_once()
+        csv.writer.return_value.writerow.assert_called_once_with(
+            (sentinel.id, sentinel.teachers, sentinel.users)
+        )
+        api_client.crm.imports.core_api.create.assert_called_once_with(
+            import_request=json.dumps(
+                {
+                    "name": "contract_year_import_2024-01-01",
+                    "files": [
+                        {
+                            "fileName": "IMPORT.csv",
+                            "fileFormat": "CSV",
+                            "fileImportPage": {
+                                "hasHeader": False,
+                                "columnMappings": [
+                                    {
+                                        "columnObjectTypeId": "0-2",
+                                        "columnName": "hs_object_id",
+                                        "propertyName": "hs_object_id",
+                                        "idColumnType": "HUBSPOT_OBJECT_ID",
+                                    },
+                                    {
+                                        "columnObjectTypeId": "0-2",
+                                        "columnName": "billable_teachers_this_contract_year",
+                                        "propertyName": "billable_teachers_this_contract_year",
+                                        "idColumnType": None,
+                                    },
+                                    {
+                                        "columnObjectTypeId": "0-2",
+                                        "columnName": "billable_users_this_contract_year",
+                                        "propertyName": "billable_users_this_contract_year",
+                                        "idColumnType": None,
+                                    },
+                                ],
+                            },
+                        }
+                    ],
+                    "dateFormat": "YEAR_MONTH_DAY",
+                }
+            ),
+            files=["IMPORT.csv"],
+            async_req=False,
+        )
+
     @pytest.fixture
     def api_client(self):
         return create_autospec(HubSpot, spec_set=True, instance=True)
+
+    @pytest.fixture
+    def csv(self, patch):
+        return patch("lms.services.hubspot._client.csv")
+
+    @pytest.fixture
+    def NamedTemporaryFile(self, patch):
+        mock = patch("lms.services.hubspot._client.NamedTemporaryFile")
+        mock.return_value.__enter__.return_value.name = "IMPORT.csv"
+
+        return mock
 
     @pytest.fixture
     def svc(self, api_client):

--- a/tests/unit/lms/tasks/hubpost_test.py
+++ b/tests/unit/lms/tasks/hubpost_test.py
@@ -1,14 +1,25 @@
 from contextlib import contextmanager
+from datetime import date
 
 import pytest
+from freezegun import freeze_time
 
-from lms.tasks.hubspot import refresh_hubspot_data
+from lms.tasks.hubspot import export_companies_contract_billables, refresh_hubspot_data
 
 
 def test_refresh_hubspot_data(hubspot_service):
     refresh_hubspot_data()
 
     hubspot_service.refresh_companies.assert_called_once()
+
+
+@freeze_time("2022-06-21 12:00:00")
+def test_export_companies_contract_billables(hubspot_service):
+    export_companies_contract_billables()
+
+    hubspot_service.export_companies_contract_billables.assert_called_once_with(
+        date(2022, 6, 21)
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6159

This PR needs a follow up to schedule the task in h-periodic.


To summarize the process we:

- Fetch HubSpot companies with tasks.hubspot.refresh_hubspot_data
- We generate monthly usage reports for thos companies with task.organization.schedule_monthly_deal_report

now, with this commit we:

- Push the calculated numbers (unique user and teachers) to the corresponding fields in HubSpot companies.



## Testing 

Describing here the process I followed locally to test this end to end.

- Fetch all HubSpot companies:

```
refresh_hubspot_data.delay()
```


- Modify some of these companies to match your local organizations, eg:

```update hubspot_company set lms_organization_id = 'local.lms.org.FFIHD9f1RwyLPfx14zM_7Q' where id = 11;```


- Generate/Insert some reports that match that organization:

```
select * from organization_usage_report where organization_id in (1,2);
 id | organization_id |     tag      |                                   key                                   |   since    |   until    | unique_users | report |          created           |          updated           | unique_teachers 
----+-----------------+--------------+-------------------------------------------------------------------------+------------+------------+--------------+--------+----------------------------+----------------------------+-----------------
 11 |               1 | monthly-deal | local.lms.org.LDtcl7EUTeW2UERPJLAVtA-monthly-deal-2023-01-01-2023-07-31 | 2023-01-01 | 2023-07-31 |            0 | []     | 2024-06-18 10:33:22.193294 | 2024-06-18 10:33:22.193294 |               0
  2 |               2 | monthly-deal | local.lms.org.LDtcl7EUTeW2UERPJLAVtA-monthly-deal-2023-01-01-2024-01-31 | 2023-01-01 | 2024-01-31 |            0 | []     | 2024-06-18 10:29:28.260707 | 2024-06-18 10:29:28.260707 |               0
```

- Finally, run the new task:

```
from lms.tasks.hubspot import export_companies_contract_billables; 
export_companies_contract_billables.delay()
```

- Let's check that the import actually happened, we log into HuBSpot, and go to the imports in: https://app.hubspot.com/import/21081992
![Screenshot from 2024-07-10 15-07-12](https://github.com/hypothesis/lms/assets/1433832/469d1266-8473-429f-86fc-d4727173cd4d)


- And we can see the records we modified  locally to match the HubSpot data being updated and the rest of the rows having no value (`--`) in those columns.




![Screenshot from 2024-07-10 15-09-17](https://github.com/hypothesis/lms/assets/1433832/1585d05d-07a6-4f1c-b445-7d3b13208007)


