### PR TITLE
Create new indexes to speed up dashboard queries

### DIFF
--- a/lms/migrations/versions/ca27e52b7303_add_missing_indexes.py
+++ b/lms/migrations/versions/ca27e52b7303_add_missing_indexes.py
@@ -1,0 +1,35 @@
+"""Add missing indexes for dashboard queries."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ca27e52b7303"
+down_revision = "e5a9845d55d7"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        op.f("ix__assignment_membership_lti_role_id"),
+        "assignment_membership",
+        ["lti_role_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__user_h_userid"),
+        "user",
+        ["h_userid"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix__user_h_userid"), table_name="user")
+    op.drop_index(
+        op.f("ix__assignment_membership_lti_role_id"),
+        table_name="assignment_membership",
+    )

--- a/lms/models/assignment_membership.py
+++ b/lms/models/assignment_membership.py
@@ -24,7 +24,10 @@ class AssignmentMembership(CreatedUpdatedMixin, Base):
     """The user who is a member."""
 
     lti_role_id = sa.Column(
-        sa.Integer(), sa.ForeignKey("lti_role.id", ondelete="cascade"), primary_key=True
+        sa.Integer(),
+        sa.ForeignKey("lti_role.id", ondelete="cascade"),
+        primary_key=True,
+        index=True,
     )
     lti_role = sa.orm.relationship("LTIRole", foreign_keys=[lti_role_id])
     """What role the user plays in the assignment."""

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -38,7 +38,7 @@ class User(CreatedUpdatedMixin, Base):
     roles = sa.Column(sa.Unicode, nullable=True)
     """The roles provided by the LTI parameters."""
 
-    h_userid: Mapped[str] = mapped_column(sa.Unicode)
+    h_userid: Mapped[str] = mapped_column(sa.Unicode, index=True)
     """The H userid which is created from LTI provided values."""
 
     email: Mapped[str | None] = mapped_column(sa.Unicode)


### PR DESCRIPTION
- Add index on Assignment Membership.lti_role_id

While this is part of the PK of the table it doesn't have an index from
when we query it on its own.


- Index for faster query of unique H users


### Testing

```
tox -e dev --run-command 'alembic upgrade head'

dev run-test-pre: PYTHONHASHSEED='4043195568'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.INFO  [alembic.runtime.migration] Running upgrade e5a9845d55d7 -> ca27e52b7303, Add missing indexes for dashboard queries.
```

