### PR TITLE
Avoid filters layout changes when clear button appears

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -60,12 +60,13 @@ export default function DashboardActivityFilters({
   );
 
   return (
-    <div className="flex gap-2 md:w-1/2">
+    <div className="flex gap-2 flex-wrap">
       <MultiSelect
         disabled={courses.isLoading}
         value={selectedCourseIds}
         onChange={onCoursesChange}
         aria-label="Select courses"
+        containerClasses="!w-auto min-w-[180px]"
         buttonContent={
           courses.isLoading ? (
             <>...</>
@@ -92,6 +93,7 @@ export default function DashboardActivityFilters({
         value={selectedAssignmentIds}
         onChange={onAssignmentsChange}
         aria-label="Select assignments"
+        containerClasses="!w-auto min-w-[180px]"
         buttonContent={
           assignments.isLoading ? (
             <>...</>
@@ -121,6 +123,7 @@ export default function DashboardActivityFilters({
         value={selectedStudentIds}
         onChange={onStudentsChange}
         aria-label="Select students"
+        containerClasses="!w-auto min-w-[180px]"
         buttonContent={
           students.isLoading ? (
             <>...</>


### PR DESCRIPTION
Adjust layout for dashboard filters to make sure selects are not "pushed" back when the clear filters button appears.

Previously, we ensured a minimum width of the selects by placing them in a "half-width" container, but since the clear button is also part of this container, selects had to share the space with it.

Now selects are rendered with an auto width, overwriting their default full width, but have a minimum 180px width so that they don't look too small at first.

Before:

https://github.com/user-attachments/assets/7fd41e0d-652e-4a80-bbab-ee6013d27532

After:

https://github.com/user-attachments/assets/6d3bb710-7e4b-499c-9054-b00f2e526b7a
