### PR TITLE
Create hook to track selected dashboard filters in query string

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -6,12 +6,12 @@ import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 
 export type DashboardActivityFiltersProps = {
-  selectedCourses: Course[];
-  onCoursesChange: (newCourses: Course[]) => void;
-  selectedAssignments: Assignment[];
-  onAssignmentsChange: (newAssignments: Assignment[]) => void;
-  selectedStudents: Student[];
-  onStudentsChange: (newStudents: Student[]) => void;
+  selectedCourseIds: string[];
+  onCoursesChange: (newCourseIds: string[]) => void;
+  selectedAssignmentIds: string[];
+  onAssignmentsChange: (newAssignmentIds: string[]) => void;
+  selectedStudentIds: string[];
+  onStudentsChange: (newStudentIds: string[]) => void;
 };
 
 /**
@@ -19,11 +19,11 @@ export type DashboardActivityFiltersProps = {
  * filter dashboard activity metrics.
  */
 export default function DashboardActivityFilters({
-  selectedCourses,
+  selectedCourseIds,
   onCoursesChange,
-  selectedAssignments,
+  selectedAssignmentIds,
   onAssignmentsChange,
-  selectedStudents,
+  selectedStudentIds,
   onStudentsChange,
 }: DashboardActivityFiltersProps) {
   const { dashboard } = useConfig(['dashboard']);
@@ -43,43 +43,46 @@ export default function DashboardActivityFilters({
     <div className="flex gap-2 md:w-1/2">
       <MultiSelect
         disabled={courses.isLoading}
-        value={selectedCourses}
+        value={selectedCourseIds}
         onChange={onCoursesChange}
         aria-label="Select courses"
         buttonContent={
           courses.isLoading ? (
             <>...</>
-          ) : selectedCourses.length === 0 ? (
+          ) : selectedCourseIds.length === 0 ? (
             <>All courses</>
-          ) : selectedCourses.length === 1 ? (
-            selectedCourses[0].title
+          ) : selectedCourseIds.length === 1 ? (
+            courses.data?.courses.find(c => `${c.id}` === selectedCourseIds[0])
+              ?.title
           ) : (
-            <>{selectedCourses.length} courses</>
+            <>{selectedCourseIds.length} courses</>
           )
         }
         data-testid="courses-select"
       >
         <MultiSelect.Option value={undefined}>All courses</MultiSelect.Option>
         {courses.data?.courses.map(course => (
-          <MultiSelect.Option key={course.id} value={course}>
+          <MultiSelect.Option key={course.id} value={`${course.id}`}>
             {course.title}
           </MultiSelect.Option>
         ))}
       </MultiSelect>
       <MultiSelect
         disabled={assignments.isLoading}
-        value={selectedAssignments}
+        value={selectedAssignmentIds}
         onChange={onAssignmentsChange}
         aria-label="Select assignments"
         buttonContent={
           assignments.isLoading ? (
             <>...</>
-          ) : selectedAssignments.length === 0 ? (
+          ) : selectedAssignmentIds.length === 0 ? (
             <>All assignments</>
-          ) : selectedAssignments.length === 1 ? (
-            selectedAssignments[0].title
+          ) : selectedAssignmentIds.length === 1 ? (
+            assignments.data?.assignments.find(
+              a => `${a.id}` === selectedAssignmentIds[0],
+            )?.title
           ) : (
-            <>{selectedAssignments.length} assignments</>
+            <>{selectedAssignmentIds.length} assignments</>
           )
         }
         data-testid="assignments-select"
@@ -88,32 +91,34 @@ export default function DashboardActivityFilters({
           All assignments
         </MultiSelect.Option>
         {assignments.data?.assignments.map(assignment => (
-          <MultiSelect.Option key={assignment.id} value={assignment}>
+          <MultiSelect.Option key={assignment.id} value={`${assignment.id}`}>
             {assignment.title}
           </MultiSelect.Option>
         ))}
       </MultiSelect>
       <MultiSelect
         disabled={students.isLoading}
-        value={selectedStudents}
+        value={selectedStudentIds}
         onChange={onStudentsChange}
         aria-label="Select students"
         buttonContent={
           students.isLoading ? (
             <>...</>
-          ) : selectedStudents.length === 0 ? (
+          ) : selectedStudentIds.length === 0 ? (
             <>All students</>
-          ) : selectedStudents.length === 1 ? (
-            selectedStudents[0].display_name
+          ) : selectedStudentIds.length === 1 ? (
+            students.data?.students.find(
+              s => s.h_userid === selectedStudentIds[0],
+            )?.display_name
           ) : (
-            <>{selectedStudents.length} students</>
+            <>{selectedStudentIds.length} students</>
           )
         }
         data-testid="students-select"
       >
         <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
         {studentsWithName?.map(student => (
-          <MultiSelect.Option key={student.lms_id} value={student}>
+          <MultiSelect.Option key={student.lms_id} value={student.h_userid}>
             {student.display_name}
           </MultiSelect.Option>
         ))}

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -1,15 +1,11 @@
 import { Link } from '@hypothesis/frontend-shared';
-import { useMemo, useState } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import { Link as RouterLink, useParams } from 'wouter-preact';
 
-import type {
-  Assignment,
-  Course,
-  CoursesResponse,
-  Student,
-} from '../../api-types';
+import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
@@ -37,23 +33,8 @@ export default function OrganizationActivity() {
 
   useDocumentTitle('All courses');
 
-  const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
-  const [selectedAssignments, setSelectedAssignments] = useState<Assignment[]>(
-    [],
-  );
-  const [selectedCourses, setSelectedCourses] = useState<Course[]>([]);
-  const studentIds = useMemo(
-    () => selectedStudents.map(s => s.h_userid),
-    [selectedStudents],
-  );
-  const assignmentIds = useMemo(
-    () => selectedAssignments.map(a => `${a.id}`),
-    [selectedAssignments],
-  );
-  const courseIds = useMemo(
-    () => selectedCourses.map(c => `${c.id}`),
-    [selectedCourses],
-  );
+  const { filters, updateFilters } = useDashboardFilters();
+  const { courseIds, assignmentIds, studentIds } = filters;
 
   const courses = useAPIFetch<CoursesResponse>(
     replaceURLParams(routes.organization_courses, {
@@ -79,12 +60,12 @@ export default function OrganizationActivity() {
     <div className="flex flex-col gap-y-5">
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
       <DashboardActivityFilters
-        selectedStudents={selectedStudents}
-        onStudentsChange={setSelectedStudents}
-        selectedAssignments={selectedAssignments}
-        onAssignmentsChange={setSelectedAssignments}
-        selectedCourses={selectedCourses}
-        onCoursesChange={setSelectedCourses}
+        selectedStudentIds={studentIds}
+        onStudentsChange={studentIds => updateFilters({ studentIds })}
+        selectedAssignmentIds={assignmentIds}
+        onAssignmentsChange={assignmentIds => updateFilters({ assignmentIds })}
+        selectedCourseIds={courseIds}
+        onCoursesChange={courseIds => updateFilters({ courseIds })}
       />
       <OrderableActivityTable
         loading={courses.isLoading}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -35,10 +35,12 @@ describe('DashboardActivityFilters', () => {
   const studentsWithName = [
     {
       lms_id: '1',
+      h_userid: 'acct:1@lms.hypothes.is',
       display_name: 'First student',
     },
     {
       lms_id: '2',
+      h_userid: 'acct:2@lms.hypothes.is',
       display_name: 'Second student',
     },
   ];
@@ -46,6 +48,7 @@ describe('DashboardActivityFilters', () => {
     ...studentsWithName,
     {
       lms_id: '3',
+      h_userid: 'acct:3@lms.hypothes.is',
       display_name: '', // Student with an empty name won't be displayed
     },
   ];
@@ -112,25 +115,25 @@ describe('DashboardActivityFilters', () => {
 
   /**
    @param {Object} [selection]
-   @param {Object[]} [selection.selectedStudents]
-   @param {Object[]} [selection.selectedAssignments]
-   @param {Object[]} [selection.selectedCourses]
+   @param {Object[]} [selection.selectedStudentIds]
+   @param {Object[]} [selection.selectedAssignmentIds]
+   @param {Object[]} [selection.selectedCourseIds]
    */
   function createComponent(selection = {}) {
     const {
-      selectedStudents = [],
-      selectedAssignments = [],
-      selectedCourses = [],
+      selectedStudentIds = [],
+      selectedAssignmentIds = [],
+      selectedCourseIds = [],
     } = selection;
 
     const wrapper = mount(
       <Config.Provider value={fakeConfig}>
         <DashboardActivityFilters
-          selectedCourses={selectedCourses}
+          selectedCourseIds={selectedCourseIds}
           onCoursesChange={onCoursesChange}
-          selectedAssignments={selectedAssignments}
+          selectedAssignmentIds={selectedAssignmentIds}
           onAssignmentsChange={onAssignmentsChange}
-          selectedStudents={selectedStudents}
+          selectedStudentIds={selectedStudentIds}
           onStudentsChange={onStudentsChange}
         />
       </Config.Provider>,
@@ -204,23 +207,26 @@ describe('DashboardActivityFilters', () => {
   [
     {
       id: 'courses-select',
+      selection: courses.map(c => `${c.id}`),
       getExpectedCallback: () => onCoursesChange,
     },
     {
       id: 'assignments-select',
+      selection: assignments.map(a => `${a.id}`),
       getExpectedCallback: () => onAssignmentsChange,
     },
     {
       id: 'students-select',
+      selection: studentsWithName.map(s => s.h_userid),
       getExpectedCallback: () => onStudentsChange,
     },
-  ].forEach(({ id, getExpectedCallback }) => {
+  ].forEach(({ id, selection, getExpectedCallback }) => {
     it('invokes corresponding change callback', () => {
       const wrapper = createComponent();
       const select = getSelect(wrapper, id);
 
-      select.props().onChange();
-      assert.called(getExpectedCallback());
+      select.props().onChange(selection);
+      assert.calledWith(getExpectedCallback(), selection);
     });
   });
 
@@ -228,9 +234,9 @@ describe('DashboardActivityFilters', () => {
     [0, 1].forEach(index => {
       it('shows item name when only one is selected', () => {
         const wrapper = createComponent({
-          selectedCourses: [courses[index]],
-          selectedAssignments: [assignments[index]],
-          selectedStudents: [students[index]],
+          selectedCourseIds: [`${courses[index].id}`],
+          selectedAssignmentIds: [`${assignments[index].id}`],
+          selectedStudentIds: [students[index].h_userid],
         });
 
         assert.equal(
@@ -250,9 +256,9 @@ describe('DashboardActivityFilters', () => {
 
     it('shows amount of selected items when more than one is selected', () => {
       const wrapper = createComponent({
-        selectedCourses: [...courses],
-        selectedAssignments: [...assignments],
-        selectedStudents: [...studentsWithName],
+        selectedCourseIds: [...courses],
+        selectedAssignmentIds: [...assignments],
+        selectedStudentIds: [...studentsWithName],
       });
 
       assert.equal(getSelectContent(wrapper, 'courses-select'), '2 courses');

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -29,11 +29,14 @@ describe('OrganizationActivity', () => {
       },
     },
   ];
+  let wrappers;
 
   let fakeUseAPIFetch;
   let fakeConfig;
 
   beforeEach(() => {
+    wrappers = [];
+
     fakeUseAPIFetch = sinon.stub().returns({
       isLoading: false,
       data: { courses },
@@ -61,15 +64,19 @@ describe('OrganizationActivity', () => {
   });
 
   afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
     $imports.$restore();
   });
 
   function createComponent() {
-    return mount(
+    const wrapper = mount(
       <Config.Provider value={fakeConfig}>
         <OrganizationActivity />
       </Config.Provider>,
     );
+    wrappers.push(wrapper);
+
+    return wrapper;
   }
 
   it('sets loading state in table while data is loading', () => {
@@ -164,27 +171,24 @@ describe('OrganizationActivity', () => {
 
     // Every time the filters callbacks are invoked, the component will
     // re-render and re-fetch metrics with updated query.
-    updateFilter('onStudentsChange', [
-      { h_userid: '123' },
-      { h_userid: '456' },
-    ]);
+    updateFilter('onStudentsChange', ['123', '456']);
     assertCoursesFetched({
       h_userid: ['123', '456'],
       assignment_id: [],
       course_id: [],
     });
 
-    updateFilter('onAssignmentsChange', [{ id: 1 }, { id: 2 }]);
+    updateFilter('onAssignmentsChange', ['1', '2']);
     assertCoursesFetched({
-      h_userid: ['123', '456'],
+      h_userid: [],
       assignment_id: ['1', '2'],
       course_id: [],
     });
 
-    updateFilter('onCoursesChange', [{ id: 3 }, { id: 8 }, { id: 9 }]);
+    updateFilter('onCoursesChange', ['3', '8', '9']);
     assertCoursesFetched({
-      h_userid: ['123', '456'],
-      assignment_id: ['1', '2'],
+      h_userid: [],
+      assignment_id: [],
       course_id: ['3', '8', '9'],
     });
   });

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -2,7 +2,7 @@ import { useConfig } from '../config';
 import { APIError } from '../errors';
 import { useFetch } from './fetch';
 import type { FetchResult, Fetcher } from './fetch';
-import { recordToSearchParams } from './url';
+import { recordToQueryString } from './url';
 
 /**
  * Parameters for an API call that will refresh an expired access token.
@@ -111,9 +111,7 @@ export async function apiCall<Result = unknown>(
     headers['Content-Type'] = 'application/json; charset=UTF-8';
   }
 
-  const queryString = recordToSearchParams(params ?? {}).toString();
-  const query = queryString.length > 0 ? `?${queryString}` : '';
-
+  const query = recordToQueryString(params ?? {});
   const defaultMethod = data === undefined ? 'GET' : 'POST';
   const result = await fetch(path + query, {
     method: method ?? defaultMethod,
@@ -208,7 +206,6 @@ export function useAPIFetch<T = unknown>(
   // something simpler, as long as it encodes the same information. The auth
   // token is not included in the key, as we assume currently that it does not
   // change the result.
-  const queryString = recordToSearchParams(params ?? {}).toString();
-  const paramStr = queryString.length > 0 ? `?${queryString}` : '';
+  const paramStr = recordToQueryString(params ?? {});
   return useFetch(path ? `${path}${paramStr}` : null, fetcher);
 }

--- a/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
@@ -1,0 +1,56 @@
+import { useCallback, useMemo } from 'preact/hooks';
+import { useLocation, useSearch } from 'wouter-preact';
+
+import { queryStringToRecord, recordToQueryString } from '../url';
+
+export type DashboardFilters = {
+  studentIds: string[];
+  assignmentIds: string[];
+  courseIds: string[];
+};
+
+export type UseDashboardFilters = {
+  filters: DashboardFilters;
+  updateFilters: (filtersToUpdate: Partial<DashboardFilters>) => void;
+};
+
+/**
+ * Hook used to read and update the state of the dashboard filters.
+ *
+ * The filter state is synchronized with query string parameters in the URL.
+ */
+export function useDashboardFilters(): UseDashboardFilters {
+  const search = useSearch();
+  const queryParams = useMemo(() => queryStringToRecord(search), [search]);
+  const filters = useMemo(() => {
+    const { student_id = [], course_id = [], assignment_id = [] } = queryParams;
+    const courseIds = Array.isArray(course_id) ? course_id : [course_id];
+    const assignmentIds = Array.isArray(assignment_id)
+      ? assignment_id
+      : [assignment_id];
+    const studentIds = Array.isArray(student_id) ? student_id : [student_id];
+
+    return { courseIds, assignmentIds, studentIds };
+  }, [queryParams]);
+
+  const [, navigate] = useLocation();
+  const updateFilters = useCallback(
+    ({ courseIds, assignmentIds, studentIds }: Partial<DashboardFilters>) => {
+      const newQueryParams = { ...queryParams };
+      if (courseIds) {
+        newQueryParams.course_id = courseIds;
+      }
+      if (assignmentIds) {
+        newQueryParams.assignment_id = assignmentIds;
+      }
+      if (studentIds) {
+        newQueryParams.student_id = studentIds;
+      }
+
+      navigate(recordToQueryString(newQueryParams), { replace: true });
+    },
+    [navigate, queryParams],
+  );
+
+  return { filters, updateFilters };
+}

--- a/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
@@ -1,0 +1,152 @@
+import { mount } from 'enzyme';
+
+import { useDashboardFilters } from '../hooks';
+
+describe('useDashboardFilters', () => {
+  function FakeComponent() {
+    const { filters, updateFilters } = useDashboardFilters();
+
+    return (
+      <div>
+        <div data-testid="course-ids">{filters.courseIds.join(',')}</div>
+        <div data-testid="assignment-ids">
+          {filters.assignmentIds.join(',')}
+        </div>
+        <div data-testid="student-ids">{filters.studentIds.join(',')}</div>
+
+        <button
+          onClick={() => updateFilters({ courseIds: ['111', '222', '333'] })}
+          data-testid="update-courses"
+        >
+          Update courses
+        </button>
+        <button
+          onClick={() =>
+            updateFilters({ assignmentIds: ['123', '456', '789'] })
+          }
+          data-testid="update-assignments"
+        >
+          Update assignments
+        </button>
+        <button
+          onClick={() => updateFilters({ studentIds: ['abc', 'def'] })}
+          data-testid="update-students"
+        >
+          Update students
+        </button>
+      </div>
+    );
+  }
+
+  function setQueryString(queryString) {
+    history.replaceState(null, '', queryString);
+  }
+
+  beforeEach(() => {
+    // Reset query string
+    setQueryString('?');
+  });
+
+  function createComponent() {
+    return mount(<FakeComponent />);
+  }
+
+  function getCurrentCourses(wrapper) {
+    return wrapper.find('[data-testid="course-ids"]').text();
+  }
+
+  function getCurrentAssignments(wrapper) {
+    return wrapper.find('[data-testid="assignment-ids"]').text();
+  }
+
+  function getCurrentStudents(wrapper) {
+    return wrapper.find('[data-testid="student-ids"]').text();
+  }
+
+  [
+    {
+      initialQueryString: '?course_id=1&assignment_id=2',
+      expectedCourses: '1',
+      expectedAssignments: '2',
+      expectedStudents: '',
+    },
+    {
+      initialQueryString: '?course_id=1&course_id=2',
+      expectedCourses: '1,2',
+      expectedAssignments: '',
+      expectedStudents: '',
+    },
+    {
+      initialQueryString: '?student_id=abc&student_id=def&assignment_id=3',
+      expectedCourses: '',
+      expectedAssignments: '3',
+      expectedStudents: 'abc,def',
+    },
+    {
+      initialQueryString: '?student_id=abc',
+      expectedCourses: '',
+      expectedAssignments: '',
+      expectedStudents: 'abc',
+    },
+  ].forEach(
+    ({
+      initialQueryString,
+      expectedCourses,
+      expectedAssignments,
+      expectedStudents,
+    }) => {
+      it('reads params from the query', () => {
+        setQueryString(initialQueryString);
+
+        const wrapper = createComponent();
+
+        assert.equal(getCurrentCourses(wrapper), expectedCourses);
+        assert.equal(getCurrentAssignments(wrapper), expectedAssignments);
+        assert.equal(getCurrentStudents(wrapper), expectedStudents);
+      });
+    },
+  );
+
+  [
+    {
+      buttonId: 'update-courses',
+      getResult: getCurrentCourses,
+      expectedResult: '111,222,333',
+      expectedQueryString: '?course_id=111&course_id=222&course_id=333',
+    },
+    {
+      buttonId: 'update-assignments',
+      getResult: getCurrentAssignments,
+      expectedResult: '123,456,789',
+      expectedQueryString:
+        '?assignment_id=123&assignment_id=456&assignment_id=789',
+    },
+    {
+      buttonId: 'update-students',
+      getResult: getCurrentStudents,
+      expectedResult: 'abc,def',
+      expectedQueryString: '?student_id=abc&student_id=def',
+    },
+  ].forEach(({ buttonId, getResult, expectedResult, expectedQueryString }) => {
+    it('persists updated values in query string', () => {
+      const wrapper = createComponent();
+
+      wrapper.find(`[data-testid="${buttonId}"]`).simulate('click');
+
+      assert.equal(getResult(wrapper), expectedResult);
+      assert.equal(location.search, expectedQueryString);
+    });
+  });
+
+  it('preserves unknown query params', () => {
+    setQueryString('?foo=bar&something=else');
+
+    const wrapper = createComponent();
+    wrapper.find('[data-testid="update-courses"]').simulate('click');
+
+    assert.equal(
+      '?foo=bar&something=else&course_id=111&course_id=222&course_id=333',
+      location.search,
+    );
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/test/url-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/url-test.js
@@ -1,4 +1,9 @@
-import { recordToSearchParams, replaceURLParams } from '../url';
+import {
+  queryStringToRecord,
+  recordToQueryString,
+  recordToSearchParams,
+  replaceURLParams,
+} from '../url';
 
 describe('replaceURLParams', () => {
   it('should replace params in URLs', () => {
@@ -45,5 +50,55 @@ describe('recordToSearchParams', () => {
     });
 
     assert.equal(result.toString(), 'foo=bar&baz=1&baz=2&baz=3');
+  });
+});
+
+describe('recordToQueryString', () => {
+  [
+    {
+      params: {
+        foo: 'bar',
+        baz: ['1', '2', '3'],
+      },
+      expectedResult: '?foo=bar&baz=1&baz=2&baz=3',
+    },
+    {
+      params: {},
+      expectedResult: '',
+    },
+    {
+      params: { foo: [], bar: [] },
+      expectedResult: '',
+    },
+  ].forEach(({ params, expectedResult }) => {
+    it('parses provided record and appends entries', () => {
+      const result = recordToQueryString(params);
+      assert.equal(result, expectedResult);
+    });
+  });
+});
+
+describe('queryStringToRecord', () => {
+  [
+    {
+      queryString: '?foo=bar&baz=1&baz=2&baz=3',
+      expectedResult: {
+        foo: 'bar',
+        baz: ['1', '2', '3'],
+      },
+    },
+    {
+      queryString: '',
+      expectedResult: {},
+    },
+    {
+      queryString: '?',
+      expectedResult: {},
+    },
+  ].forEach(({ queryString, expectedResult }) => {
+    it('parses provided record and appends entries', () => {
+      const result = queryStringToRecord(queryString);
+      assert.deepEqual(result, expectedResult);
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/url.ts
+++ b/lms/static/scripts/frontend_apps/utils/url.ts
@@ -47,3 +47,43 @@ export function recordToSearchParams(
 
   return queryParams;
 }
+
+/**
+ * Converts a record into a query string.
+ * The result is prefixed with a question mark (`?`) if it's not empty.
+ *
+ * Examples:
+ *    {} -> ''
+ *    { foo: [] } -> ''
+ *    { foo: 'bar' } -> '?foo=bar'
+ *    { foo: 'bar', something: ['hello', 'world'] } -> '?foo=bar&something=hello&something=world'
+ */
+export function recordToQueryString(
+  params: Record<string, string | string[]>,
+): string {
+  const queryString = recordToSearchParams(params).toString();
+  return queryString.length > 0 ? `?${queryString}` : '';
+}
+
+/**
+ * Converts provided query string into a record.
+ * Parameters that appear more than once will be converted to an array.
+ */
+export function queryStringToRecord(
+  queryString: string,
+): Record<string, string | string[]> {
+  const queryParams = new URLSearchParams(queryString);
+  const params: Record<string, string | string[]> = {};
+
+  queryParams.forEach((value, name) => {
+    if (!params[name]) {
+      params[name] = value;
+    } else if (Array.isArray(params[name])) {
+      (params[name] as string[]).push(value);
+    } else {
+      params[name] = [params[name] as string, value];
+    }
+  });
+
+  return params;
+}


### PR DESCRIPTION
This PR adds a new  `useDashboardQueryFilters` hook that can be used together with `DashboardActivityFilters` to a) initialize selected filters based on query parameters on active page, and b) persist selected filters in the query string, so that they can be propagated or bookmarked.

One change needed to achieve this was that `DashboardActivityFilters` now only handles the IDs of selected elements, instead of the full objects.

https://github.com/user-attachments/assets/d0081269-ec1f-4d75-9172-e03da930ea49

> [!NOTE]  
> As of now, every filter change will replace the last history entry. We can change this later with `{ replace: false }`, which makes it internally call `history.pushState()` instead of `history.replaceState()`.

### Testing steps

1. Open the dashboard.
2. Navigate to "All courses".
3. Change filters and observe how they reflected in the query string.
4. Reload the page. Filters from the query string should be applied automatically.

### TODO

- [x] ~Make sure filters are applied when using back/forward navigation buttons~ We finally decided to replace history entries instead.
- [x] Add tests