### PR TITLE
Add index on assignment_membership.user_id

### DIFF
--- a/lms/migrations/versions/d8d33d882b88_add_index_for_membership_user_id.py
+++ b/lms/migrations/versions/d8d33d882b88_add_index_for_membership_user_id.py
@@ -1,0 +1,26 @@
+"""Add index for membership.user_id."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d8d33d882b88"
+down_revision = "afa53b7464be"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        op.f("ix__assignment_membership_user_id"),
+        "assignment_membership",
+        ["user_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix__assignment_membership_user_id"), table_name="assignment_membership"
+    )

--- a/lms/models/assignment_membership.py
+++ b/lms/models/assignment_membership.py
@@ -18,7 +18,10 @@ class AssignmentMembership(CreatedUpdatedMixin, Base):
     """The assignment the user is a member of."""
 
     user_id = sa.Column(
-        sa.Integer(), sa.ForeignKey("user.id", ondelete="cascade"), primary_key=True
+        sa.Integer(),
+        sa.ForeignKey("user.id", ondelete="cascade"),
+        primary_key=True,
+        index=True,
     )
     user = sa.orm.relationship("User", foreign_keys=[user_id])
     """The user who is a member."""


### PR DESCRIPTION
Similar to assignment_membership.lti_user_id, the other column part of this table's composite  primary key but often queried on it's own.

Create an index just on the user_id column to be used when queried in isolation.


### Testing

`tox -e dev --run-command 'alembic upgrade head'`                                              

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade afa53b7464be -> d8d33d882b88, Add index for membership.user_id
```