### PR TITLE
Allow query params with value undefined in api calls

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -45,7 +45,7 @@ export type APICallOptions = {
   path: string;
 
   /** Query parameters. */
-  params?: Record<string, string | string[]>;
+  params?: Record<string, string | string[] | undefined>;
 
   /** JSON-serializable body of request. */
   data?: object;
@@ -186,7 +186,7 @@ export function urlPath(strings: TemplateStringsArray, ...params: string[]) {
  */
 export function useAPIFetch<T = unknown>(
   path: string | null,
-  params?: Record<string, string | string[]>,
+  params?: Record<string, string | string[] | undefined>,
 ): FetchResult<T> {
   const {
     api: { authToken },

--- a/lms/static/scripts/frontend_apps/utils/test/url-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/url-test.js
@@ -47,6 +47,7 @@ describe('recordToSearchParams', () => {
     const result = recordToSearchParams({
       foo: 'bar',
       baz: ['1', '2', '3'],
+      ignored: undefined,
     });
 
     assert.equal(result.toString(), 'foo=bar&baz=1&baz=2&baz=3');

--- a/lms/static/scripts/frontend_apps/utils/url.ts
+++ b/lms/static/scripts/frontend_apps/utils/url.ts
@@ -34,10 +34,15 @@ export function replaceURLParams<Param>(
  * Any param which is an array will be appended for every one of its values.
  */
 export function recordToSearchParams(
-  params: Record<string, string | string[]>,
+  params: Record<string, string | string[] | undefined>,
 ): URLSearchParams {
   const queryParams = new URLSearchParams();
   Object.entries(params).forEach(([name, value]) => {
+    // Skip params if their value is undefined
+    if (value === undefined) {
+      return;
+    }
+
     if (Array.isArray(value)) {
       value.forEach(v => queryParams.append(name, v));
     } else {
@@ -59,7 +64,7 @@ export function recordToSearchParams(
  *    { foo: 'bar', something: ['hello', 'world'] } -> '?foo=bar&something=hello&something=world'
  */
 export function recordToQueryString(
-  params: Record<string, string | string[]>,
+  params: Record<string, string | string[] | undefined>,
 ): string {
   const queryString = recordToSearchParams(params).toString();
   return queryString.length > 0 ? `?${queryString}` : '';


### PR DESCRIPTION
Change the type of query params provided to `apiCall` and `useAPIFetch` to be less strict and allow keys with `undefined` value (`Record<string, string | string[] | undefined>` instead of `Record<string, string | string[]>`).

Then, simply skip params with undefined value when serializing them.

This simplifies userland code, where we no longer need to check if a value is set in every place, in order to make an API call.

Also, passing an empty array currently has the same effect as not passing the param at all. Allowing `undefined` just makes it more convenient but also intuitive, as it's fair to expect a param which is undefined to be just ignored.

Some cases where this will simplify code:

* We won't have to fall back to an empty array for conditional params: https://github.com/hypothesis/lms/pull/6483/commits/8e5bd7cee9e42e280796cc93e270af289cd030ba#r1696839366