### PR TITLE
Remove assignment title prefix

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -44,7 +44,8 @@ export default function AssignmentActivity() {
     [students.data],
   );
 
-  useDocumentTitle(assignment.data?.title ?? 'Untitled assignment');
+  const title = assignment.data?.title ?? 'Untitled assignment';
+  useDocumentTitle(title);
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -64,12 +65,12 @@ export default function AssignmentActivity() {
         <h2 className="text-lg text-brand font-semibold" data-testid="title">
           {assignment.isLoading && 'Loading...'}
           {assignment.error && 'Could not load assignment title'}
-          {assignment.data && assignment.data.title}
+          {assignment.data && title}
         </h2>
       </div>
       <OrderableActivityTable
         loading={students.isLoading}
-        title={assignment.data?.title ?? 'Loading...'}
+        title={assignment.isLoading ? 'Loading...' : title}
         emptyMessage={
           students.error ? 'Could not load students' : 'No students found'
         }

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -32,7 +32,6 @@ export default function AssignmentActivity() {
     assignment_id: assignmentId,
   });
 
-  const title = `Assignment: ${assignment.data?.title}`;
   const rows: StudentsTableRow[] = useMemo(
     () =>
       (students.data?.students ?? []).map(
@@ -65,12 +64,12 @@ export default function AssignmentActivity() {
         <h2 className="text-lg text-brand font-semibold" data-testid="title">
           {assignment.isLoading && 'Loading...'}
           {assignment.error && 'Could not load assignment title'}
-          {assignment.data && title}
+          {assignment.data && assignment.data.title}
         </h2>
       </div>
       <OrderableActivityTable
         loading={students.isLoading}
-        title={assignment.isLoading ? 'Loading...' : title}
+        title={assignment.data?.title ?? 'Loading...'}
         emptyMessage={
           students.error ? 'Could not load students' : 'No students found'
         }

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -49,7 +49,8 @@ export default function CourseActivity() {
     [assignments.data],
   );
 
-  useDocumentTitle(course.data?.title ?? 'Untitled course');
+  const title = course.data?.title ?? 'Untitled course';
+  useDocumentTitle(title);
 
   return (
     <div className="flex flex-col gap-y-5">
@@ -60,12 +61,12 @@ export default function CourseActivity() {
         <h2 className="text-lg text-brand font-semibold" data-testid="title">
           {course.isLoading && 'Loading...'}
           {course.error && 'Could not load course title'}
-          {course.data && course.data.title}
+          {course.data && title}
         </h2>
       </div>
       <OrderableActivityTable
         loading={assignments.isLoading}
-        title={course.data?.title ?? 'Loading...'}
+        title={course.isLoading ? 'Loading...' : title}
         emptyMessage={
           assignments.error
             ? 'Could not load assignments'

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -112,7 +112,7 @@ describe('AssignmentActivity', () => {
     const wrapper = createComponent();
     const titleElement = wrapper.find('[data-testid="title"]');
     const tableElement = wrapper.find('OrderableActivityTable');
-    const expectedTitle = 'Assignment: The title';
+    const expectedTitle = 'The title';
 
     assert.equal(titleElement.text(), expectedTitle);
     assert.equal(tableElement.prop('title'), expectedTitle);


### PR DESCRIPTION
Remove the `Assignment:` title prefix in the dashboard assignment section.

This makes it more consistent with the course section, where no prefix is used.

Before:

![image](https://github.com/user-attachments/assets/58f99f55-a6d4-4fd7-8fca-c5e69565282f)

After:

![image](https://github.com/user-attachments/assets/ab959ed9-361c-4c26-a142-994c35f667e0)

> This PR is the "counterpart" of https://github.com/hypothesis/lms/pull/6468