### PR TITLE
Explicitly store the assignment assignment -> course relationship

### DIFF
--- a/lms/migrations/versions/18109b584a5b_add_assignment_course_relationship.py
+++ b/lms/migrations/versions/18109b584a5b_add_assignment_course_relationship.py
@@ -1,0 +1,25 @@
+"""Add assignment course relationship."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "18109b584a5b"
+down_revision = "d8d33d882b88"
+
+
+def upgrade() -> None:
+    op.add_column("assignment", sa.Column("course_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk__assignment__course_id__grouping"),
+        "assignment",
+        "grouping",
+        ["course_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__assignment__course_id__grouping"), "assignment", type_="foreignkey"
+    )
+    op.drop_column("assignment", "course_id")

--- a/lms/migrations/versions/f6c442c861c4_backfill_assignment_course_id.py
+++ b/lms/migrations/versions/f6c442c861c4_backfill_assignment_course_id.py
@@ -1,0 +1,37 @@
+"""Backfill assignment.course_id."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f6c442c861c4"
+down_revision = "18109b584a5b"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+        WITH assignment_courses as (
+          SELECT DISTINCT ON (assignment.id) assignment.id as assignment_id, grouping.id  as course_id
+          FROM assignment
+          JOIN assignment_grouping on assignment.id = assignment_grouping.assignment_id
+          JOIN grouping on grouping.id = grouping_id
+          -- Only courses, not sections or groups
+          WHERE grouping.type = 'course'
+          -- Don't override data we already set since we created the column
+          and assignment.course_id is null
+          -- Order for the `DISTINCT ON`, when duplicate found for one assignment, pick the latest
+          ORDER BY assignment.id, assignment_grouping.created desc
+       )
+          UPDATE assignment set course_id = assignment_courses.course_id
+          FROM assignment_courses
+          WHERE assignment.id = assignment_courses.assignment_id
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -81,6 +81,7 @@ class Assignment(CreatedUpdatedMixin, Base):
     groupings: DynamicMapped[Grouping] = sa.orm.relationship(
         secondary="assignment_grouping", viewonly=True, lazy="dynamic"
     )
