### PR TITLE
Rename OrganizationActivityFilters to DashboardActivityFilters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -5,7 +5,7 @@ import type { Assignment, Course, Student } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 
-export type OrganizationActivityFiltersProps = {
+export type DashboardActivityFiltersProps = {
   selectedCourses: Course[];
   onCoursesChange: (newCourses: Course[]) => void;
   selectedAssignments: Assignment[];
@@ -16,16 +16,16 @@ export type OrganizationActivityFiltersProps = {
 
 /**
  * Renders drop-downs to select courses, assignments and/or students, used to
- * filter organization metrics.
+ * filter dashboard activity metrics.
  */
-export default function OrganizationActivityFilters({
+export default function DashboardActivityFilters({
   selectedCourses,
   onCoursesChange,
   selectedAssignments,
   onAssignmentsChange,
   selectedStudents,
   onStudentsChange,
-}: OrganizationActivityFiltersProps) {
+}: DashboardActivityFiltersProps) {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -11,9 +11,9 @@ import type {
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { replaceURLParams } from '../../utils/url';
+import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
-import OrganizationActivityFilters from './OrganizationActivityFilters';
 
 type CoursesTableRow = {
   id: number;
@@ -75,7 +75,7 @@ export default function OrganizationActivity() {
   return (
     <div className="flex flex-col gap-y-5">
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
-      <OrganizationActivityFilters
+      <DashboardActivityFilters
         selectedStudents={selectedStudents}
         onStudentsChange={setSelectedStudents}
         selectedAssignments={selectedAssignments}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -7,11 +7,11 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
-import OrganizationActivityFilters, {
+import DashboardActivityFilters, {
   $imports,
-} from '../OrganizationActivityFilters';
+} from '../DashboardActivityFilters';
 
-describe('OrganizationActivityFilters', () => {
+describe('DashboardActivityFilters', () => {
   const courses = [
     {
       id: 1,
@@ -125,7 +125,7 @@ describe('OrganizationActivityFilters', () => {
 
     const wrapper = mount(
       <Config.Provider value={fakeConfig}>
-        <OrganizationActivityFilters
+        <DashboardActivityFilters
           selectedCourses={selectedCourses}
           onCoursesChange={onCoursesChange}
           selectedAssignments={selectedAssignments}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -154,7 +154,7 @@ describe('OrganizationActivity', () => {
 
   it('allows metrics to be filtered', () => {
     const wrapper = createComponent();
-    const filters = wrapper.find('OrganizationActivityFilters');
+    const filters = wrapper.find('DashboardActivityFilters');
     const updateFilter = (changeCallback, arg) => {
       act(() => filters.prop(changeCallback)(arg));
       wrapper.update();


### PR DESCRIPTION
After a few comes and goes, I ended up with the conclusion that it would be easier to have different filtering components per section.

However, after starting to apply filters in the second ~second~ PR, I realized we can in fact reuse the components.

This PR renames the `OrganizationActivityFilters` component, to a more generic `DashboardActivityFilters`, so that it can be reused in places other than the organization section, without causing confusion.