### PR TITLE
Include students without name in students dropdown

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -47,9 +47,9 @@ describe('DashboardActivityFilters', () => {
   const students = [
     ...studentsWithName,
     {
-      lms_id: '3',
+      lms_id: '123456789',
       h_userid: 'acct:3@lms.hypothes.is',
-      display_name: '', // Student with an empty name won't be displayed
+      display_name: null, // Student with an empty name won't be displayed
     },
   ];
 
@@ -178,9 +178,11 @@ describe('DashboardActivityFilters', () => {
       expectedOptions: [
         'All students',
         ...studentsWithName.map(s => s.display_name),
+        'Student name unavailable (ID: 12345)',
       ],
+      expectedTitles: [undefined, undefined, undefined, 'User ID: 123456789'],
     },
-  ].forEach(({ id, expectedOptions }) => {
+  ].forEach(({ id, expectedOptions, expectedTitles = [] }) => {
     it('renders corresponding options', () => {
       const wrapper = createComponent();
       const select = getSelect(wrapper, id);
@@ -189,6 +191,13 @@ describe('DashboardActivityFilters', () => {
       assert.equal(options.length, expectedOptions.length);
       options.forEach((option, index) => {
         assert.equal(option.text(), expectedOptions[index]);
+
+        if (expectedTitles[index]) {
+          assert.equal(
+            option.find('[data-testid="option-content-wrapper"]').prop('title'),
+            expectedTitles[index],
+          );
+        }
       });
     });
   });
@@ -302,7 +311,7 @@ describe('DashboardActivityFilters', () => {
       {
         props: {
           selectedAssignmentIds: [...assignments],
-          selectedStudentIds: [...studentsWithName],
+          selectedStudentIds: [...students],
         },
         shouldRenderClearButton: false,
       },


### PR DESCRIPTION
This PR rolls back the changes introduced in https://github.com/hypothesis/lms/pull/6459, as we have realized excluding students without a `display_name` from the students dropdown, makes it harder to debug when something goes wrong.

Instead, we are now displaying a `Student name unavailable (ID: X)` placeholder, where X are the first 5 characters of the user LMS ID.

For debugging purposes, we include the full ID in the option's `title` prop.

![image](https://github.com/user-attachments/assets/d7e278b9-3557-4e7e-9a85-3e392e6dd996)

### Testing steps

In dev envs it might be harder to have a student without a name, so one way to reproduce that is by checking what the `/api/dashboard/students` endpoint returns for you, copying it, and pasting one student in `user.py` but with `display_name: None`, like this:

```diff
--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -82,10 +82,11 @@ class UserViews:
 
         return {
             "students": [
-                APIStudent(
-                    h_userid=s.h_userid, lms_id=s.user_id, display_name=s.display_name
-                )
-                for s in students
+                {
+                    "h_userid": "acct:9ea84c4bcfd9329b4495f5b27d8cb6@lms.hypothes.is",
+                    "lms_id": "895e33d49018ec7f1f3f0f26da592405b07b38d0",
+                    "display_name": None,
+                },
             ],
             "pagination": pagination,
         }
```