### PR TITLE
Switch approach for staff dashboard access to org scoped URL

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -100,13 +100,4 @@ class User(TypedDict):
 
 class DashboardConfig(TypedDict):
     user: User
-
-    organization_public_id: NotRequired[str]
-    """
-    Filtering by organization is not like other filters:
-    - It's only available to staff members
-    - It doesn't only filter but also authorized access to that orgnaiztion's data
-    For those resason we include it on the config instead of handling it like other query string parameters.
-    """
-
     routes: DashboardRoutes

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -280,8 +280,6 @@ class JSConfig:
                 ),
             }
         )
-        if organization_public_id := self._request.params.get("public_id"):
-            self._config["dashboard"]["organization_public_id"] = organization_public_id
 
     def enable_lti_launch_mode(self, course, assignment: Assignment):
         """

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -258,9 +258,23 @@ def includeme(config):  # noqa: PLR0915
         "/dashboard/courses/{course_id}",
         factory="lms.resources.dashboard.DashboardResource",
     )
-
     config.add_route(
         "dashboard", "/dashboard", factory="lms.resources.dashboard.DashboardResource"
+    )
+    config.add_route(
+        "dashboard.organization",
+        "/dashboard/orgs/{public_id}",
+        factory="lms.resources.dashboard.DashboardResource",
+    )
+    config.add_route(
+        "dashboard.organization.assignment",
+        "/dashboard/orgs/{public_id}/assignments/{assignment_id}",
+        factory="lms.resources.dashboard.DashboardResource",
+    )
+    config.add_route(
+        "dashboard.organization.course",
+        "/dashboard/orgs/{public_id}/courses/{course_id}",
+        factory="lms.resources.dashboard.DashboardResource",
     )
 
     config.add_route("api.dashboard.courses.metrics", "/api/dashboard/courses/metrics")

--- a/lms/security.py
+++ b/lms/security.py
@@ -99,11 +99,11 @@ class SecurityPolicy:
 
         path = request.path
 
-        if path.startswith("/admin") or path.startswith("/googleauth"):
+        if path.startswith(("/admin", "/googleauth", "/dashboard/orgs")):
             # Routes that require the Google auth policy
             return LMSGoogleSecurityPolicy()
 
-        if path.startswith(("/dashboard", "/api/dashboard")):
+        if path.startswith(("/api/dashboard")):
             # For certain routes we only use the google policy in case it resulted
             # non empty identity.
             # This is useful for routes that can be used by admin pages users on top of

--- a/lms/static/scripts/frontend_apps/components/AppRoot.tsx
+++ b/lms/static/scripts/frontend_apps/components/AppRoot.tsx
@@ -41,6 +41,9 @@ export default function AppRoot({ initialConfig, services }: AppRootProps) {
               <FilePickerApp />
             </DataLoader>
           </Route>
+          <Route path="/dashboard/orgs/:organizationPublicId" nest>
+            <DashboardApp />
+          </Route>
           <Route path="/dashboard" nest>
             <DashboardApp />
           </Route>

--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 import { Link as RouterLink } from 'wouter-preact';
+import { useParams } from 'wouter-preact';
 
 import type { CoursesMetricsResponse } from '../../api-types';
 import { useConfig } from '../../config';
@@ -28,6 +29,7 @@ export default function AllCoursesActivity() {
 
   useDocumentTitle('All courses');
 
+  const { organizationPublicId } = useParams();
   const { filters, updateFilters } = useDashboardFilters();
   const { courseIds, assignmentIds, studentIds } = filters;
 
@@ -35,7 +37,7 @@ export default function AllCoursesActivity() {
     h_userid: studentIds,
     assignment_id: assignmentIds,
     course_id: courseIds,
-    public_id: dashboard.organization_public_id,
+    public_id: organizationPublicId,
   });
   const rows: CoursesTableRow[] = useMemo(
     () =>

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -27,7 +27,10 @@ type StudentsTableRow = {
 export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
-  const { assignmentId } = useParams<{ assignmentId: string }>();
+  const { assignmentId, organizationPublicId } = useParams<{
+    assignmentId: string;
+    organizationPublicId?: string;
+  }>();
   const assignment = useAPIFetch<AssignmentWithMetrics>(
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
@@ -35,7 +38,7 @@ export default function AssignmentActivity() {
     routes.students_metrics,
     {
       assignment_id: assignmentId,
-      public_id: dashboard.organization_public_id,
+      public_id: organizationPublicId,
     },
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -31,7 +31,10 @@ type AssignmentsTableRow = {
  * Activity in a list of assignments that are part of a specific course
  */
 export default function CourseActivity() {
-  const { courseId } = useParams<{ courseId: string }>();
+  const { courseId, organizationPublicId } = useParams<{
+    courseId: string;
+    organizationPublicId?: string;
+  }>();
   const [, navigate] = useLocation();
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
@@ -56,7 +59,7 @@ export default function CourseActivity() {
     {
       assignment_id: assignmentIds,
       h_userid: studentIds,
-      public_id: dashboard.organization_public_id,
+      public_id: organizationPublicId,
     },
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -4,6 +4,7 @@ import {
   MultiSelect,
 } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
+import { useParams } from 'wouter-preact';
 
 import type {
   Assignment,
@@ -58,19 +59,16 @@ export default function DashboardActivityFilters({
     selectedAssignmentIds.length > 0 ||
     selectedCourseIds.length > 0;
   const { dashboard } = useConfig(['dashboard']);
+  const { organizationPublicId } = useParams();
   const { routes } = dashboard;
 
   const coursesFilters = useMemo(
     () => ({
       h_userid: selectedStudentIds,
       assignment_id: selectedAssignmentIds,
-      public_id: dashboard.organization_public_id,
+      public_id: organizationPublicId,
     }),
-    [
-      dashboard.organization_public_id,
-      selectedAssignmentIds,
-      selectedStudentIds,
-    ],
+    [organizationPublicId, selectedAssignmentIds, selectedStudentIds],
   );
   const coursesResult = usePaginatedAPIFetch<
     'courses',
@@ -82,9 +80,9 @@ export default function DashboardActivityFilters({
     () => ({
       h_userid: selectedStudentIds,
       course_id: selectedCourseIds,
-      public_id: dashboard.organization_public_id,
+      public_id: organizationPublicId,
     }),
-    [dashboard.organization_public_id, selectedCourseIds, selectedStudentIds],
+    [organizationPublicId, selectedCourseIds, selectedStudentIds],
   );
   const assignmentsResults = usePaginatedAPIFetch<
     'assignments',
@@ -96,13 +94,9 @@ export default function DashboardActivityFilters({
     () => ({
       assignment_id: selectedAssignmentIds,
       course_id: selectedCourseIds,
-      public_id: dashboard.organization_public_id,
+      public_id: organizationPublicId,
     }),
-    [
-      dashboard.organization_public_id,
-      selectedAssignmentIds,
-      selectedCourseIds,
-    ],
+    [organizationPublicId, selectedAssignmentIds, selectedCourseIds],
   );
   const studentsResult = usePaginatedAPIFetch<
     'students',

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -32,6 +32,7 @@ describe('AllCoursesActivity', () => {
   let wrappers;
 
   let fakeUseAPIFetch;
+  let fakeUseParams;
   let fakeConfig;
 
   beforeEach(() => {
@@ -44,6 +45,7 @@ describe('AllCoursesActivity', () => {
       isLoading: false,
       data: { courses },
     });
+    fakeUseParams = sinon.stub().returns({});
     fakeConfig = {
       dashboard: {
         routes: {
@@ -61,6 +63,9 @@ describe('AllCoursesActivity', () => {
     $imports.$mock({
       '../../utils/api': {
         useAPIFetch: fakeUseAPIFetch,
+      },
+      'wouter-preact': {
+        useParams: fakeUseParams,
       },
     });
   });
@@ -198,9 +203,9 @@ describe('AllCoursesActivity', () => {
     });
   });
 
-  context('when `organization_public_id` is present in config', () => {
+  context('when `organizationPublicId` is present in URL params', () => {
     beforeEach(() => {
-      fakeConfig.dashboard.organization_public_id = 'the-org-public-id';
+      fakeUseParams.returns({ organizationPublicId: 'the-org-public-id' });
     });
 
     it('propagates public_id to API calls', () => {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -277,7 +277,6 @@ export type DashboardUser = {
 
 export type DashboardConfig = {
   routes: DashboardRoutes;
-  organization_public_id?: string;
   user: DashboardUser;
 };
 

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -54,11 +54,9 @@ class AdminAssignmentViews:
         assert assignment.course
         response = HTTPFound(
             location=self.request.route_url(
-                "dashboard.assignment",
+                "dashboard.organization.assignment",
                 assignment_id=assignment.id,
-                _query={
-                    "public_id": assignment.course.application_instance.organization.public_id
-                },
+                public_id=assignment.course.application_instance.organization.public_id,
             ),
         )
         return response

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -82,12 +82,9 @@ class AdminCourseViews:
 
         response = HTTPFound(
             location=self.request.route_url(
-                "dashboard.course",
+                "dashboard.organization.course",
                 public_id=course.application_instance.organization.public_id,
                 course_id=course.id,
-                _query={
-                    "public_id": course.application_instance.organization.public_id
-                },
             ),
         )
         return response

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -307,7 +307,7 @@ class AdminOrganizationViews:
 
         return HTTPFound(
             location=self.request.route_url(
-                "dashboard", _query={"public_id": org.public_id}
+                "dashboard.organization", public_id=org.public_id
             ),
         )
 

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -72,6 +72,12 @@ class DashboardViews:
         request_method="GET",
         renderer="lms:templates/dashboard/index.html.jinja2",
     )
+    @view_config(
+        route_name="dashboard.organization.assignment",
+        permission=Permissions.DASHBOARD_VIEW,
+        request_method="GET",
+        renderer="lms:templates/dashboard/index.html.jinja2",
+    )
     def assignment_show(self):
         """Start the dashboard miniapp in the frontend.
 
