### PR TITLE
Add filters to course activity section

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -6,6 +6,7 @@ import type { CoursesResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
+import { courseURL } from '../../utils/dashboard/navigation';
 import { useDocumentTitle } from '../../utils/hooks';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
@@ -17,8 +18,6 @@ type CoursesTableRow = {
   assignments: number;
   last_launched: string | null;
 };
-
-const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
 
 /**
  * List of courses that current user has access to in the dashboard

--- a/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
@@ -1,0 +1,9 @@
+import { urlPath } from '../api';
+
+export function assignmentURL(id: number) {
+  return urlPath`/assignments/${String(id)}`;
+}
+
+export function courseURL(id: number | string) {
+  return urlPath`/courses/${String(id)}`;
+}


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6505

Continuing with the work from https://github.com/hypothesis/lms/pull/6453, this PR adds filters to the course section.

The main difference here is that the courses dropdown starts with the "active" course (the one represented in the URL) pre-selected. Then, selecting a different course does not apply a filter to the activity table, as we are implicitly filtering by a single course. Instead, once a different course is selected, we navigate to that course and propagate the rest of the filters there.

Additionally, if "All courses" is selected, or the "active" course is deselected, we navigate to "All courses" with the assignments and students filters preserved.

This behavior might change in future, as the product decision is still under discussion. See https://github.com/hypothesis/lms/issues/6490

https://github.com/user-attachments/assets/704b3b1b-69e2-4f10-8ab1-1af36c1dafc1

### Testing steps

1. Go to the dashboards, and select one specific course.
2. Change selection in filters and verify it behaves as described above.

### To do/discuss

- [x] The courses dropdown behavior which "navigates" instead of "filter", presents a few cases that we need to discuss.
    * What to do when "All courses" is selected. We could navigate to the home page in that case.
    * What to do when the active course is clicked. The default multi-select behavior would be to de-select that course, which in this case is the same as selecting "all courses", so perhaps we could also navigate to the home page.
- [x] Selects manage references to objects in order to determine what options are selected. In this case we are passing a course object which deep-equals one from the list, but is a different reference, so it is not marked as selected. We could:
  * ~Refactor `Select` component to do deep-equal checks in order to determine if an option is selected.~
  * Slightly change the local logic so that we handle a list of IDs instead of a list of objects, which would require separately tracking the corresponding names. -> We are doing this as part of https://github.com/hypothesis/lms/pull/6466
- [x] Implement logic to initialize filters based on query parameters, so that we can navigate to other places and propagate filters. -> Being implemented in https://github.com/hypothesis/lms/pull/6466
- [x] "Clear filters" button should probably only clear assignments and students, but it is always visible because there's a course selected at all times.
- [x] Add tests.