### PR TITLE
Store and update the assignment / course relationship

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -9,6 +9,7 @@ from lms.models import (
     Assignment,
     AssignmentGrouping,
     AssignmentMembership,
+    Course,
     Grouping,
     LTIRole,
     Organization,
@@ -52,7 +53,14 @@ class AssignmentService:
 
         return assignment
 
-    def update_assignment(self, request, assignment, document_url, group_set_id):
+    def update_assignment(  # noqa: PLR0913
+        self,
+        request,
+        assignment: Assignment,
+        document_url: str,
+        group_set_id,
+        course: Course,
+    ):
         """Update an existing assignment."""
         if self._misc_plugin.is_speed_grader_launch(request):
             # SpeedGrader has a number of issues regarding the information it sends about the assignment
@@ -74,6 +82,7 @@ class AssignmentService:
         assignment.is_gradable = self._misc_plugin.is_assignment_gradable(
             request.lti_params
         )
+        assignment.course_id = course.id
 
         return assignment
 
@@ -101,7 +110,7 @@ class AssignmentService:
 
         return None
 
-    def get_assignment_for_launch(self, request) -> Assignment | None:
+    def get_assignment_for_launch(self, request, course: Course) -> Assignment | None:
         """
         Get or create an assignment for the current launch.
 
@@ -157,7 +166,9 @@ class AssignmentService:
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.
-        return self.update_assignment(request, assignment, document_url, group_set_id)
+        return self.update_assignment(
+            request, assignment, document_url, group_set_id, course
+        )
 
     def upsert_assignment_membership(
         self, assignment: Assignment, user: User, lti_roles: list[LTIRole]

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -59,7 +59,9 @@ class BasicLaunchViews:
     def lti_launch(self):
         """Handle regular LTI launches."""
 
-        assignment = self.assignment_service.get_assignment_for_launch(self.request)
+        assignment = self.assignment_service.get_assignment_for_launch(
+            self.request, self.course
+        )
 
         if error_code := self.request.find_service(VitalSourceService).check_h_license(
             self.request.lti_user, self.request.lti_params, assignment
@@ -263,6 +265,7 @@ class BasicLaunchViews:
             assignment,
             document_url=self.request.parsed_params["document_url"],
             group_set_id=self.request.parsed_params.get("group_set"),
+            course=self.course,
         )
 
     def _configure_js_for_file_picker(

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -39,6 +39,7 @@ class TestAssignmentService:
         resource_link_title,
         title,
     ):
+        course = factories.Course()
         pyramid_request.lti_params["resource_link_title"] = resource_link_title
         misc_plugin.is_speed_grader_launch.return_value = is_speed_grader
 
@@ -47,9 +48,11 @@ class TestAssignmentService:
             factories.Assignment(),
             sentinel.document_url,
             sentinel.group_set_id,
+            course,
         )
 
         assignment.title = title
+        assignment.course_id = course.id
         if is_speed_grader:
             assert assignment.extra == {}
             assert assignment.document_url != sentinel.document_url
@@ -100,13 +103,14 @@ class TestAssignmentService:
         get_assignment,
         _get_copied_from_assignment,
     ):
+        course = factories.Course()
         misc_plugin.get_assignment_configuration.return_value = {
             "document_url": sentinel.document_url,
             "group_set_id": sentinel.group_set_id,
         }
         get_assignment.return_value = factories.Assignment()
 
-        assignment = svc.get_assignment_for_launch(pyramid_request)
+        assignment = svc.get_assignment_for_launch(pyramid_request, course)
 
         _get_copied_from_assignment.assert_not_called()
         misc_plugin.get_assignment_configuration.assert_called_once_with(
@@ -123,13 +127,14 @@ class TestAssignmentService:
             "resource_link_description"
         )
         assert assignment.is_gradable == misc_plugin.is_assignment_gradable.return_value
+        assert assignment.course_id == course.id
 
     def test_get_assignment_returns_None_with_when_no_document(
         self, pyramid_request, svc, misc_plugin
     ):
         misc_plugin.get_assignment_configuration.return_value = {"document_url": None}
 
-        assert not svc.get_assignment_for_launch(pyramid_request)
+        assert not svc.get_assignment_for_launch(pyramid_request, factories.Course())
 
     @pytest.mark.parametrize("group_set_id", [None, "1"])
     def test_get_assignment_creates_assignment(
@@ -142,6 +147,7 @@ class TestAssignmentService:
         create_assignment,
         group_set_id,
     ):
+        course = factories.Course()
         misc_plugin.get_assignment_configuration.return_value = {
             "document_url": sentinel.document_url,
             "group_set_id": group_set_id,
@@ -150,13 +156,14 @@ class TestAssignmentService:
         get_assignment.return_value = None
         _get_copied_from_assignment.return_value = None
 
-        assignment = svc.get_assignment_for_launch(pyramid_request)
+        assignment = svc.get_assignment_for_launch(pyramid_request, course)
 
         _get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
         create_assignment.assert_called_once_with(
             "TEST_TOOL_CONSUMER_INSTANCE_GUID", "TEST_RESOURCE_LINK_ID"
         )
         assert assignment.document_url == sentinel.document_url
+        assert assignment.course_id == course.id
         if group_set_id:
             assignment.extra["group_set_id"] = group_set_id
         assert not assignment.copied_from
@@ -176,7 +183,7 @@ class TestAssignmentService:
         get_assignment.return_value = None
         _get_copied_from_assignment.return_value = sentinel.original_assignment
 
-        assignment = svc.get_assignment_for_launch(pyramid_request)
+        assignment = svc.get_assignment_for_launch(pyramid_request, factories.Course())
 
         _get_copied_from_assignment.assert_called_once_with(pyramid_request.lti_params)
         create_assignment.assert_called_once_with(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -49,7 +49,7 @@ class TestBasicLaunchViews:
         )
 
     def test_configure_assignment_callback(
-        self, svc, pyramid_request, _show_document, assignment_service
+        self, svc, pyramid_request, _show_document, assignment_service, course_service
     ):
         pyramid_request.parsed_params = {
             "document_url": sentinel.document_url,
@@ -67,6 +67,7 @@ class TestBasicLaunchViews:
             assignment_service.create_assignment.return_value,
             document_url=sentinel.document_url,
             group_set_id=sentinel.group_set,
+            course=course_service.get_from_launch.return_value,
         )
         _show_document.assert_called_once_with(
             assignment_service.create_assignment.return_value,
@@ -112,11 +113,12 @@ class TestBasicLaunchViews:
         pyramid_request,
         _show_document,
         LTIEvent,
+        course_service,
     ):
         svc.lti_launch()
 
         assignment_service.get_assignment_for_launch.assert_called_once_with(
-            pyramid_request
+            pyramid_request, course_service.get_from_launch.return_value
         )
 
         _show_document.assert_called_once_with(


### PR DESCRIPTION
Make sure we keep the relationship of course / assignment up to date with each launch.

This information is also kept in `AssigmentGrouping`


More context and the rest of the changes to follow on:

- https://github.com/hypothesis/lms/pull/6517


Planned PRs:

- ~https://github.com/hypothesis/lms/pull/6519~
- ~https://github.com/hypothesis/lms/pull/6520~
- https://github.com/hypothesis/lms/pull/6525
- Backfill assignment.course_id from existing values in assignment_grouping
- Code changes to replace the current custom query by the SQLA relationship for assignment.course.



### Testing

- Open any assignment, eg: https://hypothesis.instructure.com/courses/125/assignments/873
- Check that assigment.course_id has been updated:

`docker compose exec postgres psql -U postgres -c "select assignment.title assignment, grouping.lms_name course from assignment join grouping on assignment.course_id = grouping.id where title = 'localhost (make devdata) HTML Assignment';"`


```
                assignment                |                   course                    
------------------------------------------+---------------------------------------------
 localhost (make devdata) HTML Assignment | Developer Test Course with Sections Enabled
(1 row)
```