@@ -88,6 +94,12 @@ class DashboardViews:
         request_method="GET",
         renderer="lms:templates/dashboard/index.html.jinja2",
     )
+    @view_config(
+        route_name="dashboard.organization.course",
+        permission=Permissions.DASHBOARD_VIEW,
+        request_method="GET",
+        renderer="lms:templates/dashboard/index.html.jinja2",
+    )
     def course_show(self):
         """Start the dashboard miniapp in the frontend.
 
@@ -100,6 +112,12 @@ class DashboardViews:
 
     @view_config(
         route_name="dashboard",
+        permission=Permissions.DASHBOARD_VIEW,
+        request_method="GET",
+        renderer="lms:templates/dashboard/index.html.jinja2",
+    )
+    @view_config(
+        route_name="dashboard.organization",
         permission=Permissions.DASHBOARD_VIEW,
         request_method="GET",
         renderer="lms:templates/dashboard/index.html.jinja2",

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -713,14 +713,6 @@ class TestEnableDashboardMode:
             },
         }
 
-    def test_it_when_organizataion_public_id_present(self, js_config, pyramid_request):
-        pyramid_request.params["public_id"] = sentinel.public_id
-
-        js_config.enable_dashboard_mode()
-        config = js_config.asdict()
-
-        assert config["dashboard"]["organization_public_id"] == sentinel.public_id
-
     def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
         js_config = JSConfig(context, pyramid_request_staff_member)
         js_config.enable_dashboard_mode()

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -429,7 +429,7 @@ class TestSecurityPolicy:
         assert user_id == get_policy.return_value.forget.return_value
 
     @pytest.mark.parametrize(
-        "path", ["/api/dashboard/assignments/10", "/dashboard/organizations/ORGID"]
+        "path", ["/api/dashboard/assignments/10", "/dashboard/orgs/ORGID"]
     )
     def test_get_policy_google_when_available(
         self, pyramid_request, path, LMSGoogleSecurityPolicy
@@ -481,10 +481,8 @@ class TestSecurityPolicy:
             ("/assignment", FormBearerTokenLTIUserPolicy),
             ("/assignment/edit", FormBearerTokenLTIUserPolicy),
             ("/dashboard/launch/assignments/10", FormBearerTokenLTIUserPolicy),
-            (
-                "/dashboard/organizations/ORGID/assignments/10",
-                CookiesBearerTokenLTIUserPolicy,
-            ),
+            ("/dashboard/assignments/10", CookiesBearerTokenLTIUserPolicy),
+            ("/dashboard/orgs/ORGID/assignments/10", LMSGoogleSecurityPolicy),
         ],
     )
     def test_get_policy_lti_user(

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -57,7 +57,7 @@ class TestAdminAssignmentViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/assignments/{assignment.id}?public_id={organization.public_id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/assignments/{assignment.id}",
             }
         )
 

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -59,7 +59,7 @@ class TestAdminCourseViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/courses/{course.id}?public_id={organization.public_id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/courses/{course.id}",
             }
         )
 

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -356,7 +356,7 @@ class TestAdminOrganizationViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard?public_id={organization.public_id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}",
             }
         )
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6509


- We have now duplicate entry points URL, the ones scoped to one org (for staff) and the rest (for the LMS users)

- The frontend fetches the revalvnt public_id from the path parameter instead of a js_config value

- API endoints still take a public_id as any other filtering option