### PR TITLE
Enforce dashboard admin access for assignments and users

### DIFF
--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -44,8 +44,10 @@ class CourseViews:
         self.dashboard_service = request.find_service(name="dashboard")
         self.assignment_service = request.find_service(name="assignment")
 
-        self.current_user_email = (
-            self.request.lti_user.email if request.lti_user else request.identity.userid
+        self.admin_organizations = (
+            self.dashboard_service.get_organizations_by_admin_email(
+                request.lti_user.email if request.lti_user else request.identity.userid
+            )
         )
 
     @view_config(
@@ -58,11 +60,8 @@ class CourseViews:
     def courses(self) -> APICourses:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
-        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
-            self.current_user_email
-        )
         courses = self.course_service.get_courses(
-            admin_organization_ids=[org.id for org in admin_organizations],
+            admin_organization_ids=[org.id for org in self.admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -90,11 +89,8 @@ class CourseViews:
         filter_by_h_userids = self.request.parsed_params.get("h_userids")
         filter_by_assignment_ids = self.request.parsed_params.get("assignment_ids")
         filter_by_course_ids = self.request.parsed_params.get("course_ids")
-        admin_organizations = self.dashboard_service.get_organizations_by_admin_email(
-            self.current_user_email
-        )
         courses_query = self.course_service.get_courses(
-            admin_organization_ids=[org.id for org in admin_organizations],
+            admin_organization_ids=[org.id for org in self.admin_organizations],
             instructor_h_userid=self.request.user.h_userid
             if self.request.user
             else None,
@@ -132,7 +128,9 @@ class CourseViews:
         permission=Permissions.DASHBOARD_VIEW,
     )
     def course(self) -> APICourse:
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.admin_organizations
+        )
         return {
             "id": course.id,
             "title": course.lms_name,

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -40,6 +40,12 @@ class DashboardViews:
         )
         self.dashboard_service = request.find_service(name="dashboard")
 
+        self.admin_organizations = (
+            self.dashboard_service.get_organizations_by_admin_email(
+                request.lti_user.email if request.lti_user else request.identity.userid
+            )
+        )
+
     @view_config(
         route_name="dashboard.launch.assignment",
         permission=Permissions.DASHBOARD_VIEW,
@@ -71,7 +77,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.admin_organizations
+        )
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": assignment.title}
@@ -87,7 +95,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.admin_organizations
+        )
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": course.lms_name}

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -29,6 +29,7 @@ class TestAssignmentViews:
             instructor_h_userid=pyramid_request.user.h_userid,
             course_ids=sentinel.course_ids,
             h_userids=sentinel.h_userids,
+            admin_organization_ids=[],
         )
         get_page.assert_called_once_with(
             pyramid_request,
@@ -50,7 +51,8 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
 
         assert response == {
@@ -97,6 +99,7 @@ class TestAssignmentViews:
             role_type=RoleType.LEARNER,
             instructor_h_userid=pyramid_request.user.h_userid,
             h_userids=sentinel.h_userids,
+            admin_organization_ids=[],
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [course.authority_provided_id, section.authority_provided_id],

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -28,6 +28,7 @@ class TestUserViews:
             role_scope=RoleScope.COURSE,
             role_type=RoleType.LEARNER,
             instructor_h_userid=pyramid_request.user.h_userid,
+            admin_organization_ids=[],
             course_ids=sentinel.course_ids,
             assignment_ids=sentinel.assignment_ids,
         )
@@ -94,7 +95,8 @@ class TestUserViews:
         response = views.students_metrics()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -49,7 +49,8 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
@@ -67,7 +68,10 @@ class TestDashboardViews:
 
         views.course_show()
 
-        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
+        dashboard_service.get_request_course.assert_called_once_with(
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
+        )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
@@ -101,7 +105,8 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request,
+            dashboard_service.get_organizations_by_admin_email.return_value,
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
 


### PR DESCRIPTION
Applies the same pattern as https://github.com/hypothesis/lms/pull/6467 to assignments and users

## Testing

## As a teacher and admin

- Login into canvas as: eng+canvasteacher2@hypothes.is
- Launch https://hypothesis.instructure.com/courses/125/assignments/873 and access the dashboard from there
- You should be able to see the list of students of that assignment, the assignment in the course and the course in "All courses".
- There will be just a few of each entity (unless you use eng+canvasteacher2@hypothes.is a lot for testing).
- Include `eng+canvasteacher2@hypothes.is` as an admin the relevant organization, eg: http://localhost:8001/admin/orgs/1/dashboard-admins
- Refresh the all courses view, you should see now all courses on that org.
- Access any of the new courses and any of the assignments.




