### PR TITLE
Filter and allow access for organizations to staff members

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -65,6 +65,23 @@ class DashboardService:
 
         return course
 
+    def get_request_organization(self, request) -> Organization | None:
+        """Get and authorize an organization."""
+        if not request.has_permission(Permissions.STAFF):
+            # For now only staff request are scoped to an organization
+            return None
+
+        request_public_id = request.parsed_params.get("public_id")
+        if not request_public_id:
+            # Only relevant for request that include the query parameter
+            return None
+
+        organization = self._organization_service.get_by_public_id(request_public_id)
+        if not organization:
+            raise HTTPNotFound()
+
+        return organization
+
     def get_organizations_by_admin_email(self, email: str) -> list[Organization]:
         """Get a list of organizations where the user with email `email` is an admin in."""
         return self._db.scalars(

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -77,9 +77,7 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        assignment = self.dashboard_service.get_request_assignment(
-            self.request, self.admin_organizations
-        )
+        assignment = self.dashboard_service.get_request_assignment(self.request)
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": assignment.title}
@@ -95,9 +93,7 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        course = self.dashboard_service.get_request_course(
-            self.request, self.admin_organizations
-        )
+        course = self.dashboard_service.get_request_course(self.request)
         self.request.context.js_config.enable_dashboard_mode()
         self._set_lti_user_cookie(self.request.response)
         return {"title": course.lms_name}

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -51,8 +51,7 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
+            pyramid_request
         )
 
         assert response == {

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -43,30 +43,6 @@ class TestCourseViews:
             "pagination": sentinel.pagination,
         }
 
-    def test_get_courses_for_staff(
-        self,
-        course_service,
-        pyramid_request,
-        views,
-        dashboard_service,
-        get_page,
-        pyramid_config,
-    ):
-        pyramid_request.parsed_params = {}
-        get_page.return_value = [], sentinel.pagination
-        pyramid_config.testing_securitypolicy(permissive=True)
-
-        views.courses()
-
-        course_service.get_courses.assert_called_once_with(
-            admin_organization_ids=[
-                dashboard_service.get_request_organization.return_value.id
-            ],
-            instructor_h_userid=pyramid_request.user.h_userid,
-            h_userids=None,
-            assignment_ids=None,
-        )
-
     def test_course_metrics(
         self, course_service, pyramid_request, views, db_session, assignment_service
     ):
@@ -147,10 +123,7 @@ class TestCourseViews:
 
         response = views.course()
 
-        dashboard_service.get_request_course.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
-        )
+        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
 
         assert response == {
             "id": course.id,

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -43,6 +43,30 @@ class TestCourseViews:
             "pagination": sentinel.pagination,
         }
 
+    def test_get_courses_for_staff(
+        self,
+        course_service,
+        pyramid_request,
+        views,
+        dashboard_service,
+        get_page,
+        pyramid_config,
+    ):
+        pyramid_request.parsed_params = {}
+        get_page.return_value = [], sentinel.pagination
+        pyramid_config.testing_securitypolicy(permissive=True)
+
+        views.courses()
+
+        course_service.get_courses.assert_called_once_with(
+            admin_organization_ids=[
+                dashboard_service.get_request_organization.return_value.id
+            ],
+            instructor_h_userid=pyramid_request.user.h_userid,
+            h_userids=None,
+            assignment_ids=None,
+        )
+
     def test_course_metrics(
         self, course_service, pyramid_request, views, db_session, assignment_service
     ):

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -95,8 +95,7 @@ class TestUserViews:
         response = views.students_metrics()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
+            pyramid_request
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -49,8 +49,7 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
+            pyramid_request
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
@@ -68,10 +67,7 @@ class TestDashboardViews:
 
         views.course_show()
 
-        dashboard_service.get_request_course.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
-        )
+        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         assert (
             pyramid_request.response.headers["Set-Cookie"]
@@ -105,8 +101,7 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request,
-            dashboard_service.get_organizations_by_admin_email.return_value,
+            pyramid_request
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6480


Reuse the existing admin_organization_ids mechanism to allow and filter courses to one organization.

We don't just filter by orgazaniation_id because we'd need to solve authorization seperantly. This seems like the best compromise solution that doesn't require a lot of extra code for staff members. 


## Testing

Use https://github.com/hypothesis/lms/pull/6483 for easier testing

- Go into the admin pages, find an organization with local active
- Make sure you didn't add yourself as an admin to the local organization.
- Navigate thru all three levels. Get results back.




