### PR TITLE
Prefix course titles in dashboard's course section

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -37,6 +37,7 @@ export default function CourseActivity() {
     }),
   );
 
+  const title = `Course: ${course.data?.title}`;
   const rows: AssignmentsTableRow[] = useMemo(
     () =>
       (assignments.data?.assignments ?? []).map(
@@ -60,12 +61,12 @@ export default function CourseActivity() {
         <h2 className="text-lg text-brand font-semibold" data-testid="title">
           {course.isLoading && 'Loading...'}
           {course.error && 'Could not load course title'}
-          {course.data && course.data.title}
+          {course.data && title}
         </h2>
       </div>
       <OrderableActivityTable
         loading={assignments.isLoading}
-        title={course.data?.title ?? 'Loading...'}
+        title={course.isLoading ? 'Loading...' : title}
         emptyMessage={
           assignments.error
             ? 'Could not load assignments'

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -105,7 +105,7 @@ describe('CourseActivity', () => {
     const wrapper = createComponent();
     const titleElement = wrapper.find('[data-testid="title"]');
     const tableElement = wrapper.find('OrderableActivityTable');
-    const expectedTitle = 'The title';
+    const expectedTitle = 'Course: The title';
 
     assert.equal(titleElement.text(), expectedTitle);
     assert.equal(tableElement.prop('title'), expectedTitle);


### PR DESCRIPTION
The dashboard's assignment section displays assignment titles prefixed with `Assignment: `.

This PR changes courses section to do the same with course titles, making it more clear that we are displaying information relative to a course.

Before:

![image](https://github.com/user-attachments/assets/2c5e3a21-c2fa-4e80-ae63-607fbd648973)

After:

![image](https://github.com/user-attachments/assets/15725615-13f0-4887-9958-eacc97d75ba5)
