### PR TITLE
Keep current location when navigating in useDashboardFilters

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
@@ -33,7 +33,7 @@ export function useDashboardFilters(): UseDashboardFilters {
     return { courseIds, assignmentIds, studentIds };
   }, [queryParams]);
 
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
   const updateFilters = useCallback(
     ({ courseIds, assignmentIds, studentIds }: Partial<DashboardFilters>) => {
       const newQueryParams = { ...queryParams };
@@ -47,9 +47,16 @@ export function useDashboardFilters(): UseDashboardFilters {
         newQueryParams.student_id = studentIds;
       }
 
-      navigate(recordToQueryString(newQueryParams), { replace: true });
+      // The router's base URL is represented in `location` as '/', even if
+      // that URL does not actually end with `/` (eg. `/dashboard`).
+      // When we update the query string, we want to avoid modifying the path.
+      const normalizedLocation = location === '/' ? '' : location;
+
+      navigate(`${normalizedLocation}${recordToQueryString(newQueryParams)}`, {
+        replace: true,
+      });
     },
-    [navigate, queryParams],
+    [location, navigate, queryParams],
   );
 
   return { filters, updateFilters };

--- a/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
@@ -38,13 +38,13 @@ describe('useDashboardFilters', () => {
     );
   }
 
-  function setQueryString(queryString) {
+  function setCurrentURL(queryString) {
     history.replaceState(null, '', queryString);
   }
 
   beforeEach(() => {
     // Reset query string
-    setQueryString('?');
+    setCurrentURL('?');
   });
 
   function createComponent() {
@@ -96,7 +96,7 @@ describe('useDashboardFilters', () => {
       expectedStudents,
     }) => {
       it('reads params from the query', () => {
-        setQueryString(initialQueryString);
+        setCurrentURL(initialQueryString);
 
         const wrapper = createComponent();
 
@@ -139,7 +139,7 @@ describe('useDashboardFilters', () => {
   });
 
   it('preserves unknown query params', () => {
-    setQueryString('?foo=bar&something=else');
+    setCurrentURL('?foo=bar&something=else');
 
     const wrapper = createComponent();
     wrapper.find('[data-testid="update-courses"]').simulate('click');
@@ -148,5 +148,15 @@ describe('useDashboardFilters', () => {
       '?foo=bar&something=else&course_id=111&course_id=222&course_id=333',
       location.search,
     );
+  });
+
+  it('preserves path', () => {
+    setCurrentURL('/foo/bar');
+
+    const wrapper = createComponent();
+    wrapper.find('[data-testid="update-courses"]').simulate('click');
+
+    assert.equal('?course_id=111&course_id=222&course_id=333', location.search);
+    assert.equal('/foo/bar', location.pathname);
   });
 });


### PR DESCRIPTION
Fix an issue when using `useDashboardFilters` in a non-base URL.

I assumed `navigate(...)` would keep current path when only a query string was provided (as in `navigate('?foo=bar')`), but while working on assignment and course sections filters, I realized this is not the case.

Instead, that takes you back to the base URL, with that query string, as if `navigate('/?foo=bar')` would have been used instead.

This PR ensures current `location` is preserved when calling `navigate`, and only the query string is changed. 