### PR TITLE
Fix Canvas Studio admin token refreshes triggered by students

### DIFF
--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -267,26 +267,32 @@ class ErrorBody:
         if getattr(request.exception, "refreshable", False):
             oauth2_token_service = request.find_service(name="oauth2_token")
 
-            try:
-                kwargs = {}
-                if service := getattr(request.exception, "refresh_service", None):
-                    kwargs["service"] = service
-                oauth2_token_service.get(**kwargs)
-            except OAuth2TokenError:
-                # If we don't have an access token we can't refresh it.
-                pass
-            else:
-                refresh_route = getattr(request.exception, "refresh_route", None)
-                if refresh_route is None:
-                    refresh_route = request.product.route.oauth2_refresh
+            refresh_route = getattr(request.exception, "refresh_route", None)
+            if refresh_route is None:
+                refresh_route = request.product.route.oauth2_refresh
 
+            # Test if this user has an existing access token that we can refresh.
+            if refresh_route == "canvas_studio_api.oauth.refresh_admin":
+                # This refresh is for a user that is different than the current
+                # user, so don't try to look up an access token for them.
+                can_refresh = True
+            else:
+                try:
+                    kwargs = {}
+                    if service := getattr(request.exception, "refresh_service", None):
+                        kwargs["service"] = service
+                    oauth2_token_service.get(**kwargs)
+                    can_refresh = True
+                except OAuth2TokenError:
+                    can_refresh = False
+
+            if can_refresh:
                 if refresh_route:
                     path = request.route_path(refresh_route)
                 else:
                     raise ValueError(
                         f"No OAuth 2 refresh API for {request.product.family}"
                     )
-
                 body["refresh"] = {"method": "POST", "path": path}
 
         return body

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -292,6 +292,22 @@ class TestErrorBody:
 
         assert "refresh" not in body
 
+    @pytest.mark.usefixtures("with_refreshable_exception")
+    def test_json_includes_refresh_info_for_canvas_studio_admin_refresh(
+        self, pyramid_request, oauth2_token_service
+    ):
+        pyramid_request.exception.refresh_service = Service.CANVAS_STUDIO
+        pyramid_request.exception.refresh_route = (
+            "canvas_studio_api.oauth.refresh_admin"
+        )
+
+        body = ErrorBody().__json__(pyramid_request)
+
+        # As a special case, we don't check for an existing access token for
+        # this refresh route.
+        oauth2_token_service.get.assert_not_called()
+        assert "refresh" in body
+
     @pytest.fixture
     def pyramid_request(self, pyramid_request):
         # When Pyramid calls an exception view it sets request.exception to the


### PR DESCRIPTION
When handling refreshable `OAuth2TokenError` exceptions, don't try to look up the existing access token in the special case where the token that needs to be refreshed is the Canvas Studio admin user's token, instead of the current user's access token.

This issue caused Canvas Studio assignment launches to fail for users if:

 - The Canvas Studio admin token needed a refresh
 - The current user had not directly authorized with Canvas Studio. This primarily means students, since the instructor will authorize with Canvas Studio when they create the assignment.

In this scenario the `refresh` field was omitted from the response, so users would see a non-working "Authorize Hypothesis" screen, instead of having the frontend initiate an admin user token refresh.

Fixes https://github.com/hypothesis/support/issues/134