### PR TITLE
Scope dashboards to an organization when launched from the course and assignment views

### DIFF
--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -52,7 +52,11 @@ class AdminAssignmentViews:
 
         response = HTTPFound(
             location=self.request.route_url(
-                "dashboard.assignment", assignment_id=assignment.id
+                "dashboard.assignment",
+                assignment_id=assignment.id,
+                _query={
+                    "public_id": assignment.course.application_instance.organization.public_id
+                },
             ),
         )
         return response

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -85,6 +85,9 @@ class AdminCourseViews:
                 "dashboard.course",
                 public_id=course.application_instance.organization.public_id,
                 course_id=course.id,
+                _query={
+                    "public_id": course.application_instance.organization.public_id
+                },
             ),
         )
         return response

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -29,7 +29,13 @@ class TestAdminAssignmentViews:
             views.show()
 
     def test_assignment_dashboard(
-        self, pyramid_request, assignment_service, views, AuditTrailEvent, assignment
+        self,
+        pyramid_request,
+        assignment_service,
+        views,
+        AuditTrailEvent,
+        assignment,
+        organization,
     ):
         pyramid_request.matchdict["id_"] = sentinel.id
         assignment_service.get_by_id.return_value = assignment
@@ -51,7 +57,7 @@ class TestAdminAssignmentViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/assignments/{assignment.id}",
+                "location": f"http://example.com/dashboard/assignments/{assignment.id}?public_id={organization.public_id}",
             }
         )
 

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -31,7 +31,13 @@ class TestAdminCourseViews:
             views.show()
 
     def test_course_dashboard(
-        self, pyramid_request, course_service, views, AuditTrailEvent, course
+        self,
+        pyramid_request,
+        course_service,
+        views,
+        AuditTrailEvent,
+        course,
+        organization,
     ):
         pyramid_request.matchdict["id_"] = sentinel.id
         course_service.get_by_id.return_value = course
@@ -53,7 +59,7 @@ class TestAdminCourseViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/courses/{course.id}",
+                "location": f"http://example.com/dashboard/courses/{course.id}?public_id={organization.public_id}",
             }
         )
 


### PR DESCRIPTION
This allows to have access to the data at all levels using the public_id mechanism


### Testing

- Go to the admin pages, find an assignment, launch the dashboard.
- You'll see data at that level and all the way to "all courses".
- Repeat the same process launching from a course 