### PR TITLE
Add dashboard API response types for filters endpoints

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -173,7 +173,7 @@ export type CourseWithMetrics = Course & {
 /**
  * Response for `/api/dashboard/course/metrics` call.
  */
-export type CoursesResponse = {
+export type CoursesMetricsResponse = {
   courses: CourseWithMetrics[];
 };
 
@@ -196,9 +196,9 @@ export type StudentWithMetrics = Student & {
 };
 
 /**
- * Response for `/api/dashboard/assignments/{assignment_id}/stats` call.
+ * Response for `/api/dashboard/assignments/{assignment_id}/metrics` call.
  */
-export type StudentsResponse = {
+export type StudentsMetricsResponse = {
   students: StudentWithMetrics[];
 };
 
@@ -208,8 +208,36 @@ export type AssignmentWithMetrics = Assignment & {
 };
 
 /**
- * Response for `/api/dashboard/courses/{course_id}/assignments/stats` call.
+ * Response for `/api/dashboard/courses/{course_id}/assignments/metrics` call.
+ */
+export type AssignmentsMetricsResponse = {
+  assignments: AssignmentWithMetrics[];
+};
+
+export type Pagination = {
+  next: string | null;
+};
+
+/**
+ * Response for `/api/dashboard/courses` call.
+ */
+export type CoursesResponse = {
+  courses: Course[];
+  pagination: Pagination;
+};
+
+/**
+ * Response for `/api/dashboard/assignments` call.
  */
 export type AssignmentsResponse = {
-  assignments: AssignmentWithMetrics[];
+  assignments: Assignment[];
+  pagination: Pagination;
+};
+
+/**
+ * Response for `/api/dashboard/students` call.
+ */
+export type StudentsResponse = {
+  students: Student[];
+  pagination: Pagination;
 };

--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -2,7 +2,7 @@ import { Link } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 import { Link as RouterLink } from 'wouter-preact';
 
-import type { CoursesResponse } from '../../api-types';
+import type { CoursesMetricsResponse } from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
@@ -31,7 +31,7 @@ export default function AllCoursesActivity() {
   const { filters, updateFilters } = useDashboardFilters();
   const { courseIds, assignmentIds, studentIds } = filters;
 
-  const courses = useAPIFetch<CoursesResponse>(routes.courses_metrics, {
+  const courses = useAPIFetch<CoursesMetricsResponse>(routes.courses_metrics, {
     h_userid: studentIds,
     assignment_id: assignmentIds,
     course_id: courseIds,

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
-import type { AssignmentWithMetrics, StudentsResponse } from '../../api-types';
+import type {
+  AssignmentWithMetrics,
+  StudentsMetricsResponse,
+} from '../../api-types';
 import { useConfig } from '../../config';
 import { urlPath, useAPIFetch } from '../../utils/api';
 import { useDocumentTitle } from '../../utils/hooks';
@@ -28,10 +31,13 @@ export default function AssignmentActivity() {
   const assignment = useAPIFetch<AssignmentWithMetrics>(
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
-  const students = useAPIFetch<StudentsResponse>(routes.students_metrics, {
-    assignment_id: assignmentId,
-    public_id: dashboard.organization_public_id,
-  });
+  const students = useAPIFetch<StudentsMetricsResponse>(
+    routes.students_metrics,
+    {
+      assignment_id: assignmentId,
+      public_id: dashboard.organization_public_id,
+    },
+  );
 
   const rows: StudentsTableRow[] = useMemo(
     () =>

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -7,7 +7,7 @@ import {
   useSearch,
 } from 'wouter-preact';
 
-import type { AssignmentsResponse, Course } from '../../api-types';
+import type { AssignmentsMetricsResponse, Course } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
@@ -49,7 +49,7 @@ export default function CourseActivity() {
   const course = useAPIFetch<Course>(
     replaceURLParams(routes.course, { course_id: courseId }),
   );
-  const assignments = useAPIFetch<AssignmentsResponse>(
+  const assignments = useAPIFetch<AssignmentsMetricsResponse>(
     replaceURLParams(routes.course_assignments_metrics, {
       course_id: courseId,
     }),

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -5,7 +5,11 @@ import {
 } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 
-import type { Assignment, Course, Student } from '../../api-types';
+import type {
+  AssignmentsResponse,
+  CoursesResponse,
+  StudentsResponse,
+} from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 
@@ -39,20 +43,17 @@ export default function DashboardActivityFilters({
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 
-  const courses = useAPIFetch<{ courses: Course[] }>(routes.courses, {
+  const courses = useAPIFetch<CoursesResponse>(routes.courses, {
     h_userid: selectedStudentIds,
     assignment_id: selectedAssignmentIds,
     public_id: dashboard.organization_public_id,
   });
-  const assignments = useAPIFetch<{ assignments: Assignment[] }>(
-    routes.assignments,
-    {
-      h_userid: selectedStudentIds,
-      course_id: selectedCourseIds,
-      public_id: dashboard.organization_public_id,
-    },
-  );
-  const students = useAPIFetch<{ students: Student[] }>(routes.students, {
+  const assignments = useAPIFetch<AssignmentsResponse>(routes.assignments, {
+    h_userid: selectedStudentIds,
+    course_id: selectedCourseIds,
+    public_id: dashboard.organization_public_id,
+  });
+  const students = useAPIFetch<StudentsResponse>(routes.students, {
     assignment_id: selectedAssignmentIds,
     course_id: selectedCourseIds,
     public_id: dashboard.organization_public_id,


### PR DESCRIPTION
This PR adds some extra API type definitions in preparation for the pagination handling of the filters dropdowns.

Additionally, and to avoid colliding type names, it refactors a few of the existing metrics-related type names.