+    """Any groupings (courses, sections, groups) we have seen this assignment during a launch"""
 
     membership = sa.orm.relationship(
         "AssignmentMembership", lazy="dynamic", viewonly=True
@@ -91,16 +92,11 @@ class Assignment(CreatedUpdatedMixin, Base):
     """
     Last course we have seen this assigment belonging to.
 
-    @property
-    def course(self):
-        """Course this assignment belongs to."""
-        return (
-            self.groupings.filter_by(type="course")
-            .order_by(Grouping.created.desc())
-            # While logically one assignment belongs to only one course our grouping table might have more
-            # than one row representing the same course. Return the last created one.
-            .first()
-        )
+    Logically one assigment belongs to only one course but this might change from one launch to the next as
+    we record a new course in the DB for the same LMS one because we seen it on a new install.
+
+    We can use AssigmentGrouping for more detailed queries.
+    """
 
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,11 +1,11 @@
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import DynamicMapped, Mapped, mapped_column
+from sqlalchemy.orm import DynamicMapped, Mapped, mapped_column, relationship
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
-from lms.models.grouping import Grouping
+from lms.models.grouping import Course, Grouping
 
 
 class Assignment(CreatedUpdatedMixin, Base):
@@ -72,10 +72,10 @@ class Assignment(CreatedUpdatedMixin, Base):
     title: Mapped[str | None] = mapped_column(sa.Unicode, index=True)
     """The resource link title from LTI params."""
 
-    description = sa.Column(sa.Unicode, nullable=True)
+    description: Mapped[str | None] = mapped_column(sa.Unicode)
     """The resource link description from LTI params."""
 
-    deep_linking_uuid: Mapped[str | None] = mapped_column(sa.Unicode, nullable=True)
+    deep_linking_uuid: Mapped[str | None] = mapped_column(sa.Unicode)
     """UUID that identifies the deep linking that created this assignment."""
 
     groupings: DynamicMapped[Grouping] = sa.orm.relationship(
@@ -85,6 +85,11 @@ class Assignment(CreatedUpdatedMixin, Base):
     membership = sa.orm.relationship(
         "AssignmentMembership", lazy="dynamic", viewonly=True
     )
+
+    course_id: Mapped[int | None] = mapped_column(sa.ForeignKey(Course.id))
+    course: Mapped[Course | None] = relationship(Course)
+    """
+    Last course we have seen this assigment belonging to.
 
     @property
     def course(self):

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -9,6 +9,7 @@ from lms.models import (
     Assignment,
     AssignmentGrouping,
     AssignmentMembership,
+    Course,
     Grouping,
     LTIRole,
     Organization,
@@ -52,7 +53,14 @@ class AssignmentService:
 
         return assignment
 
-    def update_assignment(self, request, assignment, document_url, group_set_id):
+    def update_assignment(  # noqa: PLR0913
+        self,
+        request,
+        assignment: Assignment,
+        document_url: str,
+        group_set_id,
+        course: Course,
+    ):
         """Update an existing assignment."""
         if self._misc_plugin.is_speed_grader_launch(request):
             # SpeedGrader has a number of issues regarding the information it sends about the assignment
@@ -74,6 +82,7 @@ class AssignmentService:
         assignment.is_gradable = self._misc_plugin.is_assignment_gradable(
             request.lti_params
         )
+        assignment.course = course
 
         return assignment
 
@@ -101,7 +110,7 @@ class AssignmentService:
 
         return None
 
-    def get_assignment_for_launch(self, request) -> Assignment | None:
+    def get_assignment_for_launch(self, request, course: Course) -> Assignment | None:
         """
         Get or create an assignment for the current launch.
 
@@ -157,7 +166,9 @@ class AssignmentService:
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.
-        return self.update_assignment(request, assignment, document_url, group_set_id)
+        return self.update_assignment(
+            request, assignment, document_url, group_set_id, course
+        )
 
     def upsert_assignment_membership(
         self, assignment: Assignment, user: User, lti_roles: list[LTIRole]

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -55,7 +55,7 @@ class AdminAssignmentViews:
                 "dashboard.assignment",
                 assignment_id=assignment.id,
                 _query={
-                    "public_id": assignment.course.application_instance.organization.public_id
+                    "public_id": assignment.course.application_instance.organization.public_id  # type: ignore
                 },
             ),
         )

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -59,7 +59,9 @@ class BasicLaunchViews:
     def lti_launch(self):
         """Handle regular LTI launches."""
 
-        assignment = self.assignment_service.get_assignment_for_launch(self.request)
+        assignment = self.assignment_service.get_assignment_for_launch(
+            self.request, self.course
+        )
 
         if error_code := self.request.find_service(VitalSourceService).check_h_license(
             self.request.lti_user, self.request.lti_params, assignment
@@ -263,6 +265,7 @@ class BasicLaunchViews:
             assignment,
             document_url=self.request.parsed_params["document_url"],
             group_set_id=self.request.parsed_params.get("group_set"),
+            course=self.course,
         )
 
     def _configure_js_for_file_picker(

--- a/tests/unit/lms/models/assignment_test.py
+++ b/tests/unit/lms/models/assignment_test.py
@@ -1,9 +1,6 @@
-import datetime
-
 import pytest
 
 from lms.models import Assignment
-from tests import factories
 
 
 class TestAssignment:
@@ -32,23 +29,6 @@ class TestAssignment:
         self, assignment
     ):
         assert assignment.get_canvas_mapped_file_id("file_id") == "file_id"
-
-    def test_course(self, assignment, db_session):
-        course = factories.Course(created=datetime.datetime(2024, 1, 1))
-        factories.AssignmentGrouping(
-            assignment=assignment, grouping=factories.CanvasSection()
-        )
-        factories.AssignmentGrouping(
-            assignment=assignment, grouping=factories.CanvasGroup()
-        )
-        factories.AssignmentGrouping(
-            assignment=assignment,
-            grouping=factories.Course(created=datetime.datetime(2022, 1, 1)),
-        )
-        factories.AssignmentGrouping(assignment=assignment, grouping=course)
-        db_session.flush()
-
-        assert assignment.course == course
 
     @pytest.fixture
     def assignment(self, db_session):

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -61,15 +61,13 @@ class TestDashboardService:
         svc,
         organization,
         db_session,
-        application_instance,
+        course,
         get_request_admin_organizations,
     ):
-        assignment = factories.Assignment()
-        course = factories.Course(application_instance=application_instance)
-        factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        assignment = factories.Assignment(course_id=course.id)
+        db_session.flush()
         assignment_service.get_by_id.return_value = assignment
         get_request_admin_organizations.return_value = [organization]
