### PR TITLE
Organization dashboard entry point for staff

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -100,4 +100,13 @@ class User(TypedDict):
 
 class DashboardConfig(TypedDict):
     user: User
+
+    organization_public_id: str
+    """
+    Filtering by organization is not like other filters:
+    - It's only available to staff members
+    - It doesn't only filter but also authorized access to that orgnaiztion's data
+    For those resason we include it on the config instead of handling it like other query string parameters.
+    """
+
     routes: DashboardRoutes

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -257,6 +257,7 @@ class JSConfig:
                 "mode": JSConfig.Mode.DASHBOARD,
                 "dashboard": DashboardConfig(
                     user=self._get_user_info(),
+                    organization_public_id=self._request.params.get("public_id"),
                     routes=DashboardRoutes(
                         assignment=self._to_frontend_template(
                             "api.dashboard.assignment"

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -212,6 +212,9 @@ def includeme(config):  # noqa: PLR0915
     )
     config.add_route("admin.organization.toggle", "/admin/orgs/{id_}/toggle")
     config.add_route("admin.organizations", "/admin/orgs")
+    config.add_route(
+        "admin.organization.dashboard", "/admin/organization/{id_}/dashboard"
+    )
     config.add_route("admin.organization.move_org", "/admin/orgs/{id_}/move_org")
     config.add_route("admin.organization.new", "/admin/org/new")
     config.add_route(

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -30,6 +30,7 @@ export default function AssignmentActivity() {
   );
   const students = useAPIFetch<StudentsResponse>(routes.students_metrics, {
     assignment_id: assignmentId,
+    public_id: dashboard.organization_public_id,
   });
 
   const rows: StudentsTableRow[] = useMemo(

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -35,6 +35,7 @@ export default function CourseActivity() {
     replaceURLParams(routes.course_assignments_metrics, {
       course_id: courseId,
     }),
+    { public_id: dashboard.organization_public_id },
   );
 
   const rows: AssignmentsTableRow[] = useMemo(

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -42,17 +42,20 @@ export default function DashboardActivityFilters({
   const courses = useAPIFetch<{ courses: Course[] }>(routes.courses, {
     h_userid: selectedStudentIds,
     assignment_id: selectedAssignmentIds,
+    public_id: dashboard.organization_public_id,
   });
   const assignments = useAPIFetch<{ assignments: Assignment[] }>(
     routes.assignments,
     {
       h_userid: selectedStudentIds,
       course_id: selectedCourseIds,
+      public_id: dashboard.organization_public_id,
     },
   );
   const students = useAPIFetch<{ students: Student[] }>(routes.students, {
     assignment_id: selectedAssignmentIds,
     course_id: selectedCourseIds,
+    public_id: dashboard.organization_public_id,
   });
   const studentsWithName = useMemo(
     () => students.data?.students.filter(s => !!s.display_name),

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrganizationActivity.tsx
@@ -36,6 +36,7 @@ export default function OrganizationActivity() {
     h_userid: studentIds,
     assignment_id: assignmentIds,
     course_id: courseIds,
+    public_id: dashboard.organization_public_id,
   });
   const rows: CoursesTableRow[] = useMemo(
     () =>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -272,6 +272,7 @@ describe('DashboardActivityFilters', () => {
       assert.calledWith(fakeUseAPIFetch.getCall(0), '/api/dashboard/courses', {
         h_userid: selectedStudentIds,
         assignment_id: selectedAssignmentIds,
+        public_id: undefined,
       });
       assert.calledWith(
         fakeUseAPIFetch.getCall(1),
@@ -279,11 +280,13 @@ describe('DashboardActivityFilters', () => {
         {
           h_userid: selectedStudentIds,
           course_id: selectedCourseIds,
+          public_id: undefined,
         },
       );
       assert.calledWith(fakeUseAPIFetch.getCall(2), '/api/dashboard/students', {
         assignment_id: selectedAssignmentIds,
         course_id: selectedCourseIds,
+        public_id: undefined,
       });
     });
   });

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -178,6 +178,7 @@ describe('OrganizationActivity', () => {
       h_userid: ['123', '456'],
       assignment_id: [],
       course_id: [],
+      public_id: undefined,
     });
 
     updateFilter('onAssignmentsChange', ['1', '2']);
@@ -185,6 +186,7 @@ describe('OrganizationActivity', () => {
       h_userid: [],
       assignment_id: ['1', '2'],
       course_id: [],
+      public_id: undefined,
     });
 
     updateFilter('onCoursesChange', ['3', '8', '9']);
@@ -192,6 +194,25 @@ describe('OrganizationActivity', () => {
       h_userid: [],
       assignment_id: [],
       course_id: ['3', '8', '9'],
+      public_id: undefined,
+    });
+  });
+
+  context('when `organization_public_id` is present in config', () => {
+    beforeEach(() => {
+      fakeConfig.dashboard.organization_public_id = 'the-org-public-id';
+    });
+
+    it('propagates public_id to API calls', () => {
+      createComponent();
+
+      assert.calledWith(
+        fakeUseAPIFetch.lastCall,
+        sinon.match.string,
+        sinon.match({
+          public_id: 'the-org-public-id',
+        }),
+      );
     });
   });
 
@@ -206,6 +227,7 @@ describe('OrganizationActivity', () => {
       h_userid: [],
       assignment_id: [],
       course_id: [],
+      public_id: undefined,
     });
   });
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -277,6 +277,7 @@ export type DashboardUser = {
 
 export type DashboardConfig = {
   routes: DashboardRoutes;
+  organization_public_id?: string;
   user: DashboardUser;
 };
 

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -41,6 +41,9 @@
                         <legend class="label has-text-centered">Organization</legend>
                         <form method="POST"
                               action="{{ request.route_url("admin.organization", id_=org.id) }}">
+                            <div class="block has-text-right">
+                              <a class="button is-primary" target="_blank" href="{{ request.route_url('admin.organization.dashboard', id_=org.id) }}">Open instructor dashboard</a>
+                            </div>
                             <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                             {{ macros.disabled_text_field("ID", org.public_id) }}
                             {{ macros.form_text_field(request, "Name", "name", org.name) }}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -694,13 +694,17 @@ class TestEnableErrorDialogMode:
 
 
 class TestEnableDashboardMode:
-    def test_it(self, js_config, lti_user):
+    @pytest.mark.parametrize("public_id", ["PUBLIC_ID", None])
+    def test_it(self, js_config, lti_user, pyramid_request, public_id):
+        pyramid_request.params["public_id"] = public_id
+
         js_config.enable_dashboard_mode()
         config = js_config.asdict()
 
         assert config["mode"] == JSConfig.Mode.DASHBOARD
         assert config["dashboard"] == {
             "user": {"display_name": lti_user.display_name, "is_staff": False},
+            "organization_public_id": public_id,
             "routes": {
                 "assignment": "/api/dashboard/assignments/:assignment_id",
                 "students_metrics": "/api/dashboard/students/metrics",


### PR DESCRIPTION
Include a public_id parameter to access the dashboards when launched from the organization view in the admin pages

## Testing
- Go into the admin pages, find an organization with local active course
- Make sure you didn't add yourself as an admin to the local organization.
- Navigate thru all three levels. Get results back.
