### PR TITLE
Don't scope dashboard URLs and cookies to organizations

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -83,7 +83,7 @@ class DashboardRoutes(TypedDict):
 
     course_assignments_metrics: str
 
-    organization_courses: str
+    courses_metrics: str
 
     courses: str
     """Paginated endpoint to fetch courses"""

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -268,8 +268,8 @@ class JSConfig:
                         course_assignments_metrics=self._to_frontend_template(
                             "api.dashboard.course.assignments.metrics"
                         ),
-                        organization_courses=self._to_frontend_template(
-                            "api.dashboard.organizations.courses"
+                        courses_metrics=self._to_frontend_template(
+                            "api.dashboard.courses.metrics"
                         ),
                         courses=self._to_frontend_template("api.dashboard.courses"),
                         assignments=self._to_frontend_template(

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -247,37 +247,30 @@ def includeme(config):  # noqa: PLR0915
 
     config.add_route(
         "dashboard.assignment",
-        "/dashboard/organizations/{public_id}/assignments/{assignment_id}",
+        "/dashboard/assignments/{assignment_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
         "dashboard.course",
-        "/dashboard/organizations/{public_id}/courses/{course_id}",
+        "/dashboard/courses/{course_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
 
     config.add_route(
-        "dashboard.organization",
-        "/dashboard/organizations/{organization_public_id}",
-        factory="lms.resources.dashboard.DashboardResource",
+        "dashboard", "/dashboard", factory="lms.resources.dashboard.DashboardResource"
     )
 
+    config.add_route("api.dashboard.courses.metrics", "/api/dashboard/courses/metrics")
     config.add_route("api.dashboard.courses", "/api/dashboard/courses")
+    config.add_route("api.dashboard.course", r"/api/dashboard/courses/{course_id}")
 
     config.add_route(
-        "api.dashboard.organizations.courses",
-        "/api/dashboard/organizations/{organization_public_id}/courses",
+        "api.dashboard.assignment", r"/api/dashboard/assignments/{assignment_id}"
     )
-
-    config.add_route(
-        "api.dashboard.assignment", "/api/dashboard/assignments/{assignment_id}"
-    )
-    config.add_route("api.dashboard.course", "/api/dashboard/courses/{course_id}")
-
     config.add_route("api.dashboard.assignments", "/api/dashboard/assignments")
     config.add_route(
         "api.dashboard.course.assignments.metrics",
-        "/api/dashboard/courses/{course_id}/assignments/metrics",
+        r"/api/dashboard/courses/{course_id}/assignments/metrics",
     )
 
     config.add_route("api.dashboard.students", "/api/dashboard/students")

--- a/lms/security.py
+++ b/lms/security.py
@@ -152,7 +152,7 @@ class SecurityPolicy:
             # LTUser serialized in a from for non deep-linked assignment configuration
             return FormBearerTokenLTIUserPolicy()
 
-        if path.startswith("/dashboard/organizations/"):
+        if path.startswith("/dashboard"):
             return CookiesBearerTokenLTIUserPolicy()
 
         if path in {"/email/preferences", "/email/unsubscribe"}:

--- a/lms/security.py
+++ b/lms/security.py
@@ -103,7 +103,7 @@ class SecurityPolicy:
             # Routes that require the Google auth policy
             return LMSGoogleSecurityPolicy()
 
-        if path.startswith(("/dashboard/organization", "/api/dashboard")):
+        if path.startswith(("/dashboard", "/api/dashboard")):
             # For certain routes we only use the google policy in case it resulted
             # non empty identity.
             # This is useful for routes that can be used by admin pages users on top of

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,14 +1,17 @@
 import logging
+from typing import cast
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import BinaryExpression, Select, false, func, or_, select
 from sqlalchemy.orm import Session
 
 from lms.models import (
+    ApplicationInstance,
     Assignment,
     AssignmentGrouping,
     AssignmentMembership,
     Grouping,
     LTIRole,
+    Organization,
     RoleScope,
     RoleType,
     User,
@@ -218,31 +221,50 @@ class AssignmentService:
     def get_assignments(
         self,
         instructor_h_userid: str | None = None,
+        admin_organization_ids: list[int] | None = None,
         course_ids: list[int] | None = None,
         h_userids: list[str] | None = None,
     ) -> Select[tuple[Assignment]]:
         """Get a query to fetch assignments.
 
         :param instructor_h_userid: return only assignments where instructor_h_userid is an instructor.
+        :param admin_organization_ids: organizations where the current user is an admin.
         :param course_ids: only return assignments that belong to this course.
         :param h_userids: return only assignments where these users are members.
         """
 
         query = select(Assignment)
 
+        # Let's crate no op clauses by default to avoid having to check the presence of these filters
+        instructor_h_userid_clause = cast(BinaryExpression, false())
+        admin_organization_ids_clause = cast(BinaryExpression, false())
+
         if instructor_h_userid:
-            query = query.where(
-                Assignment.id.in_(
-                    select(AssignmentMembership.assignment_id)
-                    .join(User)
-                    .join(LTIRole)
-                    .where(
-                        User.h_userid == instructor_h_userid,
-                        LTIRole.scope == RoleScope.COURSE,
-                        LTIRole.type == RoleType.INSTRUCTOR,
-                    )
+            instructor_h_userid_clause = Assignment.id.in_(
+                select(AssignmentMembership.assignment_id)
+                .join(User)
+                .join(LTIRole)
+                .where(
+                    User.h_userid == instructor_h_userid,
+                    LTIRole.scope == RoleScope.COURSE,
+                    LTIRole.type == RoleType.INSTRUCTOR,
                 )
             )
+
+        if admin_organization_ids:
+            admin_organization_ids_clause = Assignment.id.in_(
+                select(Assignment.id)
+                .join(AssignmentGrouping)
+                .join(Grouping)
+                .join(ApplicationInstance)
+                .join(Organization)
+                .where(Organization.id.in_(admin_organization_ids))
+            )
+        # instructor_h_userid and admin_organization_ids are about access rather than filtering.
+        # we apply them both as an or to fetch assignments where the users is either an instructor or an admin
+        query = query.where(
+            or_(instructor_h_userid_clause, admin_organization_ids_clause)
+        )
 
         if h_userids:
             query = (

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -141,21 +141,21 @@ class CourseService:
 
     def get_courses(
         self,
+        organization_ids: list[int],
         instructor_h_userid: str | None = None,
-        organization: Organization | None = None,
         h_userids: list[str] | None = None,
         assignment_ids: list[str] | None = None,
     ) -> Select[tuple[Course]]:
         """Get a list of unique courses.
 
-        :param organization: organization the courses belong to.
+        :param organization_ids: organizations the courses belong to.
         :param instructor_h_userid: return only courses where instructor_h_userid is an instructor.
         :param h_userids: return only courses where these users are members.
         :param assignment_ids: return only the courses these assignments belong to.
         """
         courses_query = (
             self._search_query(
-                organization_ids=[organization.id] if organization else None,
+                organization_ids=organization_ids,
                 h_userids=h_userids,
                 limit=None,
             )

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -48,33 +48,8 @@ class DashboardService:
 
         return course
 
-    def get_request_organizations(self, request) -> list[Organization]:
-        """Get the relevant organizations for the current requests."""
-        organizations = []
-
-        # If we have an user, include the organization it belongs to
-        if request.lti_user:
-            lti_user_organization = request.lti_user.application_instance.organization
-
-            if not self._organization_service.is_member(
-                lti_user_organization, request.user
-            ):
-                raise HTTPUnauthorized()
-
-            organizations.append(lti_user_organization)
-
-        # Include any other organizations we are an admin in
-        admin_organizations = self.get_organizations_by_admin_email(
-            request.lti_user.email if request.lti_user else request.identity.userid
-        )
-        organizations.extend(admin_organizations)
-
-        if not organizations:
-            raise HTTPUnauthorized()
-
-        return organizations
-
     def get_organizations_by_admin_email(self, email: str) -> list[Organization]:
+        """Get a list of organizations where the user with email `email` is an admin in."""
         return self._db.scalars(
             select(Organization)
             .join(DashboardAdmin)

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -171,7 +171,7 @@ export type CourseWithMetrics = Course & {
 };
 
 /**
- * Response for `/api/dashboard/organizations/{organization_public_id}` call.
+ * Response for `/api/dashboard/course/metrics` call.
  */
 export type CoursesResponse = {
   courses: CourseWithMetrics[];

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,7 +41,7 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
-          <Route path="/dashboard/organizations/:organizationPublicId" nest>
+          <Route path="/dashboard" nest>
             <DashboardApp />
           </Route>
           <Route path="/email/preferences">

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -1,13 +1,12 @@
 import { Link } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
-import { Link as RouterLink, useParams } from 'wouter-preact';
+import { Link as RouterLink } from 'wouter-preact';
 
 import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { useDocumentTitle } from '../../utils/hooks';
-import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
 import OrderableActivityTable from './OrderableActivityTable';
@@ -27,25 +26,17 @@ const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
 export default function OrganizationActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
-  const { organizationPublicId } = useParams<{
-    organizationPublicId: string;
-  }>();
 
   useDocumentTitle('All courses');
 
   const { filters, updateFilters } = useDashboardFilters();
   const { courseIds, assignmentIds, studentIds } = filters;
 
-  const courses = useAPIFetch<CoursesResponse>(
-    replaceURLParams(routes.organization_courses, {
-      organization_public_id: organizationPublicId,
-    }),
-    {
-      h_userid: studentIds,
-      assignment_id: assignmentIds,
-      course_id: courseIds,
-    },
-  );
+  const courses = useAPIFetch<CoursesResponse>(routes.courses_metrics, {
+    h_userid: studentIds,
+    assignment_id: assignmentIds,
+    course_id: courseIds,
+  });
   const rows: CoursesTableRow[] = useMemo(
     () =>
       courses.data?.courses.map(({ id, title, course_metrics }) => ({

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -44,8 +44,7 @@ describe('OrganizationActivity', () => {
     fakeConfig = {
       dashboard: {
         routes: {
-          organization_courses:
-            '/api/dashboard/organizations/:organization_public_id',
+          courses_metrics: '/api/courses/metrics',
         },
       },
     };

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -260,7 +260,7 @@ export type DashboardRoutes = {
   course_assignments_metrics: string;
 
   /** Fetch courses stats */
-  organization_courses: string;
+  courses_metrics: string;
 
   /** Fetch list of courses */
   courses: string;

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -52,11 +52,7 @@ class AdminAssignmentViews:
 
         response = HTTPFound(
             location=self.request.route_url(
-                "dashboard.assignment",
-                public_id=assignment.groupings[
-                    0
-                ].application_instance.organization.public_id,  # type: ignore
-                assignment_id=assignment.id,
+                "dashboard.assignment", assignment_id=assignment.id
             ),
         )
         return response

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -44,6 +44,10 @@ class CourseViews:
         self.dashboard_service = request.find_service(name="dashboard")
         self.assignment_service = request.find_service(name="assignment")
 
+        self.current_user_email = (
+            self.request.lti_user.email if request.lti_user else request.identity.userid
+        )
+
     @view_config(
         route_name="api.dashboard.courses",
         request_method="GET",
@@ -54,11 +58,11 @@ class CourseViews:
     def courses(self) -> APICourses:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
-
-        organizations = self.dashboard_service.get_request_organizations(self.request)
-
+        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
+            self.current_user_email
+        )
         courses = self.course_service.get_courses(
-            organization_ids=[org.id for org in organizations],
+            admin_organization_ids=[org.id for org in admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -86,9 +90,11 @@ class CourseViews:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
         filter_by_course_ids = self.request.parsed_params.get("course_ids")
-        organizations = self.dashboard_service.get_request_organizations(self.request)
+        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
+            self.current_user_email
+        )
         courses_query = self.course_service.get_courses(
-            organization_ids=[org.id for org in organizations],
+            admin_organization_ids=[org.id for org in admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -44,8 +44,10 @@ class CourseViews:
         self.dashboard_service = request.find_service(name="dashboard")
         self.assignment_service = request.find_service(name="assignment")
 
-        self.current_user_email = (
-            self.request.lti_user.email if request.lti_user else request.identity.userid
+        self.admin_organizations = (
+            self.dashboard_service.get_organizations_by_admin_email(
+                request.lti_user.email if request.lti_user else request.identity.userid
+            )
         )
 
     @view_config(
@@ -58,11 +60,8 @@ class CourseViews:
     def courses(self) -> APICourses:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
-        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
-            self.current_user_email
-        )
         courses = self.course_service.get_courses(
-            admin_organization_ids=[org.id for org in admin_organizations],
+            admin_organization_ids=[org.id for org in self.admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -90,11 +89,8 @@ class CourseViews:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
         filter_by_course_ids = self.request.parsed_params.get("course_ids")
-        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
-            self.current_user_email
-        )
         courses_query = self.course_service.get_courses(
-            admin_organization_ids=[org.id for org in admin_organizations],
+            admin_organization_ids=[org.id for org in self.admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -132,7 +128,9 @@ class CourseViews:
         permission=Permissions.DASHBOARD_VIEW,
     )
     def course(self) -> APICourse:
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.admin_organizations
+        )
         return {
             "id": course.id,
             "title": course.lms_name,

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -55,7 +55,10 @@ class CourseViews:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
 
+        organizations = self.dashboard_service.get_request_organizations(self.request)
+
         courses = self.course_service.get_courses(
+            organization_ids=[org.id for org in organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -73,19 +76,19 @@ class CourseViews:
         }
 
     @view_config(
-        route_name="api.dashboard.organizations.courses",
+        route_name="api.dashboard.courses.metrics",
         request_method="GET",
         renderer="json",
         permission=Permissions.DASHBOARD_VIEW,
         schema=CoursesMetricsSchema,
     )
-    def organization_courses(self) -> APICourses:
+    def courses_metrics(self) -> APICourses:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
         filter_by_course_ids = self.request.parsed_params.get("course_ids")
-        org = self.dashboard_service.get_request_organization(self.request)
+        organizations = self.dashboard_service.get_request_organizations(self.request)
         courses_query = self.course_service.get_courses(
-            organization=org,
+            organization_ids=[org.id for org in organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -103,8 +103,6 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        # Just get the org for the side effect of checking permissions.
-        _ = self.dashboard_service.get_request_organizations(self.request)
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         # Org names are not 100% ready for public consumption, let's hardcode a title for now.

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -40,6 +40,12 @@ class DashboardViews:
         )
         self.dashboard_service = request.find_service(name="dashboard")
 
+        self.admin_organizations = (
+            self.dashboard_service.get_organizations_by_admin_email(
+                request.lti_user.email if request.lti_user else request.identity.userid
+            )
+        )
+
     @view_config(
         route_name="dashboard.launch.assignment",
         permission=Permissions.DASHBOARD_VIEW,
@@ -71,7 +77,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.admin_organizations
+        )
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": assignment.title}
@@ -87,7 +95,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.admin_organizations
+        )
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": course.lms_name}

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,6 +18,7 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
+from tests.factories.dashboard_admin import DashboardAdmin
 from tests.factories.event import Event
 from tests.factories.file import File
 from tests.factories.grading_info import GradingInfo

--- a/tests/factories/dashboard_admin.py
+++ b/tests/factories/dashboard_admin.py
@@ -1,0 +1,9 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+DashboardAdmin = make_factory(
+    models.DashboardAdmin,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+)

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -706,7 +706,7 @@ class TestEnableDashboardMode:
                 "students_metrics": "/api/dashboard/students/metrics",
                 "course": "/api/dashboard/courses/:course_id",
                 "course_assignments_metrics": "/api/dashboard/courses/:course_id/assignments/metrics",
-                "organization_courses": "/api/dashboard/organizations/:organization_public_id/courses",
+                "courses_metrics": "/api/dashboard/courses/metrics",
                 "courses": "/api/dashboard/courses",
                 "assignments": "/api/dashboard/assignments",
                 "students": "/api/dashboard/students",

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -260,12 +260,13 @@ class TestAssignmentService:
         db_session,
         instructor_h_userid,
         assignment,
-        with_assignment_noise,
         course_ids,
         h_userids,
+        organization,
+        application_instance,
     ):
         factories.User()
-        course = factories.Course()
+        course = factories.Course(application_instance=application_instance)
         user = factories.User()
         lti_role = factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.INSTRUCTOR)
         factories.AssignmentMembership.create(
@@ -281,26 +282,23 @@ class TestAssignmentService:
 
         if instructor_h_userid:
             query_parameters["instructor_h_userid"] = user.h_userid
+        else:
+            query_parameters["admin_organization_ids"] = [organization.id]
 
         if course_ids:
             query_parameters["course_ids"] = [course.id]
 
         if h_userids:
             query_parameters["h_userids"] = [user.h_userid]
-
         query = svc.get_assignments(**query_parameters)
 
-        if not query_parameters:
-            assert set(db_session.scalars(query).all()) == set(
-                [assignment] + with_assignment_noise
-            )
+        assert db_session.scalars(query).all() == [assignment]
 
-        else:
-            assert db_session.scalars(query).all() == [assignment]
-
-    def test_get_assignments_by_course_id_with_duplicate(self, db_session, svc):
-        course = factories.Course()
-        other_course = factories.Course()
+    def test_get_assignments_by_course_id_with_duplicate(
+        self, db_session, svc, application_instance, organization
+    ):
+        course = factories.Course(application_instance=application_instance)
+        other_course = factories.Course(application_instance=application_instance)
 
         assignment = factories.Assignment()
 
@@ -314,11 +312,15 @@ class TestAssignmentService:
         db_session.flush()
 
         assert db_session.scalars(
-            svc.get_assignments(course_ids=[course.id])
+            svc.get_assignments(
+                course_ids=[course.id], admin_organization_ids=[organization.id]
+            )
         ).all() == [assignment]
         # We don't expect to get the other one at all, now the assignment belongs to the most recent course
         assert not db_session.scalars(
-            svc.get_assignments(course_ids=[other_course.id])
+            svc.get_assignments(
+                course_ids=[other_course.id], admin_organization_ids=[organization.id]
+            )
         ).all()
 
     def test_get_courses_assignments_count(self, svc, db_session):

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -29,13 +29,7 @@ class TestAdminAssignmentViews:
             views.show()
 
     def test_assignment_dashboard(
-        self,
-        pyramid_request,
-        assignment_service,
-        views,
-        AuditTrailEvent,
-        assignment,
-        organization,
+        self, pyramid_request, assignment_service, views, AuditTrailEvent, assignment
     ):
         pyramid_request.matchdict["id_"] = sentinel.id
         assignment_service.get_by_id.return_value = assignment
@@ -57,7 +51,7 @@ class TestAdminAssignmentViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/organizations/{organization.public_id}/assignments/{assignment.id}",
+                "location": f"http://example.com/dashboard/assignments/{assignment.id}",
             }
         )
 

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -31,13 +31,7 @@ class TestAdminCourseViews:
             views.show()
 
     def test_course_dashboard(
-        self,
-        pyramid_request,
-        course_service,
-        views,
-        AuditTrailEvent,
-        organization,
-        course,
+        self, pyramid_request, course_service, views, AuditTrailEvent, course
     ):
         pyramid_request.matchdict["id_"] = sentinel.id
         course_service.get_by_id.return_value = course
@@ -59,7 +53,7 @@ class TestAdminCourseViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/organizations/{organization.public_id}/courses/{course.id}",
+                "location": f"http://example.com/dashboard/courses/{course.id}",
             }
         )
 

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -29,6 +29,7 @@ class TestAssignmentViews:
             instructor_h_userid=pyramid_request.user.h_userid,
             course_ids=sentinel.course_ids,
             h_userids=sentinel.h_userids,
+            admin_organization_ids=[],
         )
         get_page.assert_called_once_with(
             pyramid_request,
@@ -50,7 +51,8 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
 
         assert response == {
@@ -97,6 +99,7 @@ class TestAssignmentViews:
             role_type=RoleType.LEARNER,
             instructor_h_userid=pyramid_request.user.h_userid,
             h_userids=sentinel.h_userids,
+            admin_organization_ids=[],
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [course.authority_provided_id, section.authority_provided_id],

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -27,12 +27,12 @@ class TestCourseViews:
             "h_userids": sentinel.h_userids,
             "assignment_ids": sentinel.assignment_ids,
         }
-        dashboard_service.get_request_organizations.return_value = [org]
+        dashboard_service.get_organizations_by_admin_email.return_value = [org]
 
         response = views.courses()
 
         course_service.get_courses.assert_called_once_with(
-            organization_ids=[org.id],
+            admin_organization_ids=[org.id],
             instructor_h_userid=pyramid_request.user.h_userid,
             h_userids=sentinel.h_userids,
             assignment_ids=sentinel.assignment_ids,
@@ -58,7 +58,6 @@ class TestCourseViews:
     ):
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
-        dashboard_service.get_request_organizations.return_value = [org]
         course_service.get_courses.return_value = select(Course).order_by(Course.id)
         pyramid_request.matchdict["organization_public_id"] = sentinel.public_id
         pyramid_request.parsed_params = {
@@ -66,14 +65,12 @@ class TestCourseViews:
             "assignment_ids": sentinel.assignment_ids,
         }
         db_session.flush()
+        dashboard_service.get_organizations_by_admin_email.return_value = [org]
 
         response = views.courses_metrics()
 
-        dashboard_service.get_request_organizations.assert_called_once_with(
-            pyramid_request
-        )
         course_service.get_courses.assert_called_once_with(
-            organization_ids=[org.id],
+            admin_organization_ids=[org.id],
             instructor_h_userid=pyramid_request.user.h_userid,
             h_userids=sentinel.h_userids,
             assignment_ids=sentinel.assignment_ids,
@@ -107,19 +104,16 @@ class TestCourseViews:
     ):
         org = factories.Organization()
         courses = factories.Course.create_batch(5)
-        dashboard_service.get_request_organizations.return_value = [org]
         course_service.get_courses.return_value = select(Course).order_by(Course.id)
         pyramid_request.matchdict["organization_public_id"] = sentinel.public_id
+        dashboard_service.get_organizations_by_admin_email.return_value = [org]
         db_session.flush()
         pyramid_request.parsed_params = {"course_ids": [courses[0].id]}
 
         response = views.courses_metrics()
 
-        dashboard_service.get_request_organizations.assert_called_once_with(
-            pyramid_request
-        )
         course_service.get_courses.assert_called_once_with(
-            organization_ids=[org.id],
+            admin_organization_ids=[org.id],
             instructor_h_userid=pyramid_request.user.h_userid,
             h_userids=None,
             assignment_ids=None,

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -28,6 +28,7 @@ class TestUserViews:
             role_scope=RoleScope.COURSE,
             role_type=RoleType.LEARNER,
             instructor_h_userid=pyramid_request.user.h_userid,
+            admin_organization_ids=[],
             course_ids=sentinel.course_ids,
             assignment_ids=sentinel.assignment_ids,
         )
@@ -94,7 +95,8 @@ class TestUserViews:
         response = views.students_metrics()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -49,7 +49,8 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
@@ -67,7 +68,10 @@ class TestDashboardViews:
 
         views.course_show()
 
-        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
+        dashboard_service.get_request_course.assert_called_once_with(
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
+        )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
@@ -101,7 +105,8 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
 

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures(
 class TestDashboardViews:
     @freeze_time("2024-04-01 12:00:00")
     def test_assignment_redirect_from_launch(
-        self, views, pyramid_request, BearerTokenSchema, organization
+        self, views, pyramid_request, BearerTokenSchema
     ):
         pyramid_request.matchdict["assignment_id"] = sentinel.id
 
@@ -31,24 +31,16 @@ class TestDashboardViews:
             pyramid_request.lti_user
         )
         assert response == Any.instance_of(HTTPFound).with_attrs(
-            {
-                "location": f"http://example.com/dashboard/organizations/{organization.public_id}/assignments/sentinel.id",
-            }
+            {"location": "http://example.com/dashboard/assignments/sentinel.id"}
         )
         assert (
             response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization.public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == "authorization=TOKEN; Max-Age=86400; Path=/dashboard; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     @freeze_time("2024-04-01 12:00:00")
     @pytest.mark.usefixtures("BearerTokenSchema")
-    def test_assignment_show(
-        self,
-        views,
-        pyramid_request,
-        organization,
-        dashboard_service,
-    ):
+    def test_assignment_show(self, views, pyramid_request, dashboard_service):
         context = DashboardResource(pyramid_request)
         context.js_config = create_autospec(JSConfig, spec_set=True, instance=True)
         pyramid_request.context = context
@@ -62,12 +54,12 @@ class TestDashboardViews:
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization.public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == "authorization=TOKEN; Max-Age=86400; Path=/dashboard; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     @freeze_time("2024-04-01 12:00:00")
     @pytest.mark.usefixtures("BearerTokenSchema")
-    def test_course_show(self, views, pyramid_request, organization, dashboard_service):
+    def test_course_show(self, views, pyramid_request, dashboard_service):
         context = DashboardResource(pyramid_request)
         context.js_config = create_autospec(JSConfig, spec_set=True, instance=True)
         pyramid_request.context = context
@@ -79,27 +71,25 @@ class TestDashboardViews:
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization.public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == "authorization=TOKEN; Max-Age=86400; Path=/dashboard; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     @freeze_time("2024-04-01 12:00:00")
     @pytest.mark.usefixtures("BearerTokenSchema")
-    def test_organization_show(
-        self, views, pyramid_request, organization, dashboard_service
-    ):
+    def test_organization_show(self, views, pyramid_request, dashboard_service):
         context = DashboardResource(pyramid_request)
         context.js_config = create_autospec(JSConfig, spec_set=True, instance=True)
         pyramid_request.context = context
 
-        views.organization_show()
+        views.courses()
 
-        dashboard_service.get_request_organization.assert_called_once_with(
+        dashboard_service.get_request_organizations.assert_called_once_with(
             pyramid_request
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
-            == f"authorization=TOKEN; Max-Age=86400; Path=/dashboard/organizations/{organization.public_id}; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
+            == "authorization=TOKEN; Max-Age=86400; Path=/dashboard; expires=Tue, 02-Apr-2024 12:00:00 GMT; secure; HttpOnly"
         )
 
     def test_assignment_show_with_no_lti_user(

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -76,16 +76,13 @@ class TestDashboardViews:
 
     @freeze_time("2024-04-01 12:00:00")
     @pytest.mark.usefixtures("BearerTokenSchema")
-    def test_organization_show(self, views, pyramid_request, dashboard_service):
+    def test_organization_show(self, views, pyramid_request):
         context = DashboardResource(pyramid_request)
         context.js_config = create_autospec(JSConfig, spec_set=True, instance=True)
         pyramid_request.context = context
 
         views.courses()
 
-        dashboard_service.get_request_organizations.assert_called_once_with(
-            pyramid_request
-        )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]


### PR DESCRIPTION
We are trying to accomplish two things at the same time:

- Stop scoping URLs and cookies to one organization
- Start considering "DashboardAdmins" for permissions.

We can't completely separate the two so this PR tries to move in that direction without creating a huge PR.

This PR then:
- Scopes cookies to /dashboard* URLs
- Changes URLs that included the organization public ID to remove it.
- Home / All courses now displays courses from organization you are an admin in & all the ones you are an instructor in.
- As we no longer scope "all courses" to "all of this organization courses" we don't want to display all courses for staff members. Staff members don't have privileges on the "all courses" view.  They need to add an explicit dashboard admin to the orgs they are interested in. We could in the future special case this for staff members so they don't need to that but also don't get into a situation where we try to list all courses in the DB. T


For follow up PRs:

- Include all children organizations when filtering by organizations.
- Apply the dashboard admin concept to assignment and student view. Currently 


## Testing



As a teacher and admin

-Login into canvas as: [eng+canvasteacher2@hypothes.is](mailto:eng+canvasteacher2@hypothes.is)
-Launch https://hypothesis.instructure.com/courses/125/assignments/873 and access the dashboard from there
-You should be able to see the list of students of that assignment, the assignment in the course and the course in "All courses".
-Include eng+canvasteacher2@hypothes.is as an admin the relevant organization, eg: http://localhost:8001/admin/orgs/1/dashboard-admins
-Refresh the all courses view, you should see now all courses on that org.
-Accessing the new courses/assignments won't work yet as an admin. Will tackle that on a PR focused on that.
-Listing all assignments in the course won't work either (you'll only see the one you launched). Also for a separate PR.

As staff

-Find the same assignment in the admin pages and launch the dashboard.
-You should be able to open it, go back to the parent course.
-Go all the way to the top, to "All courses". You'll get an empty list of courses.
-Add yourself, your google email address, to the org admins. The course list will include all the ones from that org.