-        db_session.flush()
 
         pyramid_request.matchdict["assignment_id"] = sentinel.id
 
@@ -108,13 +106,11 @@ class TestDashboardService:
         pyramid_request,
         course_service,
         svc,
-        application_instance,
         organization,
         get_request_admin_organizations,
+        course,
     ):
-        course_service.get_by_id.return_value = factories.Course(
-            application_instance=application_instance
-        )
+        course_service.get_by_id.return_value = course
         get_request_admin_organizations.return_value = [organization]
         pyramid_request.matchdict["course_id"] = sentinel.id
 
@@ -201,6 +197,12 @@ class TestDashboardService:
         return DashboardService(
             pyramid_request, assignment_service, course_service, organization_service
         )
+
+    @pytest.fixture()
+    def course(self, db_session, application_instance):
+        course = factories.Course(application_instance=application_instance)
+        db_session.flush()
+        return course
 
     @pytest.fixture()
     def get_request_admin_organizations(self, svc):

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -63,8 +63,8 @@ class TestAdminAssignmentViews:
 
     @pytest.fixture
     def assignment(self, application_instance, db_session):
-        assignment = factories.Assignment()
         course = factories.Course(application_instance=application_instance)
+        assignment = factories.Assignment(course=course)
         factories.AssignmentGrouping(assignment=assignment, grouping=course)
         db_session.flush()  # Give the DB objects IDs
         return assignment

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -42,7 +42,7 @@ class TestAssignmentViews:
         }
 
     def test_assignment(
-        self, views, pyramid_request, course, assignment, db_session, dashboard_service
+        self, views, pyramid_request, assignment, db_session, dashboard_service
     ):
         db_session.flush()
         pyramid_request.matchdict["assignment_id"] = sentinel.id
@@ -57,7 +57,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "course": {"id": course.id, "title": course.lms_name},
+            "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
         }
 
     def test_course_assignments(
@@ -212,7 +212,7 @@ class TestAssignmentViews:
 
     @pytest.fixture
     def assignment(self, course):
-        assignment = factories.Assignment()
+        assignment = factories.Assignment(course=course)
         factories.AssignmentGrouping(assignment=assignment, grouping=course)
 
         return assignment

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -49,7 +49,7 @@ class TestBasicLaunchViews:
         )
 
     def test_configure_assignment_callback(
-        self, svc, pyramid_request, _show_document, assignment_service
+        self, svc, pyramid_request, _show_document, assignment_service, course_service
     ):
         pyramid_request.parsed_params = {
             "document_url": sentinel.document_url,
@@ -67,6 +67,7 @@ class TestBasicLaunchViews:
             assignment_service.create_assignment.return_value,
             document_url=sentinel.document_url,
             group_set_id=sentinel.group_set,
+            course=course_service.get_from_launch.return_value,
         )
         _show_document.assert_called_once_with(
             assignment_service.create_assignment.return_value,
@@ -112,11 +113,12 @@ class TestBasicLaunchViews:
         pyramid_request,
         _show_document,
         LTIEvent,
+        course_service,
     ):
         svc.lti_launch()
 
         assignment_service.get_assignment_for_launch.assert_called_once_with(
-            pyramid_request
+            pyramid_request, course_service.get_from_launch.return_value
         )
 
         _show_document.assert_called_once_with(


### PR DESCRIPTION
**This PR can not be merged as a whole, the first migration needs to be deployed first.**

--

This doesn't address 

- https://github.com/hypothesis/lms/issues/6516

But it will help simplify some queries for now while we fix it, out of scope of this PR.

--

We currently store the relationship between assignments and any "grouping" in assigment_grouping.

While that contains the assignment course relationship is not trivial to query for such a fundamental relationship.

This PR introduces a new relationship to explicitly access the course an assignment belongs to.

There are no behaviour changes here, we just enable a more straightforward way to access the same data.


The process to merge it would be to split this in the following PRs:

- [x] [Migration for the new column](https://github.com/hypothesis/lms/pull/6519)
- [x] [Code changes in the model ](https://github.com/hypothesis/lms/pull/6520)
- [x] [Filling the value for new launches.](https://github.com/hypothesis/lms/pull/6525)
- [x] [Backfill assignment.course_id from existing values in assignment_grouping](https://github.com/hypothesis/lms/pull/6526)
- [x] [Code changes to replace the current custom query by the SQLA relationship.](https://github.com/hypothesis/lms/pull/6528)

