### PR TITLE
Migration for assignment.course_id

### DIFF
--- a/lms/migrations/versions/18109b584a5b_add_assignment_course_relationship.py
+++ b/lms/migrations/versions/18109b584a5b_add_assignment_course_relationship.py
@@ -1,0 +1,25 @@
+"""Add assignment course relationship."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "18109b584a5b"
+down_revision = "d8d33d882b88"
+
+
+def upgrade() -> None:
+    op.add_column("assignment", sa.Column("course_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk__assignment__course_id__grouping"),
+        "assignment",
+        "grouping",
+        ["course_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__assignment__course_id__grouping"), "assignment", type_="foreignkey"
+    )
+    op.drop_column("assignment", "course_id")


### PR DESCRIPTION
Add a new relationship that links courses to assignment

Migration auto generated from:

- https://github.com/hypothesis/lms/pull/6520


More context and the rest of the changes to follow on:

- https://github.com/hypothesis/lms/pull/6517


## Testing


`tox -e dev --run-command 'alembic upgrade head'`


```dev run-test-pre: PYTHONHASHSEED='1184398793'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade d8d33d882b88 -> 18109b584a5b, Add assignment course relationship.````