### PR TITLE
Allow dashboard filters to be conditionally displayed

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -51,12 +51,18 @@ export default function AllCoursesActivity() {
     <div className="flex flex-col gap-y-5">
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
       <DashboardActivityFilters
-        selectedStudentIds={studentIds}
-        onStudentsChange={studentIds => updateFilters({ studentIds })}
-        selectedAssignmentIds={assignmentIds}
-        onAssignmentsChange={assignmentIds => updateFilters({ assignmentIds })}
-        selectedCourseIds={courseIds}
-        onCoursesChange={courseIds => updateFilters({ courseIds })}
+        students={{
+          selectedIds: studentIds,
+          onChange: studentIds => updateFilters({ studentIds }),
+        }}
+        assignments={{
+          selectedIds: assignmentIds,
+          onChange: assignmentIds => updateFilters({ assignmentIds }),
+        }}
+        courses={{
+          selectedIds: courseIds,
+          onChange: courseIds => updateFilters({ courseIds }),
+        }}
         onClearSelection={() =>
           updateFilters({ studentIds: [], assignmentIds: [], courseIds: [] })
         }

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -88,27 +88,33 @@ export default function CourseActivity() {
         </h2>
       </div>
       <DashboardActivityFilters
-        selectedCourseIds={[courseId]}
-        onCoursesChange={newCourseIds => {
-          // When no courses are selected (which happens if either "All courses" is
-          // selected or the active course is deselected), navigate to "All courses"
-          // section and propagate the rest of the filters.
-          if (newCourseIds.length === 0) {
-            navigate(`?${search}`);
-          }
+        courses={{
+          selectedIds: [courseId],
+          onChange: newCourseIds => {
+            // When no courses are selected (which happens if either "All courses" is
+            // selected or the active course is deselected), navigate to "All courses"
+            // section and propagate the rest of the filters.
+            if (newCourseIds.length === 0) {
+              navigate(`?${search}`);
+            }
 
-          // When a course other than the "active" one (the one represented
-          // in the URL) is selected, navigate to that course and propagate
-          // the rest of the filters.
-          const firstDifferentCourse = newCourseIds.find(c => c !== courseId);
-          if (firstDifferentCourse) {
-            navigate(`${courseURL(firstDifferentCourse)}?${search}`);
-          }
+            // When a course other than the "active" one (the one represented
+            // in the URL) is selected, navigate to that course and propagate
+            // the rest of the filters.
+            const firstDifferentCourse = newCourseIds.find(c => c !== courseId);
+            if (firstDifferentCourse) {
+              navigate(`${courseURL(firstDifferentCourse)}?${search}`);
+            }
+          },
         }}
-        selectedAssignmentIds={assignmentIds}
-        onAssignmentsChange={assignmentIds => updateFilters({ assignmentIds })}
-        selectedStudentIds={studentIds}
-        onStudentsChange={studentIds => updateFilters({ studentIds })}
+        assignments={{
+          selectedIds: assignmentIds,
+          onChange: assignmentIds => updateFilters({ assignmentIds }),
+        }}
+        students={{
+          selectedIds: studentIds,
+          onChange: studentIds => updateFilters({ studentIds }),
+        }}
         onClearSelection={hasSelection ? onClearSelection : undefined}
       />
       <OrderableActivityTable

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -164,8 +164,8 @@ describe('AllCoursesActivity', () => {
   it('allows metrics to be filtered', () => {
     const wrapper = createComponent();
     const filters = wrapper.find('DashboardActivityFilters');
-    const updateFilter = (changeCallback, arg) => {
-      act(() => filters.prop(changeCallback)(arg));
+    const updateFilter = (prop, arg) => {
+      act(() => filters.prop(prop).onChange(arg));
       wrapper.update();
     };
     const assertCoursesFetched = query =>
@@ -173,7 +173,7 @@ describe('AllCoursesActivity', () => {
 
     // Every time the filters callbacks are invoked, the component will
     // re-render and re-fetch metrics with updated query.
-    updateFilter('onStudentsChange', ['123', '456']);
+    updateFilter('students', ['123', '456']);
     assertCoursesFetched({
       h_userid: ['123', '456'],
       assignment_id: [],
@@ -181,7 +181,7 @@ describe('AllCoursesActivity', () => {
       public_id: undefined,
     });
 
-    updateFilter('onAssignmentsChange', ['1', '2']);
+    updateFilter('assignments', ['1', '2']);
     assertCoursesFetched({
       h_userid: [],
       assignment_id: ['1', '2'],
@@ -189,7 +189,7 @@ describe('AllCoursesActivity', () => {
       public_id: undefined,
     });
 
-    updateFilter('onCoursesChange', ['3', '8', '9']);
+    updateFilter('courses', ['3', '8', '9']);
     assertCoursesFetched({
       h_userid: [],
       assignment_id: [],

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -228,10 +228,10 @@ describe('CourseActivity', () => {
       const filters = wrapper.find('DashboardActivityFilters');
 
       // Course ID is set from the route
-      assert.deepEqual(filters.prop('selectedCourseIds'), ['123']);
+      assert.deepEqual(filters.prop('courses').selectedIds, ['123']);
       // Assignments and students are set from the query
-      assert.deepEqual(filters.prop('selectedAssignmentIds'), ['1', '2']);
-      assert.deepEqual(filters.prop('selectedStudentIds'), ['3']);
+      assert.deepEqual(filters.prop('assignments').selectedIds, ['1', '2']);
+      assert.deepEqual(filters.prop('students').selectedIds, ['3']);
 
       // Selected filters are propagated when loading assignment metrics
       assert.calledWith(fakeUseAPIFetch.lastCall, sinon.match.string, {
@@ -262,7 +262,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onAssignmentsChange(['3', '7']));
+      act(() => filters.prop('assignments').onChange(['3', '7']));
 
       assert.equal(location.search, '?assignment_id=3&assignment_id=7');
     });
@@ -271,7 +271,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onStudentsChange(['8', '20', '32']));
+      act(() => filters.prop('students').onChange(['8', '20', '32']));
 
       assert.equal(
         location.search,
@@ -296,7 +296,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onCoursesChange([]));
+      act(() => filters.prop('courses').onChange([]));
 
       assert.calledWith(fakeNavigate, '?current=query');
     });
@@ -305,7 +305,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onCoursesChange(['123', '789']));
+      act(() => filters.prop('courses').onChange(['123', '789']));
 
       assert.calledWith(fakeNavigate, '/courses/789?current=query');
     });

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -113,23 +113,33 @@ describe('DashboardActivityFilters', () => {
     $imports.$restore();
   });
 
-  function createComponent(props = {}) {
+  function createComponentWithProps(props) {
     const wrapper = mount(
       <Config.Provider value={fakeConfig}>
-        <DashboardActivityFilters
-          selectedCourseIds={[]}
-          onCoursesChange={onCoursesChange}
-          selectedAssignmentIds={[]}
-          onAssignmentsChange={onAssignmentsChange}
-          selectedStudentIds={[]}
-          onStudentsChange={onStudentsChange}
-          {...props}
-        />
+        <DashboardActivityFilters {...props} />
       </Config.Provider>,
     );
     wrappers.push(wrapper);
 
     return wrapper;
+  }
+
+  function createComponent(options = {}) {
+    return createComponentWithProps({
+      courses: {
+        selectedIds: options.selectedCourseIds ?? [],
+        onChange: onCoursesChange,
+      },
+      assignments: {
+        selectedIds: options.selectedAssignmentIds ?? [],
+        onChange: onAssignmentsChange,
+      },
+      students: {
+        selectedIds: options.selectedStudentIds ?? [],
+        onChange: onStudentsChange,
+      },
+      onClearSelection: options.onClearSelection,
+    });
   }
 
   function getSelect(wrapper, id) {
@@ -345,6 +355,72 @@ describe('DashboardActivityFilters', () => {
       assert.called(onClearSelection);
     });
   });
+
+  const emptyFilters = {
+    selectedIds: [],
+    onChange: sinon.stub(),
+  };
+
+  [
+    {
+      props: {},
+      coursesSelectShouldExist: false,
+      assignmentsSelectShouldExist: false,
+      studentsSelectShouldExist: false,
+    },
+    {
+      props: { courses: emptyFilters },
+      coursesSelectShouldExist: true,
+      assignmentsSelectShouldExist: false,
+      studentsSelectShouldExist: false,
+    },
+    {
+      props: { assignments: emptyFilters },
+      coursesSelectShouldExist: false,
+      assignmentsSelectShouldExist: true,
+      studentsSelectShouldExist: false,
+    },
+    {
+      props: { assignments: emptyFilters, students: emptyFilters },
+      coursesSelectShouldExist: false,
+      assignmentsSelectShouldExist: true,
+      studentsSelectShouldExist: true,
+    },
+    {
+      props: {
+        courses: emptyFilters,
+        assignments: emptyFilters,
+        students: emptyFilters,
+      },
+      coursesSelectShouldExist: true,
+      assignmentsSelectShouldExist: true,
+      studentsSelectShouldExist: true,
+    },
+  ].forEach(
+    ({
+      props,
+      coursesSelectShouldExist,
+      assignmentsSelectShouldExist,
+      studentsSelectShouldExist,
+    }) => {
+      it('does not render controls for which config is not provided', () => {
+        const wrapper = createComponentWithProps(props);
+
+        assert.equal(
+          wrapper.exists('[data-testid="courses-select"]'),
+          coursesSelectShouldExist,
+        );
+        assert.equal(
+          wrapper.exists('[data-testid="assignments-select"]'),
+          assignmentsSelectShouldExist,
+        );
+        assert.equal(
+          wrapper.exists('[data-testid="students-select"]'),
+          studentsSelectShouldExist,
+        );
+      });
+    },
+  );
 
   it(
     'should pass a11y checks',


### PR DESCRIPTION
In preparation for the eventual requirement to display different filtering dropdowns depending on the active section, this PR changes the `DashboardActivityFilters` props API so that we can conditionally pass different options in order to control which of the dropdowns should be displayed.

To support that, we move from this contract:

```ts
export type DashboardActivityFiltersProps = {
  selectedCourseIds: string[];
  onCoursesChange: (newCourseIds: string[]) => void;
  selectedAssignmentIds: string[];
  onAssignmentsChange: (newAssignmentIds: string[]) => void;
  selectedStudentIds: string[];
  onStudentsChange: (newStudentIds: string[]) => void;
}
```

to this one:

```ts
export type ActivityFilters = {
  selectedIds: string[];
  onChange: (newSelectedIds: string[]) => void;
};

export type DashboardActivityFiltersProps = {
  courses?: ActivityFilters;
  assignments?: ActivityFilters;
  students?: ActivityFilters;
};
```

If any of `courses`, `assignments` or `students` is not provided, the corresponding dropdown won't be rendered either.

### Alternative approaches.

I considered other options, perhaps simpler ones that would have required less changes:

* Make `selectedCourseIds`, `selectedAssignmentIds` and `selectedStudentIds` optional, and use them to control which dropdowns to render.
    However, this allowed for combinations in which for example `selectedStudentIds` is not provided, but `onStudentsChange` is, ending up in a not very intuitive situation where it's not obvious that `onStudentsChange` is going to be ignored.
* Add flags or a new prop to control which dropdowns to render, but it has a similar problem to previous point, allowing stuff to be provided just to end-up unused.
* Make everything optional. Similar to first point, and with the same drawbacks.

In the end, this seemed like the most intuitive approach, but it can cause many conflicts with other PRs, so I won't merge it until we have fully decided how filters should behave in all sections.

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/lms/pull/6524/files?w=1)