### PR TITLE
Create filters component for dashboard organization section

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -183,24 +183,27 @@ export type CoursesResponse = {
 export type Assignment = {
   id: number;
   title: string;
-  course: Course;
+};
+
+export type Student = {
+  h_userid: string;
+  lms_id: string;
+  display_name: string | null;
+};
+
+export type StudentWithMetrics = Student & {
+  annotation_metrics: AnnotationMetrics;
 };
 
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
  */
-export type StudentStats = {
-  h_userid: string;
-  lms_id: string;
-  display_name: string | null;
-  annotation_metrics: AnnotationMetrics;
-};
-
 export type StudentsResponse = {
-  students: StudentStats[];
+  students: StudentWithMetrics[];
 };
 
 export type AssignmentWithMetrics = Assignment & {
+  course: Course;
   annotation_metrics: AnnotationMetrics;
 };
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
-import type { Assignment, StudentsResponse } from '../../api-types';
+import type { AssignmentWithMetrics, StudentsResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
@@ -24,7 +24,7 @@ export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
   const { assignmentId } = useParams<{ assignmentId: string }>();
-  const assignment = useAPIFetch<Assignment>(
+  const assignment = useAPIFetch<AssignmentWithMetrics>(
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
   const students = useAPIFetch<StudentsResponse>(routes.students_metrics, {

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivityFilters.tsx
@@ -1,0 +1,118 @@
+import { MultiSelect } from '@hypothesis/frontend-shared';
+
+import type { Assignment, Course, Student } from '../../api-types';
+import { useConfig } from '../../config';
+import { useAPIFetch } from '../../utils/api';
+
+export type OrganizationActivityFiltersProps = {
+  selectedCourses: Course[];
+  onCoursesChange: (newCourses: Course[]) => void;
+  selectedAssignments: Assignment[];
+  onAssignmentsChange: (newAssignments: Assignment[]) => void;
+  selectedStudents: Student[];
+  onStudentsChange: (newStudents: Student[]) => void;
+};
+
+/**
+ * Renders drop-downs to select courses, assignments and/or students, used to
+ * filter organization metrics.
+ */
+export default function OrganizationActivityFilters({
+  selectedCourses,
+  onCoursesChange,
+  selectedAssignments,
+  onAssignmentsChange,
+  selectedStudents,
+  onStudentsChange,
+}: OrganizationActivityFiltersProps) {
+  const { dashboard } = useConfig(['dashboard']);
+  const { routes } = dashboard;
+
+  const courses = useAPIFetch<{ courses: Course[] }>(routes.courses);
+  const assignments = useAPIFetch<{ assignments: Assignment[] }>(
+    routes.assignments,
+  );
+  const students = useAPIFetch<{ students: Student[] }>(routes.students);
+
+  return (
+    <div className="flex gap-2 md:w-1/2">
+      <MultiSelect
+        disabled={courses.isLoading}
+        value={selectedCourses}
+        onChange={onCoursesChange}
+        aria-label="Select courses"
+        buttonContent={
+          courses.isLoading ? (
+            <>...</>
+          ) : selectedCourses.length === 0 ? (
+            <>All courses</>
+          ) : selectedCourses.length === 1 ? (
+            selectedCourses[0].title
+          ) : (
+            <>{selectedCourses.length} courses</>
+          )
+        }
+        data-testid="courses-select"
+      >
+        <MultiSelect.Option value={undefined}>All courses</MultiSelect.Option>
+        {courses.data?.courses.map(course => (
+          <MultiSelect.Option key={course.id} value={course}>
+            {course.title}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+      <MultiSelect
+        disabled={assignments.isLoading}
+        value={selectedAssignments}
+        onChange={onAssignmentsChange}
+        aria-label="Select assignments"
+        buttonContent={
+          assignments.isLoading ? (
+            <>...</>
+          ) : selectedAssignments.length === 0 ? (
+            <>All assignments</>
+          ) : selectedAssignments.length === 1 ? (
+            selectedAssignments[0].title
+          ) : (
+            <>{selectedAssignments.length} assignments</>
+          )
+        }
+        data-testid="assignments-select"
+      >
+        <MultiSelect.Option value={undefined}>
+          All assignments
+        </MultiSelect.Option>
+        {assignments.data?.assignments.map(assignment => (
+          <MultiSelect.Option key={assignment.id} value={assignment}>
+            {assignment.title}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+      <MultiSelect
+        disabled={students.isLoading}
+        value={selectedStudents}
+        onChange={onStudentsChange}
+        aria-label="Select students"
+        buttonContent={
+          students.isLoading ? (
+            <>...</>
+          ) : selectedStudents.length === 0 ? (
+            <>All students</>
+          ) : selectedStudents.length === 1 ? (
+            selectedStudents[0].display_name
+          ) : (
+            <>{selectedStudents.length} students</>
+          )
+        }
+        data-testid="students-select"
+      >
+        <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
+        {students.data?.students.map(student => (
+          <MultiSelect.Option key={student.lms_id} value={student}>
+            {student.display_name}
+          </MultiSelect.Option>
+        ))}
+      </MultiSelect>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivityFilters-test.js
@@ -1,0 +1,263 @@
+import { MultiSelect } from '@hypothesis/frontend-shared';
+import {
+  checkAccessibility,
+  mockImportedComponents,
+} from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { Config } from '../../../config';
+import OrganizationActivityFilters, {
+  $imports,
+} from '../OrganizationActivityFilters';
+
+describe('OrganizationActivityFilters', () => {
+  const courses = [
+    {
+      id: 1,
+      title: 'Course A',
+    },
+    {
+      id: 2,
+      title: 'Course B',
+    },
+  ];
+  const assignments = [
+    {
+      id: 1,
+      title: 'Assignment 1',
+    },
+    {
+      id: 2,
+      title: 'Assignment 2',
+    },
+  ];
+  const students = [
+    {
+      lms_id: '1',
+      display_name: 'First student',
+    },
+    {
+      lms_id: '2',
+      display_name: 'Second student',
+    },
+  ];
+
+  let fakeUseAPIFetch;
+  let fakeConfig;
+  let onCoursesChange;
+  let onAssignmentsChange;
+  let onStudentsChange;
+  let wrappers = [];
+
+  /**
+   * @param {object} options
+   * @param {boolean} options.isLoading
+   */
+  function configureFakeAPIFetch(fakeUseAPIFetch, options) {
+    const { isLoading } = options;
+
+    fakeUseAPIFetch.onCall(0).returns({
+      isLoading,
+      data: isLoading ? null : { courses },
+    });
+    fakeUseAPIFetch.onCall(1).returns({
+      isLoading,
+      data: isLoading ? null : { assignments },
+    });
+    fakeUseAPIFetch.onCall(2).returns({
+      isLoading,
+      data: isLoading ? null : { students },
+    });
+  }
+
+  beforeEach(() => {
+    fakeUseAPIFetch = sinon.stub();
+    configureFakeAPIFetch(fakeUseAPIFetch, { isLoading: false });
+
+    onCoursesChange = sinon.stub();
+    onAssignmentsChange = sinon.stub();
+    onStudentsChange = sinon.stub();
+    wrappers = [];
+
+    fakeConfig = {
+      dashboard: {
+        routes: {
+          courses: '/api/dashboard/courses',
+          assignments: '/api/dashboard/assignments',
+          students: '/api/dashboard/students',
+        },
+      },
+    };
+
+    $imports.$mock(mockImportedComponents());
+    $imports.$mock({
+      '../../utils/api': {
+        useAPIFetch: fakeUseAPIFetch,
+      },
+    });
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+    $imports.$restore();
+  });
+
+  /**
+   @param {Object} [selection]
+   @param {Object[]} [selection.selectedStudents]
+   @param {Object[]} [selection.selectedAssignments]
+   @param {Object[]} [selection.selectedCourses]
+   */
+  function createComponent(selection = {}) {
+    const {
+      selectedStudents = [],
+      selectedAssignments = [],
+      selectedCourses = [],
+    } = selection;
+
+    const wrapper = mount(
+      <Config.Provider value={fakeConfig}>
+        <OrganizationActivityFilters
+          selectedCourses={selectedCourses}
+          onCoursesChange={onCoursesChange}
+          selectedAssignments={selectedAssignments}
+          onAssignmentsChange={onAssignmentsChange}
+          selectedStudents={selectedStudents}
+          onStudentsChange={onStudentsChange}
+        />
+      </Config.Provider>,
+    );
+    wrappers.push(wrapper);
+
+    return wrapper;
+  }
+
+  function getSelect(wrapper, id) {
+    return wrapper.find(`MultiSelect[data-testid="${id}"]`);
+  }
+
+  function getSelectContent(wrapper, id) {
+    const content = getSelect(wrapper, id).prop('buttonContent');
+    // Wrap content in div, as it could be a fragment with multiple children
+    // or a scalar value, which would make the call to `mount` fail
+    return mount(<div>{content}</div>).text();
+  }
+
+  it('shows loading indicators while loading', () => {
+    configureFakeAPIFetch(fakeUseAPIFetch, { isLoading: true });
+
+    const wrapper = createComponent();
+
+    assert.equal(getSelectContent(wrapper, 'courses-select'), '...');
+    assert.equal(getSelectContent(wrapper, 'assignments-select'), '...');
+    assert.equal(getSelectContent(wrapper, 'students-select'), '...');
+  });
+
+  it('shows placeholders when selection is empty', () => {
+    const wrapper = createComponent();
+
+    assert.equal(getSelectContent(wrapper, 'courses-select'), 'All courses');
+    assert.equal(
+      getSelectContent(wrapper, 'assignments-select'),
+      'All assignments',
+    );
+    assert.equal(getSelectContent(wrapper, 'students-select'), 'All students');
+  });
+
+  [
+    {
+      id: 'courses-select',
+      expectedOptions: ['All courses', ...courses.map(c => c.title)],
+    },
+    {
+      id: 'assignments-select',
+      expectedOptions: ['All assignments', ...assignments.map(a => a.title)],
+    },
+    {
+      id: 'students-select',
+      expectedOptions: ['All students', ...students.map(s => s.display_name)],
+    },
+  ].forEach(({ id, expectedOptions }) => {
+    it('renders corresponding options', () => {
+      const wrapper = createComponent();
+      const select = getSelect(wrapper, id);
+      const options = select.find(MultiSelect.Option);
+
+      assert.equal(options.length, expectedOptions.length);
+      options.forEach((option, index) => {
+        assert.equal(option.text(), expectedOptions[index]);
+      });
+    });
+  });
+
+  [
+    {
+      id: 'courses-select',
+      getExpectedCallback: () => onCoursesChange,
+    },
+    {
+      id: 'assignments-select',
+      getExpectedCallback: () => onAssignmentsChange,
+    },
+    {
+      id: 'students-select',
+      getExpectedCallback: () => onStudentsChange,
+    },
+  ].forEach(({ id, getExpectedCallback }) => {
+    it('invokes corresponding change callback', () => {
+      const wrapper = createComponent();
+      const select = getSelect(wrapper, id);
+
+      select.props().onChange();
+      assert.called(getExpectedCallback());
+    });
+  });
+
+  context('when items are selected', () => {
+    [0, 1].forEach(index => {
+      it('shows item name when only one is selected', () => {
+        const wrapper = createComponent({
+          selectedCourses: [courses[index]],
+          selectedAssignments: [assignments[index]],
+          selectedStudents: [students[index]],
+        });
+
+        assert.equal(
+          getSelectContent(wrapper, 'courses-select'),
+          courses[index].title,
+        );
+        assert.equal(
+          getSelectContent(wrapper, 'assignments-select'),
+          assignments[index].title,
+        );
+        assert.equal(
+          getSelectContent(wrapper, 'students-select'),
+          students[index].display_name,
+        );
+      });
+    });
+
+    it('shows amount of selected items when more than one is selected', () => {
+      const wrapper = createComponent({
+        selectedCourses: [...courses],
+        selectedAssignments: [...assignments],
+        selectedStudents: [...students],
+      });
+
+      assert.equal(getSelectContent(wrapper, 'courses-select'), '2 courses');
+      assert.equal(
+        getSelectContent(wrapper, 'assignments-select'),
+        '2 assignments',
+      );
+      assert.equal(getSelectContent(wrapper, 'students-select'), '2 students');
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});


### PR DESCRIPTION
This PR introduces a new component that wraps the filtering dropdowns for the dashboard homepage. For now, dropdowns will show all courses, all assignments and all students, but this may change later as we [clarify expected behaviors](https://github.com/hypothesis/lms/pull/6453#issuecomment-2242651989).

Filtering components for other sections will be implemented separately. You can find why I choose this approach here: https://github.com/hypothesis/lms/pull/6416#issuecomment-2236120392

The only purpose of this PR is to introduce the visual components, and handle the logic to display selected filters and forward them to the metrics endpoint and also filter among themselves. There are a few missing things that will be implemented afterwards:

- Load paginated information in filter dropdowns. Only first page is currently loaded.
- Persist selected filters in the page query string, so that it's possible to bookmark, reload or navigate through different selections.
- As mentioned above, implement the filters for the other dashboard sections. Once this is tackled, some logic introduced here will likely be extracted for reusing.

https://github.com/user-attachments/assets/b2e83b0b-b492-4b77-8289-5e802b5a119e

### TODO

- [x] Write tests.
- [x] Evaluate type definitions: Optional props vs different types. See https://github.com/hypothesis/lms/pull/6453/files#r1684282200
- [x] ~Make selection in filters affect each other. See https://github.com/hypothesis/lms/pull/6453#issuecomment-2242438396~ Finally not doing this due to some needed clarifications. We can merge this and change it later if needed.