### PR TITLE
Remove dashboard settings entry point until we have a place to redirect

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -1,9 +1,4 @@
-import {
-  Link,
-  LogoIcon,
-  ProfileIcon,
-  SettingsIcon,
-} from '@hypothesis/frontend-shared';
+import { LogoIcon, ProfileIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { Link as RouterLink, Route, Switch } from 'wouter-preact';
 
@@ -38,26 +33,6 @@ export default function DashboardApp() {
               <ProfileIcon />
               {dashboard.user.display_name}
             </span>
-            <Link
-              underline="hover"
-              variant="text"
-              href="/email/preferences"
-              target="_blank"
-              classes={classnames(
-                'flex gap-2 items-center',
-                'font-semibold text-color-text-light',
-              )}
-              onClick={
-                /* istanbul ignore next - Temporary until settings link works */
-                e => {
-                  e.preventDefault();
-                  alert('This is not implemented yet');
-                }
-              }
-            >
-              <SettingsIcon />
-              Settings
-            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Remove link to `Settings` from the dashboard header.

We considered redirecting to the email settings for now, but auth was a bit tricky, so we ended up with a placeholder alerting that it was not implemented.

But even if we would have been able to redirect there, I'm not sure that was the right place. We should have first either a more generic settings page, or a dashboard-related one.

So for the MVP, I suggest we remove it entirely.