### PR TITLE
Fix flaky organization model test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ disable = [
     "too-many-statements",
     "protected-access",
     "singleton-comparison",
+    "unnecessary-lambda-assignment",
 
     # Not supported by ruff
     "too-many-ancestors",

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -73,6 +73,7 @@ disable = [
     # Ported to ruff
     "unused-argument",
     "protected-access",
+    "unnecessary-lambda-assignment",
 ]
 
 # Just disable PyLint's name style checking for the tests, because we

--- a/tests/unit/lms/models/organization_test.py
+++ b/tests/unit/lms/models/organization_test.py
@@ -19,7 +19,10 @@ class TestOrganization:
     ):
         db_session.flush()
 
-        assert organization.application_instances == application_instances
+        by_id = lambda x: x.id  # noqa: E731
+        assert sorted(organization.application_instances, key=by_id) == sorted(
+            application_instances, key=by_id
+        )
         for application_instance in application_instances:
             assert application_instance.organization == organization
 


### PR DESCRIPTION
Compare sets instead of list to avoid any issues around ordering.


Failed here, I haven't seen it fail locally:


https://github.com/hypothesis/lms/actions/runs/10093618220/job/27909714767?pr=6467