### PR TITLE
Do not set document title placeholder if pathname didn't change

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/hooks.ts
@@ -29,7 +29,7 @@ export function useDocumentTitle(documentTitle: string) {
 
 /**
  * In development environments, set a placeholder document title at the start
- * of a navigation.
+ * of a navigation to a different path.
  *
  * Navigations are detected using the `navigate` event of the Navigation API.
  * https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API
@@ -44,8 +44,13 @@ export function usePlaceholderDocumentTitleInDev() {
       return () => {};
     }
 
-    const listener = () => {
-      document.title = 'PLACEHOLDER DOCUMENT TITLE';
+    const listener = (e: NavigateEvent) => {
+      const { pathname: newPath } = new URL(e.destination.url);
+      const currentPath = location.pathname;
+
+      if (currentPath !== newPath) {
+        document.title = 'PLACEHOLDER DOCUMENT TITLE';
+      }
     };
     window.navigation.addEventListener('navigate', listener);
 


### PR DESCRIPTION
This is a small fix for a dev-only piece of logic.

In https://github.com/hypothesis/lms/pull/6469 we added an event handler that sets a placeholder document title used to ensure we don't forget to set proper titles for new URLs in future. However, that event did not take into consideration navigations where the pathname does not change, like when setting dashboard filters in the query.

Those should be considered "the same page", and therefore they don't need a different title.

With the changes in this PR we only set the placeholder title right before navigating to a different path.