### PR TITLE
Add filters to course activity section

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -1,11 +1,18 @@
 import { Link } from '@hypothesis/frontend-shared';
-import { useMemo } from 'preact/hooks';
-import { Link as RouterLink, useParams } from 'wouter-preact';
+import { useMemo, useState } from 'preact/hooks';
+import { Link as RouterLink, useParams, useLocation } from 'wouter-preact';
 
-import type { AssignmentsResponse, Course } from '../../api-types';
+import type {
+  Assignment,
+  AssignmentsResponse,
+  Course,
+  Student,
+} from '../../api-types';
 import { useConfig } from '../../config';
-import { urlPath, useAPIFetch } from '../../utils/api';
-import { replaceURLParams } from '../../utils/url';
+import { useAPIFetch } from '../../utils/api';
+import { assignmentURL, courseURL } from '../../utils/dashboard/navigation';
+import { recordToQueryStringFragment, replaceURLParams } from '../../utils/url';
+import DashboardActivityFilters from './DashboardActivityFilters';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
@@ -18,15 +25,27 @@ type AssignmentsTableRow = {
   replies: number;
 };
 
-const assignmentURL = (id: number) => urlPath`/assignments/${String(id)}`;
-
 /**
  * Activity in a list of assignments that are part of a specific course
  */
 export default function CourseActivity() {
+  const [, navigate] = useLocation();
   const { courseId } = useParams<{ courseId: string }>();
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
+
+  const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
+  const [selectedAssignments, setSelectedAssignments] = useState<Assignment[]>(
+    [],
+  );
+  const filteringQuery = useMemo(
+    () => ({
+      h_userid: selectedStudents.map(s => s.h_userid),
+      assignment_id: selectedAssignments.map(a => `${a.id}`),
+    }),
+    [selectedAssignments, selectedStudents],
+  );
+
   const course = useAPIFetch<Course>(
     replaceURLParams(routes.course, { course_id: courseId }),
   );
@@ -34,6 +53,7 @@ export default function CourseActivity() {
     replaceURLParams(routes.course_assignments_metrics, {
       course_id: courseId,
     }),
+    filteringQuery,
   );
 
   const rows: AssignmentsTableRow[] = useMemo(
@@ -60,6 +80,25 @@ export default function CourseActivity() {
           {course.data && course.data.title}
         </h2>
       </div>
+      <DashboardActivityFilters
+        selectedCourses={course.data ? [course.data] : []}
+        onCoursesChange={courses => {
+          const firstDifferentCourse = courses.find(
+            c => `${c.id}` !== courseId,
+          );
+          if (firstDifferentCourse) {
+            // When a course other than the "active" one (the one represented
+            // in the URL) is selected, navigate to that course and propagate
+            // the rest of the filters.
+            const queryString = recordToQueryStringFragment(filteringQuery);
+            navigate(`${courseURL(firstDifferentCourse.id)}${queryString}`);
+          }
+        }}
+        selectedAssignments={selectedAssignments}
+        onAssignmentsChange={setSelectedAssignments}
+        selectedStudents={selectedStudents}
+        onStudentsChange={setSelectedStudents}
+      />
       <OrderableActivityTable
         loading={assignments.isLoading}
         title={course.data?.title ?? 'Loading...'}

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { courseURL } from '../../utils/dashboard/navigation';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
@@ -21,8 +22,6 @@ type CoursesTableRow = {
   assignments: number;
   last_launched: string | null;
 };
-
-const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
 
 /**
  * List of courses that belong to a specific organization

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -2,7 +2,7 @@ import { useConfig } from '../config';
 import { APIError } from '../errors';
 import { useFetch } from './fetch';
 import type { FetchResult, Fetcher } from './fetch';
-import { recordToSearchParams } from './url';
+import { recordToQueryStringFragment } from './url';
 
 /**
  * Parameters for an API call that will refresh an expired access token.
@@ -111,9 +111,7 @@ export async function apiCall<Result = unknown>(
     headers['Content-Type'] = 'application/json; charset=UTF-8';
   }
 
-  const queryString = recordToSearchParams(params ?? {}).toString();
-  const query = queryString.length > 0 ? `?${queryString}` : '';
-
+  const query = recordToQueryStringFragment(params ?? {});
   const defaultMethod = data === undefined ? 'GET' : 'POST';
   const result = await fetch(path + query, {
     method: method ?? defaultMethod,
@@ -208,7 +206,6 @@ export function useAPIFetch<T = unknown>(
   // something simpler, as long as it encodes the same information. The auth
   // token is not included in the key, as we assume currently that it does not
   // change the result.
-  const queryString = recordToSearchParams(params ?? {}).toString();
-  const paramStr = queryString.length > 0 ? `?${queryString}` : '';
+  const paramStr = recordToQueryStringFragment(params ?? {});
   return useFetch(path ? `${path}${paramStr}` : null, fetcher);
 }

--- a/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
@@ -1,0 +1,9 @@
+import { urlPath } from '../api';
+
+export function assignmentURL(id: number) {
+  return urlPath`/assignments/${String(id)}`;
+}
+
+export function courseURL(id: number) {
+  return urlPath`/courses/${String(id)}`;
+}

--- a/lms/static/scripts/frontend_apps/utils/test/url-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/url-test.js
@@ -1,4 +1,9 @@
-import { recordToSearchParams, replaceURLParams } from '../url';
+import {
+  queryStringToRecord,
+  recordToQueryStringFragment,
+  recordToSearchParams,
+  replaceURLParams,
+} from '../url';
 
 describe('replaceURLParams', () => {
   it('should replace params in URLs', () => {
@@ -45,5 +50,55 @@ describe('recordToSearchParams', () => {
     });
 
     assert.equal(result.toString(), 'foo=bar&baz=1&baz=2&baz=3');
+  });
+});
+
+describe('recordToQueryStringFragment', () => {
+  [
+    {
+      params: {
+        foo: 'bar',
+        baz: ['1', '2', '3'],
+      },
+      expectedResult: '?foo=bar&baz=1&baz=2&baz=3',
+    },
+    {
+      params: {},
+      expectedResult: '',
+    },
+    {
+      params: { foo: [], bar: [] },
+      expectedResult: '',
+    },
+  ].forEach(({ params, expectedResult }) => {
+    it('parses provided record and appends entries', () => {
+      const result = recordToQueryStringFragment(params);
+      assert.equal(result, expectedResult);
+    });
+  });
+});
+
+describe('queryStringToRecord', () => {
+  [
+    {
+      queryString: '?foo=bar&baz=1&baz=2&baz=3',
+      expectedResult: {
+        foo: 'bar',
+        baz: ['1', '2', '3'],
+      },
+    },
+    {
+      queryString: '',
+      expectedResult: {},
+    },
+    {
+      queryString: '?',
+      expectedResult: {},
+    },
+  ].forEach(({ queryString, expectedResult }) => {
+    it('parses provided record and appends entries', () => {
+      const result = queryStringToRecord(queryString);
+      assert.deepEqual(result, expectedResult);
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/url.ts
+++ b/lms/static/scripts/frontend_apps/utils/url.ts
@@ -47,3 +47,43 @@ export function recordToSearchParams(
 
   return queryParams;
 }
+
+/**
+ * Converts a record into a query string fragment.
+ * The result is prefixed with a question mark (`?`) if it's not empty.
+ *
+ * Examples:
+ *  * {} -> ''
+ *  * { foo: [] } -> ''
+ *  * { foo: 'bar' } -> '?foo=bar'
+ *  * { foo: 'bar', something: ['hello', 'world'] } -> '?foo=bar&something=hello&something=world'
+ */
+export function recordToQueryStringFragment(
+  params: Record<string, string | string[]>,
+): string {
+  const queryString = recordToSearchParams(params).toString();
+  return queryString.length > 0 ? `?${queryString}` : '';
+}
+
+/**
+ * Converts provided query string into a record object.
+ * Parameters that appear more than once will be converted to an array.
+ */
+export function queryStringToRecord(
+  queryString: string,
+): Record<string, string | string[]> {
+  const queryParams = new URLSearchParams(queryString);
+  const params: Record<string, string | string[]> = {};
+
+  queryParams.forEach((value, name) => {
+    if (!params[name]) {
+      params[name] = value;
+    } else if (Array.isArray(params[name])) {
+      (params[name] as string[]).push(value);
+    } else {
+      params[name] = [params[name] as string, value];
+    }
+  });
+
+  return params;
+}


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6466

Continuing with the work from https://github.com/hypothesis/lms/pull/6453, this PR adds filters to the course section.

The main difference here is that the courses dropdown starts with the "active" course (the one represented in the URL) pre-selected. Then, selecting a different course does not apply a filter to the activity table, as we are implicitly filtering by a single course. Instead, once a different course is selected, we navigate to that course and propagate the rest of the filters there.

![image](https://github.com/user-attachments/assets/9ea850e1-cb6a-47ff-85ff-6a7935edf3fa)

### To do/discuss

- [ ] The courses dropdown behavior which "navigates" instead of "filter", presents a few cases that we need to discuss.
    * What to do when "All courses" is selected. We could navigate to the home page in that case.
    * What to do when the active course is clicked. The default multi-select behavior would be to de-select that course, which in this case is the same as selecting "all courses", so perhaps we could also navigate to the home page.
- [x] Selects manage references to objects in order to determine what options are selected. In this case we are passing a course object which deep-equals one from the list, but is a different reference, so it is not marked as selected. We could:
  * ~Refactor `Select` component to do deep-equal checks in order to determine if an option is selected.~
  * Slightly change the local logic so that we handle a list of IDs instead of a list of objects, which would require separately tracking the corresponding names. -> We are doing this as part of https://github.com/hypothesis/lms/pull/6466
- [x] Implement logic to initialize filters based on query parameters, so that we can navigate to other places and propagate filters. -> Being implemented in https://github.com/hypothesis/lms/pull/6466
- [ ] Add tests.