### PR TITLE
Exclude empty titled assignments from get_assignments

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -232,8 +232,7 @@ class AssignmentService:
         :param course_ids: only return assignments that belong to this course.
         :param h_userids: return only assignments where these users are members.
         """
-
-        query = select(Assignment)
+        query = select(Assignment).where(Assignment.title.is_not(None))
 
         # Let's crate no op clauses by default to avoid having to check the presence of these filters
         instructor_h_userid_clause = cast(BinaryExpression, false())

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -294,6 +294,18 @@ class TestAssignmentService:
 
         assert db_session.scalars(query).all() == [assignment]
 
+    def test_get_assignments_excludes_empty_titles(self, db_session, svc):
+        course = factories.Course()
+        assignment = factories.Assignment(title=None)
+        factories.AssignmentGrouping(
+            grouping=course, assignment=assignment, updated=date(2022, 1, 1)
+        )
+        db_session.flush()
+
+        assert not db_session.scalars(
+            svc.get_assignments(course_ids=[course.id])
+        ).all() == [assignment]
+
     def test_get_assignments_by_course_id_with_duplicate(
         self, db_session, svc, application_instance, organization
     ):


### PR DESCRIPTION
[Most of these come from the original creation of the table](https://metabase.hypothes.is/question/1277-assignments-without-names-by-date), where we only had the title IDs.
