### PR TITLE
Make sure process.env.NODE_ENV is stringified

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,8 +2,8 @@ import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
-import virtual from '@rollup/plugin-virtual';
 import terser from '@rollup/plugin-terser';
+import virtual from '@rollup/plugin-virtual';
 
 const isProd = process.env.NODE_ENV === 'production';
 const prodPlugins = [];
@@ -14,7 +14,7 @@ if (isProd) {
   prodPlugins.push(
     virtual({
       'preact/debug': '',
-    })
+    }),
   );
 }
 
@@ -38,7 +38,7 @@ function bundleConfig(name, entryFile) {
       replace({
         preventAssignment: true,
         values: {
-          'process.env.NODE_ENV': process.env.NODE_ENV,
+          'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         },
       }),
       babel({


### PR DESCRIPTION
We had some rollup config to replace `process.env.NODE_ENV` with their actual values, but incorrectly set to do it as a direct replacement.

That meant that if `NODE_ENV=production`, it would replace `process.env.NODE_ENV` by the literal value `production`, which is then treated as a variable, causing a `ReferenceError: production is not defined` error.

This PR fixes that by JSON-encoding the value of `process.env.NODE_ENV` before replacing it in code, as seen in the docs https://www.npmjs.com/package/@rollup/plugin-replace