### PR TITLE
Fix typo in prop name inside CoursesMetricsSchema

### DIFF
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -28,7 +28,7 @@ class CoursesMetricsSchema(PyramidRequestSchema):
     assignment_ids = fields.List(fields.Integer(), data_key="assignment_id")
     """Return metrics for these assignments only."""
 
-    courses_ids = fields.List(fields.Integer(), data_key="course_id")
+    course_ids = fields.List(fields.Integer(), data_key="course_id")
     """Return metrics for these courses only."""
 
 


### PR DESCRIPTION
I found a typo while working on https://github.com/hypothesis/lms/pull/6453, and since I don't know how long will it take to merge that, I decided to extract the fix here.

See [my comment](https://github.com/hypothesis/lms/pull/6453/files#r1684180579) there for context.