### PR TITLE
Exclude students without a name from students filter dropdown

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivityFilters.tsx
@@ -1,4 +1,5 @@
 import { MultiSelect } from '@hypothesis/frontend-shared';
+import { useMemo } from 'preact/hooks';
 
 import type { Assignment, Course, Student } from '../../api-types';
 import { useConfig } from '../../config';
@@ -33,6 +34,10 @@ export default function OrganizationActivityFilters({
     routes.assignments,
   );
   const students = useAPIFetch<{ students: Student[] }>(routes.students);
+  const studentsWithName = useMemo(
+    () => students.data?.students.filter(s => !!s.display_name),
+    [students.data?.students],
+  );
 
   return (
     <div className="flex gap-2 md:w-1/2">
@@ -107,7 +112,7 @@ export default function OrganizationActivityFilters({
         data-testid="students-select"
       >
         <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
-        {students.data?.students.map(student => (
+        {studentsWithName?.map(student => (
           <MultiSelect.Option key={student.lms_id} value={student}>
             {student.display_name}
           </MultiSelect.Option>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivityFilters-test.js
@@ -32,7 +32,7 @@ describe('OrganizationActivityFilters', () => {
       title: 'Assignment 2',
     },
   ];
-  const students = [
+  const studentsWithName = [
     {
       lms_id: '1',
       display_name: 'First student',
@@ -40,6 +40,13 @@ describe('OrganizationActivityFilters', () => {
     {
       lms_id: '2',
       display_name: 'Second student',
+    },
+  ];
+  const students = [
+    ...studentsWithName,
+    {
+      lms_id: '3',
+      display_name: '', // Student with an empty name won't be displayed
     },
   ];
 
@@ -176,7 +183,10 @@ describe('OrganizationActivityFilters', () => {
     },
     {
       id: 'students-select',
-      expectedOptions: ['All students', ...students.map(s => s.display_name)],
+      expectedOptions: [
+        'All students',
+        ...studentsWithName.map(s => s.display_name),
+      ],
     },
   ].forEach(({ id, expectedOptions }) => {
     it('renders corresponding options', () => {
@@ -242,7 +252,7 @@ describe('OrganizationActivityFilters', () => {
       const wrapper = createComponent({
         selectedCourses: [...courses],
         selectedAssignments: [...assignments],
-        selectedStudents: [...students],
+        selectedStudents: [...studentsWithName],
       });
 
       assert.equal(getSelectContent(wrapper, 'courses-select'), '2 courses');


### PR DESCRIPTION
There are some cases in which we could have students without a display name, if they haven't launched an assignment before May 9th, 2024.

For the students table we decided to show a placeholder and a helper text explaining what that means (see https://github.com/hypothesis/lms/pull/6382), but for the filters dropdown we think it makes more sense to completely ignore those students. Since you don't know who they are, it's not very likely you want to filter by them.

This decision might change in the future.

Closes https://github.com/hypothesis/lms/issues/6457