### PR TITLE
Correctly display context ID on courses lists in the admin pages

### DIFF
--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -275,6 +275,6 @@
     {{ object_list_table(request, 'admin.course', courses,
         fields=[
         {"label": "Name", "name": "lms_name"},
-        {"label": "Context ID", "name": "lms_name"},
+        {"label": "Context ID", "name": "lms_id"},
     ]) }}
 {% endmacro %}


### PR DESCRIPTION
Currently the template duplicates the name in both columns:

![Screenshot from 2024-08-02 15-40-21](https://github.com/user-attachments/assets/35ace0e0-37c1-4361-a0b6-c71e28103148)

Fix the templated to expose the context ID as the header suggests. 