### PR TITLE
Make sure dashboard page titles update when navigating

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'wouter-preact';
 import type { AssignmentWithMetrics, StudentsResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { usePageTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
@@ -43,6 +44,8 @@ export default function AssignmentActivity() {
       ),
     [students.data],
   );
+
+  usePageTitle(`${assignment.data?.title ?? ''} - Hypothesis`);
 
   return (
     <div className="flex flex-col gap-y-5">

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -5,6 +5,7 @@ import { Link as RouterLink, useParams } from 'wouter-preact';
 import type { AssignmentsResponse, Course } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { usePageTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
@@ -47,6 +48,8 @@ export default function CourseActivity() {
       ),
     [assignments.data],
   );
+
+  usePageTitle(`${course.data?.title ?? ''} - Hypothesis`);
 
   return (
     <div className="flex flex-col gap-y-5">

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { usePageTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
@@ -33,6 +34,8 @@ export default function OrganizationActivity() {
   const { organizationPublicId } = useParams<{
     organizationPublicId: string;
   }>();
+
+  usePageTitle('All courses - Hypothesis');
 
   const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
   const [selectedAssignments, setSelectedAssignments] = useState<Assignment[]>(

--- a/lms/static/scripts/frontend_apps/utils/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 // Global counter used to create a unique ids
 let idCounter = 0;
@@ -13,4 +13,13 @@ export function useUniqueId(prefix: string): string {
     return idCounter;
   });
   return `${prefix}${localId}`;
+}
+
+/**
+ * Updates page title with provided one
+ */
+export function usePageTitle(pageTitle: string) {
+  useEffect(() => {
+    document.title = pageTitle;
+  }, [pageTitle]);
 }

--- a/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
@@ -1,8 +1,9 @@
+import { mount } from 'enzyme';
 import { render } from 'preact';
 
-import { useUniqueId } from '../hooks';
+import { useUniqueId, usePageTitle } from '../hooks';
 
-describe('hooks', () => {
+describe('useUniqueId', () => {
   it('generates unique ids each time useUniqueId is called', () => {
     let id1;
     let id2;
@@ -19,5 +20,31 @@ describe('hooks', () => {
     assert.isTrue(id1.startsWith('prefix:'));
     assert.isTrue(id2.startsWith('prefix:'));
     assert.notEqual(id1, id2);
+  });
+});
+
+describe('usePageTitle', () => {
+  let initialPageTitle;
+
+  beforeEach(() => {
+    initialPageTitle = document.title;
+  });
+
+  afterEach(() => {
+    // Reset document title back to its initial state to avoid side effects in
+    // other tests
+    document.title = initialPageTitle;
+  });
+
+  function FakeComponent({ pageTitle }) {
+    usePageTitle(pageTitle);
+    return <div />;
+  }
+
+  ['foo bar', 'something', 'hello world'].forEach(pageTitle => {
+    it('updates page title', () => {
+      mount(<FakeComponent pageTitle={pageTitle} />);
+      assert.equal(document.title, pageTitle);
+    });
   });
 });

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -110,12 +110,12 @@ class DashboardViews:
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         # Org names are not 100% ready for public consumption, let's hardcode a title for now.
-        return {"title": "Courses - Hypothesis"}
+        return {"title": "All courses"}
 
     def _set_lti_user_cookie(self, response):
         lti_user = self.request.lti_user
         if not lti_user:
-            # An LTIUser might not exists if accessing from the admin pages.
+            # An LTIUser might not exist if accessing from the admin pages.
             return response
         auth_token = (
             BearerTokenSchema(self.request)


### PR DESCRIPTION
Closes #6458 

Add a new `usePageTitle` hook that sets `document.title`, and use it in all dashboard page/section components to ensure the page title is in sync with what's being displayed.

This approach has the drawback that we'll have to remember to call `usePageTitle` with any future section we add, but I think that's going to be needed regardless the approach, as we'll have to define the title per section somewhere no matter what.

### Testing steps

1. Open the dashboard.
2. Navigate to other sections and observe the page title gets updated.

Titles should be the same that the backend sets on initial server-side renders, but we could potentially get rid of the backend logic entirely.