### PR TITLE
Add better logging / error capturing of Canvas Studio admin auth errors

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -20,6 +20,10 @@ class ExternalRequestError(Exception):
     :arg message: A short error message for displaying to the user
     :type message: str
 
+    :arg error_code:
+        A code that identifies the error. Used by the frontend to display richer
+        error messages.
+
     :arg refreshable: True if the error can be fixed by refreshing an access token
     :arg refresh_route:
         If `refreshable` is True, the name of the API route that should be
@@ -48,8 +52,10 @@ class ExternalRequestError(Exception):
         refreshable=False,
         refresh_route: str | None = None,
         refresh_service: Service | None = None,
+        error_code: str | None = None,
     ):
         super().__init__()
+        self.error_code = error_code
         self.message = message
         self.request = request
         self.response = response

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -12,7 +12,6 @@ from lms.services.canvas_studio import CanvasStudioService, factory
 from lms.services.exceptions import (
     ExternalRequestError,
     OAuth2TokenError,
-    SerializableError,
 )
 from lms.services.oauth_http import OAuthHTTPService
 from tests import factories
@@ -60,7 +59,7 @@ class TestCanvasStudioService:
             ExternalRequestError(response=response)
         )
 
-        with pytest.raises(SerializableError) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.refresh_admin_access_token()
 
         assert exc_info.value.error_code == "canvas_studio_admin_token_refresh_failed"
@@ -290,7 +289,7 @@ class TestCanvasStudioService:
     ):
         admin_oauth_http_service.get.side_effect = OAuth2TokenError()
 
-        with pytest.raises(HTTPBadRequest) as exc_info:
+        with pytest.raises(ExternalRequestError) as exc_info:
             svc.get_video_download_url("42")
 
         assert (

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -36,6 +36,10 @@ class TestExternalRequestError:
         assert err.reason is None
         assert err.response_body is None
 
+    def test_custom_error_code(self):
+        err = ExternalRequestError(error_code="something_went_wrong")
+        assert err.error_code == "something_went_wrong"
+
     @pytest.mark.parametrize(
         "message,request_,response,validation_errors,cause,expected",
         [


### PR DESCRIPTION
Improve the debug-ability of Canvas Studio admin auth errors.

 - For errors reported in response to an external request, raise the error as an
   `ExternalRequestError` (instead of `HTTPBadRequest` or `SerializableError`) so that it gets logged in Sentry

 - For other errors related to admin auth, log details so that we can see these events in Papertrail

For context see [this Slack thread](https://hypothes-is.slack.com/archives/C2C2U40LW/p1720627872492559).