### PR TITLE
Add assignment and user filters to the courses API

### DIFF
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -11,10 +11,13 @@ from lms.views.dashboard.pagination import PaginationParametersMixin, get_page
 
 
 class ListCoursesSchema(PaginationParametersMixin):
-    """Query parameters to fetch a list of courses.
+    """Query parameters to fetch a list of courses."""
 
-    Only the pagination related ones from the mixin.
-    """
+    h_userids = fields.List(fields.Str(), data_key="h_userid")
+    """Return courses for these users only."""
+
+    assignment_ids = fields.List(fields.Integer(), data_key="assignment_id")
+    """Return only the courses to which these assigments belong."""
 
 
 class CoursesMetricsSchema(PyramidRequestSchema):
@@ -49,10 +52,15 @@ class CourseViews:
         schema=ListCoursesSchema,
     )
     def courses(self) -> APICourses:
+        filter_by_h_userids = self.request.parsed_params.get("h_userids")
+        filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
+
         courses = self.course_service.get_courses(
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
+            h_userids=filter_by_h_userids,
+            assignment_ids=filter_by_assignment_ids,
         )
         courses, pagination = get_page(
             self.request, courses, [Course.lms_name, Course.id]

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -20,11 +20,17 @@ class TestCourseViews:
     def test_get_courses(self, course_service, pyramid_request, views, get_page):
         courses = factories.Course.create_batch(5)
         get_page.return_value = courses, sentinel.pagination
+        pyramid_request.parsed_params = {
+            "h_userids": sentinel.h_userids,
+            "assignment_ids": sentinel.assignment_ids,
+        }
 
         response = views.courses()
 
         course_service.get_courses.assert_called_once_with(
-            pyramid_request.user.h_userid
+            instructor_h_userid=pyramid_request.user.h_userid,
+            h_userids=sentinel.h_userids,
+            assignment_ids=sentinel.assignment_ids,
         )
         get_page.assert_called_once_with(
             pyramid_request,


### PR DESCRIPTION
### Testing 

(these IDs are environment dependent)

- Courses with assignments IDs from different courses returns multiple courses:

http://localhost:8001/api/dashboard/courses?assignment_id=399&assignment_id=398


- Filter courses by user ids of different courses returns multiple courses:

http://localhost:8001/api/dashboard/courses?h_userid=acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is&acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is