### PR TITLE
Don't include public_id on the dashboard config when not present

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -101,7 +101,7 @@ class User(TypedDict):
 class DashboardConfig(TypedDict):
     user: User
 
-    organization_public_id: str
+    organization_public_id: NotRequired[str]
     """
     Filtering by organization is not like other filters:
     - It's only available to staff members

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -257,7 +257,6 @@ class JSConfig:
                 "mode": JSConfig.Mode.DASHBOARD,
                 "dashboard": DashboardConfig(
                     user=self._get_user_info(),
-                    organization_public_id=self._request.params.get("public_id"),
                     routes=DashboardRoutes(
                         assignment=self._to_frontend_template(
                             "api.dashboard.assignment"
@@ -281,6 +280,8 @@ class JSConfig:
                 ),
             }
         )
+        if organization_public_id := self._request.params.get("public_id"):
+            self._config["dashboard"]["organization_public_id"] = organization_public_id
 
     def enable_lti_launch_mode(self, course, assignment: Assignment):
         """

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -694,17 +694,13 @@ class TestEnableErrorDialogMode:
 
 
 class TestEnableDashboardMode:
-    @pytest.mark.parametrize("public_id", ["PUBLIC_ID", None])
-    def test_it(self, js_config, lti_user, pyramid_request, public_id):
-        pyramid_request.params["public_id"] = public_id
-
+    def test_it(self, js_config, lti_user):
         js_config.enable_dashboard_mode()
         config = js_config.asdict()
 
         assert config["mode"] == JSConfig.Mode.DASHBOARD
         assert config["dashboard"] == {
             "user": {"display_name": lti_user.display_name, "is_staff": False},
-            "organization_public_id": public_id,
             "routes": {
                 "assignment": "/api/dashboard/assignments/:assignment_id",
                 "students_metrics": "/api/dashboard/students/metrics",
@@ -716,6 +712,14 @@ class TestEnableDashboardMode:
                 "students": "/api/dashboard/students",
             },
         }
+
+    def test_it_when_organizataion_public_id_present(self, js_config, pyramid_request):
+        pyramid_request.params["public_id"] = sentinel.public_id
+
+        js_config.enable_dashboard_mode()
+        config = js_config.asdict()
+
+        assert config["dashboard"]["organization_public_id"] == sentinel.public_id
 
     def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
         js_config = JSConfig(context, pyramid_request_staff_member)


### PR DESCRIPTION
This way we avoid having to deal with undefined vs null values in the frontend.

Fixes: https://hypothesis.sentry.io/issues/5664280137/?referrer=slack&notification_uuid=14c12951-d0d0-4d5c-9f08-3d24eddee6d7&alert_rule_id=4849653&alert_type=issue

# Testing 

- Open the dashboard as a staff member
- You'll get an exception in main,  it will be fixed in this branch.