### PR TITLE
Add indices for courses, assignment and user names

### DIFF
--- a/lms/migrations/versions/afa53b7464be_add_indexes_for_names_we_sort_by.py
+++ b/lms/migrations/versions/afa53b7464be_add_indexes_for_names_we_sort_by.py
@@ -1,0 +1,40 @@
+"""Add indexes for names we sort by in the dashboards."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "afa53b7464be"
+down_revision = "ca27e52b7303"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        op.f("ix__assignment_title"),
+        "assignment",
+        ["title"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__grouping_lms_name"),
+        "grouping",
+        ["lms_name"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__user_display_name"),
+        "user",
+        ["display_name"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix__user_display_name"), table_name="user")
+    op.drop_index(op.f("ix__grouping_lms_name"), table_name="grouping")
+    op.drop_index(op.f("ix__assignment_title"), table_name="assignment")

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -69,7 +69,7 @@ class Assignment(CreatedUpdatedMixin, Base):
     )
     """Whether this assignment is gradable or not."""
 
-    title: Mapped[str | None] = mapped_column(sa.Unicode)
+    title: Mapped[str | None] = mapped_column(sa.Unicode, index=True)
     """The resource link title from LTI params."""
 
     description = sa.Column(sa.Unicode, nullable=True)

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -114,7 +114,7 @@ class Grouping(CreatedUpdatedMixin, Base):
     lms_id = sa.Column(sa.Unicode(), nullable=False)
 
     #: Full name given on the LMS (e.g. "A course name 101")
-    lms_name: Mapped[str] = mapped_column(sa.UnicodeText())
+    lms_name: Mapped[str] = mapped_column(sa.UnicodeText(), index=True)
 
     type = varchar_enum(Type, nullable=False)
 

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -44,5 +44,5 @@ class User(CreatedUpdatedMixin, Base):
     email: Mapped[str | None] = mapped_column(sa.Unicode)
     """Email address of the user"""
 
-    display_name: Mapped[str | None] = mapped_column(sa.Unicode)
+    display_name: Mapped[str | None] = mapped_column(sa.Unicode, index=True)
     """The user's display name."""


### PR DESCRIPTION
We use these to sort list in their respective queries, add the missing indices to speed them up

## Testing

`tox -e dev --run-command 'alembic upgrade head'`

```
dev run-test-pre: PYTHONHASHSEED='3761224678'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade ca27e52b7303 -> afa53b7464be, Add indexes for names we sort by in the dashboards.
```