### PR TITLE
Rename OrganizationActivity to AllCoursesActivity

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -21,9 +21,9 @@ type CoursesTableRow = {
 const courseURL = (id: number) => urlPath`/courses/${String(id)}`;
 
 /**
- * List of courses that belong to a specific organization
+ * List of courses that current user has access to in the dashboard
  */
-export default function OrganizationActivity() {
+export default function AllCoursesActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -9,10 +9,10 @@ import { Link as RouterLink, Route, Switch } from 'wouter-preact';
 
 import { useConfig } from '../../config';
 import { usePlaceholderDocumentTitleInDev } from '../../utils/hooks';
+import AllCoursesActivity from './AllCoursesActivity';
 import AssignmentActivity from './AssignmentActivity';
 import CourseActivity from './CourseActivity';
 import DashboardFooter from './DashboardFooter';
-import OrganizationActivity from './OrganizationActivity';
 
 export default function DashboardApp() {
   const { dashboard } = useConfig(['dashboard']);
@@ -71,7 +71,7 @@ export default function DashboardApp() {
               <CourseActivity />
             </Route>
             <Route path="">
-              <OrganizationActivity />
+              <AllCoursesActivity />
             </Route>
           </Switch>
         </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -8,9 +8,9 @@ import sinon from 'sinon';
 
 import { Config } from '../../../config';
 import { formatDateTime } from '../../../utils/date';
-import OrganizationActivity, { $imports } from '../OrganizationActivity';
+import AllCoursesActivity, { $imports } from '../AllCoursesActivity';
 
-describe('OrganizationActivity', () => {
+describe('AllCoursesActivity', () => {
   const courses = [
     {
       id: 1,
@@ -73,7 +73,7 @@ describe('OrganizationActivity', () => {
   function createComponent() {
     const wrapper = mount(
       <Config.Provider value={fakeConfig}>
-        <OrganizationActivity />
+        <AllCoursesActivity />
       </Config.Provider>,
     );
     wrappers.push(wrapper);

--- a/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AppRoot-test.js
@@ -75,7 +75,7 @@ describe('AppRoot', () => {
     {
       config: { mode: 'dashboard' },
       appComponent: 'DashboardApp',
-      route: '/dashboard/organizations/ORG_ID/assignments/123',
+      route: '/dashboard/assignments/123',
     },
     {
       config: { mode: 'error-dialog' },


### PR DESCRIPTION
With the removal of the organization ID in the URL, and references to the organization in the dashboard, there was a component left still incorrectly referencing the organization concept.

This PR renames `OrganizationActivity` to `AllCoursesActivity` to solve that.