### PR TITLE
Replace SelectNext usages with Select

### DIFF
--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Link, SelectNext } from '@hypothesis/frontend-shared';
+import { Checkbox, Link, Select } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
@@ -64,7 +64,7 @@ function GroupSelect({
       >
         Group set
       </label>
-      <SelectNext
+      <Select
         value={selectedGroupSet}
         onChange={newGroupSet => onInput(newGroupSet?.id ?? null)}
         buttonId={selectId}
@@ -76,11 +76,11 @@ function GroupSelect({
         }
       >
         {groupSets?.map(gs => (
-          <SelectNext.Option value={gs} key={gs.id}>
+          <Select.Option value={gs} key={gs.id}>
             {gs.name}
-          </SelectNext.Option>
+          </Select.Option>
         ))}
-      </SelectNext>
+      </Select>
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentSelector.tsx
@@ -3,7 +3,7 @@ import {
   ArrowRightIcon,
   IconButton,
   InputGroup,
-  SelectNext,
+  Select,
 } from '@hypothesis/frontend-shared';
 
 import type { StudentInfo } from '../config';
@@ -77,7 +77,7 @@ export default function StudentSelector<Student extends StudentOption>({
             title="Previous student"
             variant="dark"
           />
-          <SelectNext
+          <Select
             aria-label="Select student"
             value={selectedStudent}
             onChange={onSelectStudent}
@@ -85,13 +85,13 @@ export default function StudentSelector<Student extends StudentOption>({
             buttonContent={selectedStudent?.displayName ?? 'All Students'}
             buttonClasses="md:w-[12rem] lg:w-[16rem] xl:w-[20rem]"
           >
-            <SelectNext.Option value={null}>All Students</SelectNext.Option>
+            <Select.Option value={null}>All Students</Select.Option>
             {students.map((studentOption, idx) => (
-              <SelectNext.Option value={studentOption} key={`student-${idx}`}>
+              <Select.Option value={studentOption} key={`student-${idx}`}>
                 {studentOption.displayName}
-              </SelectNext.Option>
+              </Select.Option>
             ))}
-          </SelectNext>
+          </Select>
           <IconButton
             data-testid="next-student-button"
             disabled={selectedIndex >= students.length - 1}

--- a/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/GroupConfigSelector-test.js
@@ -1,4 +1,4 @@
-import { SelectNext } from '@hypothesis/frontend-shared';
+import { Select } from '@hypothesis/frontend-shared';
 import {
   mockImportedComponents,
   waitForElement,
@@ -131,15 +131,15 @@ describe('GroupConfigSelector', () => {
       groupConfig: { useGroupSet: true, groupConfig: null },
     });
 
-    // While groups are being fetched, the `<SelectNext>` should be visible but
+    // While groups are being fetched, the `<Select>` should be visible but
     // disabled, and display a fetching status.
-    const groupSetSelect = wrapper.find('SelectNext');
+    const groupSetSelect = wrapper.find('Select');
     assert.isTrue(groupSetSelect.exists());
     assert.isTrue(groupSetSelect.prop('disabled'));
     assert.equal(groupSetSelect.prop('buttonContent'), 'Fetching group sets…');
 
     // Once group sets are fetched, they should be rendered as options.
-    const options = await waitForElement(wrapper, SelectNext.Option);
+    const options = await waitForElement(wrapper, Select.Option);
     assert.equal(options.length, fakeGroupSets.length);
 
     fakeGroupSets.forEach((gs, i) => {
@@ -155,11 +155,11 @@ describe('GroupConfigSelector', () => {
       onChangeGroupConfig,
     });
 
-    const options = await waitForElement(wrapper, SelectNext.Option);
+    const options = await waitForElement(wrapper, Select.Option);
     assert.equal(options.length, fakeGroupSets.length);
     assert.notCalled(onChangeGroupConfig);
 
-    const select = wrapper.find('SelectNext');
+    const select = wrapper.find('Select');
 
     options.forEach((option, i) => {
       onChangeGroupConfig.resetHistory();
@@ -191,7 +191,7 @@ describe('GroupConfigSelector', () => {
     fakeAPICall.withArgs(groupSetsAPIRequest).resolves(fakeGroupSets);
     authModal.prop('onAuthComplete')();
 
-    const options = await waitForElement(wrapper, SelectNext.Option);
+    const options = await waitForElement(wrapper, Select.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 
@@ -223,7 +223,7 @@ describe('GroupConfigSelector', () => {
       authModal.prop('onRetry')();
     });
 
-    const options = await waitForElement(wrapper, SelectNext.Option);
+    const options = await waitForElement(wrapper, Select.Option);
     assert.equal(options.length, fakeGroupSets.length);
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentSelector-test.js
@@ -47,10 +47,7 @@ describe('StudentSelector', () => {
 
   it('shall have "All Students" as the default option', () => {
     const wrapper = renderSelector({ selectedStudent: null });
-    assert.equal(
-      wrapper.find('SelectNext').prop('buttonContent'),
-      'All Students',
-    );
+    assert.equal(wrapper.find('Select').prop('buttonContent'), 'All Students');
     assert.equal(
       wrapper.find('[data-testid="student-selector-label"]').text(),
       '2 Students',
@@ -59,7 +56,7 @@ describe('StudentSelector', () => {
 
   it('sets the selected option to the reflect the selected student', () => {
     const wrapper = renderSelector({ selectedStudent: fakeStudents[1] });
-    assert.equal(wrapper.find('SelectNext').prop('buttonContent'), 'Student 2');
+    assert.equal(wrapper.find('Select').prop('buttonContent'), 'Student 2');
     assert.equal(
       wrapper.find('[data-testid="student-selector-label"]').text(),
       'Student 2 of 2',
@@ -72,7 +69,7 @@ describe('StudentSelector', () => {
       onSelectStudent: onChange,
       selectedStudent: fakeStudents[0],
     });
-    wrapper.find('SelectNext').props().onChange(fakeStudents[1]);
+    wrapper.find('Select').props().onChange(fakeStudents[1]);
     assert.calledWith(onChange, fakeStudents[1]);
   });
 
@@ -83,7 +80,7 @@ describe('StudentSelector', () => {
       selectedStudent: fakeStudents[0],
     });
     // No student is selected
-    wrapper.find('SelectNext').props().onChange(null);
+    wrapper.find('Select').props().onChange(null);
     assert.calledWith(onChange, null);
   });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.11.0",
+    "@hypothesis/frontend-shared": "^7.14.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,15 +1996,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.11.0":
-  version: 7.11.0
-  resolution: "@hypothesis/frontend-shared@npm:7.11.0"
+"@hypothesis/frontend-shared@npm:^7.14.0":
+  version: 7.14.0
+  resolution: "@hypothesis/frontend-shared@npm:7.14.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 12d10503b2a51a8c5d690f0f892341698465f49d3c760574a838918879a7a0151ddf0994f422515264224f6462a5b1baf1169f4f16ca6f5f9b8d7b4d8065cc4b
+  checksum: e5a21a08d4e23b9ca412320b03ddab07bc849a0962d608af7758c4c71aed5e9748fa9ae57ec0cf74f7deaa42a01d9960f11a1681b96b116503f53317e9f368e8
   languageName: node
   linkType: hard
 
@@ -7217,7 +7217,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.11.0
+    "@hypothesis/frontend-shared": ^7.14.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
Update to latest frontend-shared, and replace usages of `SelectNext` with its `Select` drop-in replacement.

The frontend-shared update also brings the new UI improvements on `Select` components, around focus ring and selected option/s.

* https://github.com/hypothesis/frontend-shared/pull/1604
* https://github.com/hypothesis/frontend-shared/pull/1605