### PR TITLE
Backfill assignment.course_id from existing values in assignment_grouping

### DIFF
--- a/lms/migrations/versions/f6c442c861c4_backfill_assignment_course_id.py
+++ b/lms/migrations/versions/f6c442c861c4_backfill_assignment_course_id.py
@@ -1,0 +1,37 @@
+"""Backfill assignment.course_id."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f6c442c861c4"
+down_revision = "18109b584a5b"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+        WITH assignment_courses as (
+          SELECT DISTINCT ON (assignment.id) assignment.id as assignment_id, grouping.id  as course_id
+          FROM assignment
+          JOIN assignment_grouping on assignment.id = assignment_grouping.assignment_id
+          JOIN grouping on grouping.id = grouping_id
+          -- Only courses, not sections or groups
+          WHERE grouping.type = 'course'
+          -- Don't override data we already set since we created the column
+          and assignment.course_id is null
+          -- Order for the `DISTINCT ON`, when duplicate found for one assignment, pick the latest
+          ORDER BY assignment.id, assignment_grouping.created desc
+       )
+          UPDATE assignment set course_id = assignment_courses.course_id
+          FROM assignment_courses
+          WHERE assignment.id = assignment_courses.assignment_id
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Needs to be merged after https://github.com/hypothesis/lms/pull/6525 

---


More context and the rest of the changes to follow on:

- https://github.com/hypothesis/lms/pull/6517


Planned PRs:

- ~https://github.com/hypothesis/lms/pull/6519~
- ~https://github.com/hypothesis/lms/pull/6520~
- https://github.com/hypothesis/lms/pull/6525
- **[Backfill assignment.course_id from existing values in assignment_grouping](https://github.com/hypothesis/lms/pull/6526)** <-- This PR
- Code changes to replace the current custom query by the SQLA relationship for assignment.course.



### Testing

```tox -e dev --run-command 'alembic upgrade head'```        

```
dev run-test-pre: PYTHONHASHSEED='470380643'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
;dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 18109b584a5b -> f6c442c861c4, Backfill assignment.course_id.
```


