### PR TITLE
Replace query to fetch an assignments course by the new relationship

### DIFF
--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -50,6 +50,8 @@ class AdminAssignmentViews:
             )
         )
 
+        # We can only navigate to assignments via their course, assigmentl.course won't be null
+        assert assignment.course
         response = HTTPFound(
             location=self.request.route_url(
                 "dashboard.assignment",

--- a/tests/unit/lms/models/assignment_test.py
+++ b/tests/unit/lms/models/assignment_test.py
@@ -1,9 +1,6 @@
-import datetime
-
 import pytest
 
 from lms.models import Assignment
-from tests import factories
 
 
 class TestAssignment:
@@ -32,23 +29,6 @@ class TestAssignment:
         self, assignment
     ):
         assert assignment.get_canvas_mapped_file_id("file_id") == "file_id"
-
-    def test_course(self, assignment, db_session):
-        course = factories.Course(created=datetime.datetime(2024, 1, 1))
-        factories.AssignmentGrouping(
-            assignment=assignment, grouping=factories.CanvasSection()
-        )
-        factories.AssignmentGrouping(
-            assignment=assignment, grouping=factories.CanvasGroup()
-        )
-        factories.AssignmentGrouping(
-            assignment=assignment,
-            grouping=factories.Course(created=datetime.datetime(2022, 1, 1)),
-        )
-        factories.AssignmentGrouping(assignment=assignment, grouping=course)
-        db_session.flush()
-
-        assert assignment.course == course
 
     @pytest.fixture
     def assignment(self, db_session):

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -51,15 +51,13 @@ class TestDashboardService:
         svc,
         organization,
         db_session,
-        application_instance,
+        course,
         get_request_admin_organizations,
     ):
-        assignment = factories.Assignment()
-        course = factories.Course(application_instance=application_instance)
-        factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        assignment = factories.Assignment(course_id=course.id)
+        db_session.flush()
         assignment_service.get_by_id.return_value = assignment
         get_request_admin_organizations.return_value = [organization]
-        db_session.flush()
 
         pyramid_request.matchdict["assignment_id"] = sentinel.id
 
@@ -98,13 +96,11 @@ class TestDashboardService:
         pyramid_request,
         course_service,
         svc,
-        application_instance,
         organization,
         get_request_admin_organizations,
+        course,
     ):
-        course_service.get_by_id.return_value = factories.Course(
-            application_instance=application_instance
-        )
+        course_service.get_by_id.return_value = course
         get_request_admin_organizations.return_value = [organization]
         pyramid_request.matchdict["course_id"] = sentinel.id
 
@@ -210,7 +206,13 @@ class TestDashboardService:
         organization_service.get_hierarchy_ids.return_value = []
         return organization_service
 
-    @pytest.fixture
+    @pytest.fixture()
+    def course(self, db_session, application_instance):
+        course = factories.Course(application_instance=application_instance)
+        db_session.flush()
+        return course
+
+    @pytest.fixture()
     def get_request_admin_organizations(self, svc):
         with patch.object(
             svc, "get_request_admin_organizations"

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -63,8 +63,8 @@ class TestAdminAssignmentViews:
 
     @pytest.fixture
     def assignment(self, application_instance, db_session):
-        assignment = factories.Assignment()
         course = factories.Course(application_instance=application_instance)
+        assignment = factories.Assignment(course=course)
         factories.AssignmentGrouping(assignment=assignment, grouping=course)
         db_session.flush()  # Give the DB objects IDs
         return assignment

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -42,7 +42,7 @@ class TestAssignmentViews:
         }
 
     def test_assignment(
-        self, views, pyramid_request, course, assignment, db_session, dashboard_service
+        self, views, pyramid_request, assignment, db_session, dashboard_service
     ):
         db_session.flush()
         pyramid_request.matchdict["assignment_id"] = sentinel.id
@@ -57,7 +57,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "course": {"id": course.id, "title": course.lms_name},
+            "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
         }
 
     def test_course_assignments(
@@ -162,7 +162,7 @@ class TestAssignmentViews:
 
     @pytest.fixture
     def assignment(self, course):
-        assignment = factories.Assignment()
+        assignment = factories.Assignment(course=course)
         factories.AssignmentGrouping(assignment=assignment, grouping=course)
 
         return assignment


### PR DESCRIPTION
Use a standard SQLA relationship instead of custom code to access an assignment's course.

This should just work as expected, must changes are about adjusting the tests.

More context and the rest of the changes to follow on:

- https://github.com/hypothesis/lms/pull/6517


Planned PRs:

- ~https://github.com/hypothesis/lms/pull/6519~
- ~https://github.com/hypothesis/lms/pull/6520~
- ~~https://github.com/hypothesis/lms/pull/6525~~
- ~~https://github.com/hypothesis/lms/pull/6526~~
- [Code changes to replace the current custom query by the SQLA relationship for assignment.course.](https://github.com/hypothesis/lms/pull/6528) <-- This PR
