### PR TITLE
Make sure dashboard page titles update when navigating

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'wouter-preact';
 import type { AssignmentWithMetrics, StudentsResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
@@ -43,6 +44,8 @@ export default function AssignmentActivity() {
       ),
     [students.data],
   );
+
+  useDocumentTitle(assignment.data?.title ?? 'Untitled assignment');
 
   return (
     <div className="flex flex-col gap-y-5">

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -5,6 +5,7 @@ import { Link as RouterLink, useParams } from 'wouter-preact';
 import type { AssignmentsResponse, Course } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
@@ -47,6 +48,8 @@ export default function CourseActivity() {
       ),
     [assignments.data],
   );
+
+  useDocumentTitle(course.data?.title ?? 'Untitled course');
 
   return (
     <div className="flex flex-col gap-y-5">

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 import { Link as RouterLink, Route, Switch } from 'wouter-preact';
 
 import { useConfig } from '../../config';
+import { usePlaceholderDocumentTitleInDev } from '../../utils/hooks';
 import AssignmentActivity from './AssignmentActivity';
 import CourseActivity from './CourseActivity';
 import DashboardFooter from './DashboardFooter';
@@ -15,6 +16,8 @@ import OrganizationActivity from './OrganizationActivity';
 
 export default function DashboardApp() {
   const { dashboard } = useConfig(['dashboard']);
+
+  usePlaceholderDocumentTitleInDev();
 
   return (
     <div className="flex flex-col min-h-screen gap-5">

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
+import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
@@ -33,6 +34,8 @@ export default function OrganizationActivity() {
   const { organizationPublicId } = useParams<{
     organizationPublicId: string;
   }>();
+
+  useDocumentTitle('All courses');
 
   const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
   const [selectedAssignments, setSelectedAssignments] = useState<Assignment[]>(

--- a/lms/static/scripts/frontend_apps/types.d.ts
+++ b/lms/static/scripts/frontend_apps/types.d.ts
@@ -1,3 +1,5 @@
+import 'navigation-api-types';
+
 export {};
 
 declare global {

--- a/lms/static/scripts/frontend_apps/utils/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 // Global counter used to create a unique ids
 let idCounter = 0;
@@ -13,4 +13,42 @@ export function useUniqueId(prefix: string): string {
     return idCounter;
   });
   return `${prefix}${localId}`;
+}
+
+/**
+ * Set the document title.
+ *
+ * This must only be called by one component in any page. If multiple
+ * components set the title, whichever runs last will take effect.
+ */
+export function useDocumentTitle(documentTitle: string) {
+  useEffect(() => {
+    document.title = `${documentTitle} - Hypothesis`;
+  }, [documentTitle]);
+}
+
+/**
+ * In development environments, set a placeholder document title at the start
+ * of a navigation.
+ *
+ * Navigations are detected using the `navigate` event of the Navigation API.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API
+ *
+ * This placeholder makes it more obvious when a route fails to set a
+ * route-specific document title using {@link useDocumentTitle}.
+ */
+export function usePlaceholderDocumentTitleInDev() {
+  // istanbul ignore next - not used in prod, so we don't need to test it
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production' || !window.navigation) {
+      return () => {};
+    }
+
+    const listener = () => {
+      document.title = 'PLACEHOLDER DOCUMENT TITLE';
+    };
+    window.navigation.addEventListener('navigate', listener);
+
+    return () => window.navigation?.removeEventListener('navigate', listener);
+  }, []);
 }

--- a/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/hooks-test.js
@@ -1,8 +1,9 @@
+import { mount } from 'enzyme';
 import { render } from 'preact';
 
-import { useUniqueId } from '../hooks';
+import { useUniqueId, useDocumentTitle } from '../hooks';
 
-describe('hooks', () => {
+describe('useUniqueId', () => {
   it('generates unique ids each time useUniqueId is called', () => {
     let id1;
     let id2;
@@ -19,5 +20,31 @@ describe('hooks', () => {
     assert.isTrue(id1.startsWith('prefix:'));
     assert.isTrue(id2.startsWith('prefix:'));
     assert.notEqual(id1, id2);
+  });
+});
+
+describe('useDocumentTitle', () => {
+  let initialDocTitle;
+
+  beforeEach(() => {
+    initialDocTitle = document.title;
+  });
+
+  afterEach(() => {
+    // Reset document title back to its initial state to avoid affecting other
+    // tests
+    document.title = initialDocTitle;
+  });
+
+  function FakeComponent({ documentTitle }) {
+    useDocumentTitle(documentTitle);
+    return <div />;
+  }
+
+  ['foo bar', 'something', 'hello world'].forEach(documentTitle => {
+    it('updates document title', () => {
+      mount(<FakeComponent documentTitle={documentTitle} />);
+      assert.equal(document.title, `${documentTitle} - Hypothesis`);
+    });
   });
 });

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -110,12 +110,12 @@ class DashboardViews:
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         # Org names are not 100% ready for public consumption, let's hardcode a title for now.
-        return {"title": "Courses - Hypothesis"}
+        return {"title": "All courses"}
 
     def _set_lti_user_cookie(self, response):
         lti_user = self.request.lti_user
         if not lti_user:
-            # An LTIUser might not exists if accessing from the admin pages.
+            # An LTIUser might not exist if accessing from the admin pages.
             return response
         auth_token = (
             BearerTokenSchema(self.request)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "karma-sinon": "^1.0.5",
     "karma-source-map-support": "^1.4.0",
     "mocha": "^10.2.0",
+    "navigation-api-types": "^0.5.1",
     "prettier": "3.2.5",
     "sinon": "^17.0.1",
     "typescript": "^5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7257,6 +7257,7 @@ __metadata:
     karma-sinon: ^1.0.5
     karma-source-map-support: ^1.4.0
     mocha: ^10.2.0
+    navigation-api-types: ^0.5.1
     normalize.css: ^8.0.1
     postcss: ^8.4.38
     preact: 10.19.6
@@ -7829,6 +7830,13 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
+  languageName: node
+  linkType: hard
+
+"navigation-api-types@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "navigation-api-types@npm:0.5.1"
+  checksum: 42783a2546e0af948c65f1c4a47effe8257e5155626ae42df8d06ad2b1f3404f7e32816edc09c0e8acefb723ea5a6f6314ab2ae84efc51e0e4f9a8d144cd4208
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #6458 

Add a new `useDocumentTitle` hook that sets `document.title`, and use it in all dashboard page/section components to ensure the page title is in sync with what's being displayed.

To make sure we don't forget calling it in future page components, this PR also adds a dev-env-only navigation listener which sets a placeholder page title right before navigation occurs.

### Testing steps

1. Open the dashboard.
2. Navigate to other sections and observe the page title gets updated.

Titles should be the same that the backend sets on initial server-side renders, but we could potentially get rid of the backend logic entirely.