### PR TITLE
Trim leading and trailing whitespace for assignment and course names

### DIFF
--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -69,7 +69,7 @@ class Assignment(CreatedUpdatedMixin, Base):
     )
     """Whether this assignment is gradable or not."""
 
-    title = sa.Column(sa.Unicode, nullable=True)
+    title: Mapped[str | None] = mapped_column(sa.Unicode)
     """The resource link title from LTI params."""
 
     description = sa.Column(sa.Unicode, nullable=True)

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -114,7 +114,7 @@ class Grouping(CreatedUpdatedMixin, Base):
     lms_id = sa.Column(sa.Unicode(), nullable=False)
 
     #: Full name given on the LMS (e.g. "A course name 101")
-    lms_name = sa.Column(sa.UnicodeText(), nullable=False)
+    lms_name: Mapped[str] = mapped_column(sa.UnicodeText())
 
     type = varchar_enum(Type, nullable=False)
 

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -62,8 +62,12 @@ class AssignmentService:
         assignment.extra["group_set_id"] = group_set_id
 
         # Metadata based on the launch
-        assignment.title = request.lti_params.get("resource_link_title")
-        assignment.description = request.lti_params.get("resource_link_description")
+        assignment.title = (
+            request.lti_params.get("resource_link_title", "").strip() or None
+        )
+        assignment.description = (
+            request.lti_params.get("resource_link_description", "") or None
+        )
         assignment.is_gradable = self._misc_plugin.is_assignment_gradable(
             request.lti_params
         )

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -70,7 +70,7 @@ class GroupingService:
                 "type": type_,
                 # Things the caller provides
                 "lms_id": grouping["lms_id"],
-                "lms_name": grouping["lms_name"],
+                "lms_name": grouping["lms_name"].strip(),
                 "extra": grouping.get("extra"),
                 "settings": grouping.get("settings"),
             }
@@ -229,7 +229,7 @@ class GroupingService:
             groupings = [
                 {
                     "lms_id": grouping["id"],
-                    "lms_name": grouping["name"],
+                    "lms_name": grouping["name"].strip(),
                     # This product specific stuff should really be removed
                     "extra": {
                         "group_set_id": grouping.get("group_set_id")  # Standard format

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -26,9 +26,20 @@ class TestAssignmentService:
         assert assignment in db_session.new
 
     @pytest.mark.parametrize("is_speed_grader", [False, True])
+    @pytest.mark.parametrize(
+        "resource_link_title, title",
+        [("", None), ("    ", None), (" title  ", "title")],
+    )
     def test_update_assignment(
-        self, svc, pyramid_request, is_speed_grader, misc_plugin
+        self,
+        svc,
+        pyramid_request,
+        is_speed_grader,
+        misc_plugin,
+        resource_link_title,
+        title,
     ):
+        pyramid_request.lti_params["resource_link_title"] = resource_link_title
         misc_plugin.is_speed_grader_launch.return_value = is_speed_grader
 
         assignment = svc.update_assignment(
@@ -38,6 +49,7 @@ class TestAssignmentService:
             sentinel.group_set_id,
         )
 
+        assignment.title = title
         if is_speed_grader:
             assert assignment.extra == {}
             assert assignment.document_url != sentinel.document_url

--- a/tests/unit/lms/services/grouping/service_test.py
+++ b/tests/unit/lms/services/grouping/service_test.py
@@ -149,7 +149,7 @@ class TestUpsertGroupings:
 
         attrs = {
             "lms_id": parent_course.lms_id,
-            "lms_name": "new_name",
+            "lms_name": " new_name ",
             "extra": {"updated": "extra"},
         }
 
@@ -160,7 +160,9 @@ class TestUpsertGroupings:
         # Load the changes we made in SQLAlchemy
         db_session.refresh(parent_course)
         assert courses == [parent_course]
-        assert parent_course == Any.object.with_attrs(attrs)
+        assert courses[0].lms_id == parent_course.lms_id
+        assert courses[0].lms_name == "new_name"
+        assert courses[0].extra == {"updated": "extra"}
 
     @pytest.fixture
     def parent_course(self, svc):
@@ -404,7 +406,7 @@ class TestGetGroupings:
         grouping_dicts = [
             {
                 "id": sentinel.id,
-                "name": sentinel.name,
+                "name": "   name   ",
                 "settings": sentinel.settings,
                 group_set_key: sentinel.group_set_id,
             },
@@ -418,7 +420,7 @@ class TestGetGroupings:
             [
                 {
                     "lms_id": sentinel.id,
-                    "lms_name": sentinel.name,
+                    "lms_name": "name",
                     "extra": {"group_set_id": sentinel.group_set_id},
                     "settings": sentinel.settings,
                 }


### PR DESCRIPTION
For assignments, for which we allow null names in the database we convert empty "" names to null.

As a next step will do a migration to change the names already in the DB.