### PR TITLE
Add test to cover the presence of organization_public_id in dashboard config

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/OrganizationActivity-test.js
@@ -195,6 +195,24 @@ describe('OrganizationActivity', () => {
     });
   });
 
+  context('when `organization_public_id` is present in config', () => {
+    beforeEach(() => {
+      fakeConfig.dashboard.organization_public_id = 'the-org-public-id';
+    });
+
+    it('propagates public_id to API calls', () => {
+      createComponent();
+
+      assert.calledWith(
+        fakeUseAPIFetch.lastCall,
+        sinon.match.string,
+        sinon.match({
+          public_id: 'the-org-public-id',
+        }),
+      );
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({


### PR DESCRIPTION
Add one extra test to `OrganizationActivity-test` to cover the behavior when `organization_public_id` is defined in dashboard config. 