### PR TITLE
Add pagination handling to dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -6,13 +6,15 @@ import {
 import { useMemo } from 'preact/hooks';
 
 import type {
+  Assignment,
   AssignmentsResponse,
+  Course,
   CoursesResponse,
   Student,
   StudentsResponse,
 } from '../../api-types';
 import { useConfig } from '../../config';
-import { useAPIFetch } from '../../utils/api';
+import { usePaginatedAPIFetch } from '../../utils/api';
 
 export type DashboardActivityFiltersProps = {
   selectedCourseIds: string[];
@@ -25,6 +27,18 @@ export type DashboardActivityFiltersProps = {
 };
 
 type FiltersStudent = Student & { has_display_name: boolean };
+
+/**
+ * Checks if provided element's scroll is at the bottom.
+ * @param offset - Return true if the difference between the element's current
+ *                 and maximum scroll position is below this value.
+ *                 Defaults to 20.
+ */
+function elementScrollIsAtBottom(element: HTMLElement, offset = 20): boolean {
+  const distanceToTop = element.scrollTop + element.clientHeight;
+  const triggerPoint = element.scrollHeight - offset;
+  return distanceToTop >= triggerPoint;
+}
 
 /**
  * Renders drop-downs to select courses, assignments and/or students, used to
@@ -46,112 +60,176 @@ export default function DashboardActivityFilters({
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 
-  const courses = useAPIFetch<CoursesResponse>(routes.courses, {
-    h_userid: selectedStudentIds,
-    assignment_id: selectedAssignmentIds,
-    public_id: dashboard.organization_public_id,
-  });
-  const assignments = useAPIFetch<AssignmentsResponse>(routes.assignments, {
-    h_userid: selectedStudentIds,
-    course_id: selectedCourseIds,
-    public_id: dashboard.organization_public_id,
-  });
-  const students = useAPIFetch<StudentsResponse>(routes.students, {
-    assignment_id: selectedAssignmentIds,
-    course_id: selectedCourseIds,
-    public_id: dashboard.organization_public_id,
-  });
+  const coursesFilters = useMemo(
+    () => ({
+      h_userid: selectedStudentIds,
+      assignment_id: selectedAssignmentIds,
+      public_id: dashboard.organization_public_id,
+    }),
+    [
+      dashboard.organization_public_id,
+      selectedAssignmentIds,
+      selectedStudentIds,
+    ],
+  );
+  const coursesResult = usePaginatedAPIFetch<
+    'courses',
+    Course[],
+    CoursesResponse
+  >('courses', routes.courses, coursesFilters);
+
+  const assignmentFilters = useMemo(
+    () => ({
+      h_userid: selectedStudentIds,
+      course_id: selectedCourseIds,
+      public_id: dashboard.organization_public_id,
+    }),
+    [dashboard.organization_public_id, selectedCourseIds, selectedStudentIds],
+  );
+  const assignmentsResults = usePaginatedAPIFetch<
+    'assignments',
+    Assignment[],
+    AssignmentsResponse
+  >('assignments', routes.assignments, assignmentFilters);
+
+  const studentsFilters = useMemo(
+    () => ({
+      assignment_id: selectedAssignmentIds,
+      course_id: selectedCourseIds,
+      public_id: dashboard.organization_public_id,
+    }),
+    [
+      dashboard.organization_public_id,
+      selectedAssignmentIds,
+      selectedCourseIds,
+    ],
+  );
+  const studentsResult = usePaginatedAPIFetch<
+    'students',
+    Student[],
+    StudentsResponse
+  >('students', routes.students, studentsFilters);
   const studentsWithFallbackName: FiltersStudent[] | undefined = useMemo(
     () =>
-      students.data?.students.map(({ display_name, ...s }) => ({
+      studentsResult.data?.map(({ display_name, ...s }) => ({
         ...s,
         display_name:
           display_name ??
           `Student name unavailable (ID: ${s.lms_id.substring(0, 5)})`,
         has_display_name: !!display_name,
       })),
-    [students.data?.students],
+    [studentsResult.data],
   );
 
   return (
     <div className="flex gap-2 flex-wrap">
       <MultiSelect
-        disabled={courses.isLoading}
+        disabled={coursesResult.isLoadingFirstPage}
         value={selectedCourseIds}
         onChange={onCoursesChange}
         aria-label="Select courses"
         containerClasses="!w-auto min-w-[180px]"
         buttonContent={
-          courses.isLoading ? (
+          coursesResult.isLoadingFirstPage ? (
             <>...</>
           ) : selectedCourseIds.length === 0 ? (
             <>All courses</>
           ) : selectedCourseIds.length === 1 ? (
-            courses.data?.courses.find(c => `${c.id}` === selectedCourseIds[0])
-              ?.title
+            coursesResult.data?.find(c => `${c.id}` === selectedCourseIds[0])
+              ?.title ?? '1 course'
           ) : (
             <>{selectedCourseIds.length} courses</>
           )
         }
         data-testid="courses-select"
+        onListboxScroll={e => {
+          if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {
+            coursesResult.loadNextPage();
+          }
+        }}
       >
         <MultiSelect.Option value={undefined}>All courses</MultiSelect.Option>
-        {courses.data?.courses.map(course => (
+        {coursesResult.data?.map(course => (
           <MultiSelect.Option key={course.id} value={`${course.id}`}>
             {course.title}
           </MultiSelect.Option>
         ))}
+        {coursesResult.isLoading && !coursesResult.isLoadingFirstPage && (
+          <MultiSelect.Option disabled value={undefined}>
+            <span className="italic" data-testid="loading-more-courses">
+              Loading more courses...
+            </span>
+          </MultiSelect.Option>
+        )}
       </MultiSelect>
       <MultiSelect
-        disabled={assignments.isLoading}
+        disabled={assignmentsResults.isLoadingFirstPage}
         value={selectedAssignmentIds}
         onChange={onAssignmentsChange}
         aria-label="Select assignments"
         containerClasses="!w-auto min-w-[180px]"
         buttonContent={
-          assignments.isLoading ? (
+          assignmentsResults.isLoadingFirstPage ? (
             <>...</>
           ) : selectedAssignmentIds.length === 0 ? (
             <>All assignments</>
           ) : selectedAssignmentIds.length === 1 ? (
-            assignments.data?.assignments.find(
+            assignmentsResults.data?.find(
               a => `${a.id}` === selectedAssignmentIds[0],
-            )?.title
+            )?.title ?? '1 assignment'
           ) : (
             <>{selectedAssignmentIds.length} assignments</>
           )
         }
         data-testid="assignments-select"
+        onListboxScroll={e => {
+          if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {
+            assignmentsResults.loadNextPage();
+          }
+        }}
       >
         <MultiSelect.Option value={undefined}>
           All assignments
         </MultiSelect.Option>
-        {assignments.data?.assignments.map(assignment => (
+        {assignmentsResults.data?.map(assignment => (
           <MultiSelect.Option key={assignment.id} value={`${assignment.id}`}>
             {assignment.title}
           </MultiSelect.Option>
         ))}
+        {assignmentsResults.isLoading &&
+          !assignmentsResults.isLoadingFirstPage && (
+            <MultiSelect.Option disabled value={undefined}>
+              <span className="italic" data-testid="loading-more-assignments">
+                Loading more assignments...
+              </span>
+            </MultiSelect.Option>
+          )}
       </MultiSelect>
       <MultiSelect
-        disabled={students.isLoading}
+        disabled={studentsResult.isLoadingFirstPage}
         value={selectedStudentIds}
         onChange={onStudentsChange}
         aria-label="Select students"
         containerClasses="!w-auto min-w-[180px]"
         buttonContent={
-          students.isLoading ? (
+          studentsResult.isLoadingFirstPage ? (
             <>...</>
           ) : selectedStudentIds.length === 0 ? (
             <>All students</>
           ) : selectedStudentIds.length === 1 ? (
             studentsWithFallbackName?.find(
               s => s.h_userid === selectedStudentIds[0],
-            )?.display_name
+            )?.display_name ?? '1 student'
           ) : (
             <>{selectedStudentIds.length} students</>
           )
         }
         data-testid="students-select"
+        onListboxScroll={e => {
+          if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {
+            studentsResult.loadNextPage();
+          }
+        }}
       >
         <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
         {studentsWithFallbackName?.map(student => (
@@ -169,6 +247,13 @@ export default function DashboardActivityFilters({
             </span>
           </MultiSelect.Option>
         ))}
+        {studentsResult.isLoading && !studentsResult.isLoadingFirstPage && (
+          <MultiSelect.Option disabled value={undefined}>
+            <span className="italic" data-testid="loading-more-students">
+              Loading more students...
+            </span>
+          </MultiSelect.Option>
+        )}
       </MultiSelect>
       {hasSelection && onClearSelection && (
         <IconButton


### PR DESCRIPTION
Add logic to load paginated items in filters dropdowns.

With the changes introduced here, dropdowns will initially load the first page of results, but when scrolling close to the bottom 20px, it will start loading the next page and append the results to the existing ones, if any.

Considerations:

* When filters change, all depending dropdowns will reset loaded pages and start with the first one again.
* When loading the first page, the dropdown will appear disabled, but when loading the next pages, users will still be able to interact with existing pages, and an extra option will be displayed at the very bottom to indicate further data loading.
  * Ideally, we should find the balance between not loading data too soon, but also not showing the option loading indicator if possible.

[Grabación de pantalla desde 2024-08-05 12-29-14.webm](https://github.com/user-attachments/assets/afb57c5c-48d6-4682-8534-b7555c28c5c8)

> This video has been recorded with Slow 3G throttling and 15-item pages, just to showcase the feature more clearly

### Out of scope

* This PR handles the case in which one item is selected, but it does not appear in the first page, by simply rendering "1 item", and replacing it with the actual value once loaded.
    This only covers the happy path though. If an item is selected but it is invalid, the fallback logic will still render "1 item". I'll explore ways to improve this separately.
* Error handling is not covered here, as it was already missing. I created a dedicated issue to improve error handling https://github.com/hypothesis/lms/issues/6531
* Improve how generics are defined in `usePaginatedAPIFetch`. See https://github.com/hypothesis/lms/pull/6515#discussion_r1706552845 for details.

### Testing steps

The assignments list is the easiest to populate in local envs, so I have been testing with that one specifically.

1. Go to https://hypothesis.instructure.com/courses/125/assignments and launch all assignments under `localhost (make devdata) Assignments (please keep tidy)`. This should make add all of them to the dashboard assignments dropdown.
2. Open `pagination.py` and add a smaller default page size. 15 allows for scroll to appear while being smaller than the total.
    ```diff
    diff --git a/lms/views/dashboard/pagination.py b/lms/views/dashboard/pagination.py
    index 680843cdd..396c7d893 100644
    --- a/lms/views/dashboard/pagination.py
    +++ b/lms/views/dashboard/pagination.py
    @@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
     T = TypeVar("T")
     
     
    -MAX_ITEMS_PER_PAGE = 100
    +MAX_ITEMS_PER_PAGE = 15
    ```
3. Open the assignments dropdown, scroll down, and notice how another page is loaded.
4. Select anything in the other dropdowns. It should reset the contents of the assignments dropdown.

If you enable network throttling, some of the state changes are easier to notice.

### Todo

- [x] Prevent loading next page again if it is already being loaded, for example if users scrolls up and down repeatedly.
- [x] Think on how to handle selected items that are not part of the first page:
    - ~Load pages until all selected items have been loaded.~
    - Just display the amount of selected items assuming they are all "good". If only one item is selected and we can't find it in first page, display "1 item selected" as we do when there's multiple items. <- I choose this for now.
- [x] Fix some consistency issues in `usePaginatedAPIFetch`.
- [x] Add tests.