### PR TITLE
Trim whitespace of existing assignment and grouping titles

### DIFF
--- a/lms/migrations/versions/e5a9845d55d7_clean_grouping_and_assignment_titles.py
+++ b/lms/migrations/versions/e5a9845d55d7_clean_grouping_and_assignment_titles.py
@@ -1,0 +1,49 @@
+"""Clean grouping and assignment titles.
+
+Revision ID: e5a9845d55d7
+Revises: f8ff7e49cbbf
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e5a9845d55d7"
+down_revision = "f8ff7e49cbbf"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+        UPDATE assignment SET title = TRIM(title)
+        WHERE TRIM(title) != title;
+    """
+        )
+    )
+    print(f"Assignment titles updated: {result.rowcount}")
+
+    result = conn.execute(
+        sa.text(
+            """
+        UPDATE assignment SET title = null
+        WHERE title = '';
+    """
+        )
+    )
+    print(f"Empty assignment titles: {result.rowcount}")
+
+    result = conn.execute(
+        sa.text(
+            """
+        UPDATE grouping SET lms_name = TRIM(lms_name)
+        WHERE TRIM(lms_name) != lms_name;
+    """
+        )
+    )
+    print(f"Grouping titles updated: {result.rowcount}")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Since https://github.com/hypothesis/lms/pull/6472 we do the same in the python code, we trim new assignment and course titles. We also normalize empty (``) titles to null.

This PR does the same for existing titles in the DB with a DB migration.


### Testing

```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='378749627'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f8ff7e49cbbf -> e5a9845d55d7, Clean grouping and assignment titles.
Assignment titles updated: 5
Empty assignment titles: 1
Grouping titles updated: 2
```



