### PR TITLE
Make dashboard selected filters affect each other

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -39,11 +39,21 @@ export default function DashboardActivityFilters({
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 
-  const courses = useAPIFetch<{ courses: Course[] }>(routes.courses);
+  const courses = useAPIFetch<{ courses: Course[] }>(routes.courses, {
+    h_userid: selectedStudentIds,
+    assignment_id: selectedAssignmentIds,
+  });
   const assignments = useAPIFetch<{ assignments: Assignment[] }>(
     routes.assignments,
+    {
+      h_userid: selectedStudentIds,
+      course_id: selectedCourseIds,
+    },
   );
-  const students = useAPIFetch<{ students: Student[] }>(routes.students);
+  const students = useAPIFetch<{ students: Student[] }>(routes.students, {
+    assignment_id: selectedAssignmentIds,
+    course_id: selectedCourseIds,
+  });
   const studentsWithName = useMemo(
     () => students.data?.students.filter(s => !!s.display_name),
     [students.data?.students],

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -245,9 +245,9 @@ describe('DashboardActivityFilters', () => {
 
     it('shows amount of selected items when more than one is selected', () => {
       const wrapper = createComponent({
-        selectedCourseIds: [...courses],
-        selectedAssignmentIds: [...assignments],
-        selectedStudentIds: [...studentsWithName],
+        selectedCourseIds: courses.map(c => `${c.id}`),
+        selectedAssignmentIds: assignments.map(a => `${a.id}`),
+        selectedStudentIds: studentsWithName.map(s => s.h_userid),
       });
 
       assert.equal(getSelectContent(wrapper, 'courses-select'), '2 courses');
@@ -256,6 +256,35 @@ describe('DashboardActivityFilters', () => {
         '2 assignments',
       );
       assert.equal(getSelectContent(wrapper, 'students-select'), '2 students');
+    });
+
+    it('filters each dropdown by the values selected in the other dropdowns', () => {
+      const selectedCourseIds = [`${courses[0].id}`];
+      const selectedAssignmentIds = [`${assignments[1].id}`];
+      const selectedStudentIds = studentsWithName.map(s => s.h_userid);
+
+      createComponent({
+        selectedCourseIds,
+        selectedAssignmentIds,
+        selectedStudentIds,
+      });
+
+      assert.calledWith(fakeUseAPIFetch.getCall(0), '/api/dashboard/courses', {
+        h_userid: selectedStudentIds,
+        assignment_id: selectedAssignmentIds,
+      });
+      assert.calledWith(
+        fakeUseAPIFetch.getCall(1),
+        '/api/dashboard/assignments',
+        {
+          h_userid: selectedStudentIds,
+          course_id: selectedCourseIds,
+        },
+      );
+      assert.calledWith(fakeUseAPIFetch.getCall(2), '/api/dashboard/students', {
+        assignment_id: selectedAssignmentIds,
+        course_id: selectedCourseIds,
+      });
     });
   });
 


### PR DESCRIPTION
With this PR we are ensuring selected filters in one dropdown affect the values displayed in the other dropdowns, regardless the order in which they are selected.

In the home page, when no filters are applied, we start displaying the full list of courses, assignments and students. As soon as a value is changed in any of those, the other two will reload and get filtered by the just selected value.

For example, if we select a student, we will only show courses and assignments that student is part of.

If, instead, we select a course, we will show only assignments and students that are part of that course, etc.

### Testing steps

To verify the params are being taken into consideration by the backend, apply this diff:

```diff
diff --git a/lms/views/dashboard/api/assignment.py b/lms/views/dashboard/api/assignment.py
index 7e3f12f7d..52444e826 100644
--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -64,6 +64,7 @@ class AssignmentViews:
             course_ids=self.request.parsed_params.get("course_ids"),
             h_userids=filter_by_h_userids,
         )
+        print(self.request.parsed_params)
         assignments, pagination = get_page(
             self.request, assignments, [Assignment.title, Assignment.id]
         )
diff --git a/lms/views/dashboard/api/course.py b/lms/views/dashboard/api/course.py
index 898ce85b4..fdbde6329 100644
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -54,6 +54,7 @@ class CourseViews:
     def courses(self) -> APICourses:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
+        print(self.request.parsed_params)
 
         courses = self.course_service.get_courses(
             instructor_h_userid=self.request.user.h_userid
diff --git a/lms/views/dashboard/api/user.py b/lms/views/dashboard/api/user.py
index efb012c74..5e1e5ad73 100644
--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -65,6 +65,7 @@ class UserViews:
             course_ids=self.request.parsed_params.get("course_ids"),
             assignment_ids=self.request.parsed_params.get("assignment_ids"),
         )
+        print(self.request.parsed_params)
         students, pagination = get_page(
             self.request, students_query, [User.display_name, User.id]
         )
```

Then, you should see the selected params printed ion the LMS service output.