### PR TITLE
Support single active items in dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -53,12 +53,18 @@ export default function AllCoursesActivity() {
     <div className="flex flex-col gap-y-5">
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
       <DashboardActivityFilters
-        selectedStudentIds={studentIds}
-        onStudentsChange={studentIds => updateFilters({ studentIds })}
-        selectedAssignmentIds={assignmentIds}
-        onAssignmentsChange={assignmentIds => updateFilters({ assignmentIds })}
-        selectedCourseIds={courseIds}
-        onCoursesChange={courseIds => updateFilters({ courseIds })}
+        students={{
+          selectedIds: studentIds,
+          onChange: studentIds => updateFilters({ studentIds }),
+        }}
+        assignments={{
+          selectedIds: assignmentIds,
+          onChange: assignmentIds => updateFilters({ assignmentIds }),
+        }}
+        courses={{
+          selectedIds: courseIds,
+          onChange: courseIds => updateFilters({ courseIds }),
+        }}
         onClearSelection={() =>
           updateFilters({ studentIds: [], assignmentIds: [], courseIds: [] })
         }

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -11,7 +11,7 @@ import type { AssignmentsMetricsResponse, Course } from '../../api-types';
 import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
-import { assignmentURL, courseURL } from '../../utils/dashboard/navigation';
+import { assignmentURL } from '../../utils/dashboard/navigation';
 import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
@@ -90,30 +90,25 @@ export default function CourseActivity() {
           {course.data && title}
         </h2>
       </div>
-      <DashboardActivityFilters
-        selectedCourseIds={[courseId]}
-        onCoursesChange={newCourseIds => {
-          // When no courses are selected (which happens if either "All courses" is
-          // selected or the active course is deselected), navigate to "All courses"
-          // section and propagate the rest of the filters.
-          if (newCourseIds.length === 0) {
-            navigate(`?${search}`);
-          }
-
-          // When a course other than the "active" one (the one represented
-          // in the URL) is selected, navigate to that course and propagate
-          // the rest of the filters.
-          const firstDifferentCourse = newCourseIds.find(c => c !== courseId);
-          if (firstDifferentCourse) {
-            navigate(`${courseURL(firstDifferentCourse)}?${search}`);
-          }
-        }}
-        selectedAssignmentIds={assignmentIds}
-        onAssignmentsChange={assignmentIds => updateFilters({ assignmentIds })}
-        selectedStudentIds={studentIds}
-        onStudentsChange={studentIds => updateFilters({ studentIds })}
-        onClearSelection={hasSelection ? onClearSelection : undefined}
-      />
+      {course.data && (
+        <DashboardActivityFilters
+          courses={{
+            activeItem: course.data,
+            // When selected course is cleared, navigate to the home page,
+            // AKA "All courses"
+            onClear: () => navigate(search.length > 0 ? `?${search}` : ''),
+          }}
+          assignments={{
+            selectedIds: assignmentIds,
+            onChange: assignmentIds => updateFilters({ assignmentIds }),
+          }}
+          students={{
+            selectedIds: studentIds,
+            onChange: studentIds => updateFilters({ studentIds }),
+          }}
+          onClearSelection={hasSelection ? onClearSelection : undefined}
+        />
+      )}
       <OrderableActivityTable
         loading={assignments.isLoading}
         title={course.isLoading ? 'Loading...' : title}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -169,8 +169,8 @@ describe('AllCoursesActivity', () => {
   it('allows metrics to be filtered', () => {
     const wrapper = createComponent();
     const filters = wrapper.find('DashboardActivityFilters');
-    const updateFilter = (changeCallback, arg) => {
-      act(() => filters.prop(changeCallback)(arg));
+    const updateFilter = (prop, arg) => {
+      act(() => filters.prop(prop).onChange(arg));
       wrapper.update();
     };
     const assertCoursesFetched = query =>
@@ -178,7 +178,7 @@ describe('AllCoursesActivity', () => {
 
     // Every time the filters callbacks are invoked, the component will
     // re-render and re-fetch metrics with updated query.
-    updateFilter('onStudentsChange', ['123', '456']);
+    updateFilter('students', ['123', '456']);
     assertCoursesFetched({
       h_userid: ['123', '456'],
       assignment_id: [],
@@ -186,7 +186,7 @@ describe('AllCoursesActivity', () => {
       public_id: undefined,
     });
 
-    updateFilter('onAssignmentsChange', ['1', '2']);
+    updateFilter('assignments', ['1', '2']);
     assertCoursesFetched({
       h_userid: [],
       assignment_id: ['1', '2'],
@@ -194,7 +194,7 @@ describe('AllCoursesActivity', () => {
       public_id: undefined,
     });
 
-    updateFilter('onCoursesChange', ['3', '8', '9']);
+    updateFilter('courses', ['3', '8', '9']);
     assertCoursesFetched({
       h_userid: [],
       assignment_id: [],

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -39,16 +39,18 @@ describe('CourseActivity', () => {
       },
     },
   ];
+  const activeCourse = { id: 123, title: 'The title' };
 
   let fakeUseAPIFetch;
   let fakeConfig;
   let fakeNavigate;
+  let fakeUseSearch;
   let wrappers;
 
   beforeEach(() => {
     fakeUseAPIFetch = sinon.stub().callsFake(url => ({
       isLoading: false,
-      data: url.endsWith('stats') ? { assignments } : { title: 'The title' },
+      data: url.endsWith('stats') ? { assignments } : activeCourse,
     }));
     fakeConfig = {
       dashboard: {
@@ -59,6 +61,7 @@ describe('CourseActivity', () => {
       },
     };
     fakeNavigate = sinon.stub();
+    fakeUseSearch = sinon.stub().returns('current=query');
     wrappers = [];
 
     $imports.$mock(mockImportedComponents());
@@ -68,7 +71,7 @@ describe('CourseActivity', () => {
       },
       'wouter-preact': {
         useParams: sinon.stub().returns({ courseId: '123' }),
-        useSearch: sinon.stub().returns('current=query'),
+        useSearch: fakeUseSearch,
         useLocation: sinon.stub().returns(['', fakeNavigate]),
       },
     });
@@ -227,11 +230,11 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      // Course ID is set from the route
-      assert.deepEqual(filters.prop('selectedCourseIds'), ['123']);
+      // Active course is set from the route
+      assert.deepEqual(filters.prop('courses').activeItem, activeCourse);
       // Assignments and students are set from the query
-      assert.deepEqual(filters.prop('selectedAssignmentIds'), ['1', '2']);
-      assert.deepEqual(filters.prop('selectedStudentIds'), ['3']);
+      assert.deepEqual(filters.prop('assignments').selectedIds, ['1', '2']);
+      assert.deepEqual(filters.prop('students').selectedIds, ['3']);
 
       // Selected filters are propagated when loading assignment metrics
       assert.calledWith(fakeUseAPIFetch.lastCall, sinon.match.string, {
@@ -262,7 +265,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onAssignmentsChange(['3', '7']));
+      act(() => filters.prop('assignments').onChange(['3', '7']));
 
       assert.equal(location.search, '?assignment_id=3&assignment_id=7');
     });
@@ -271,7 +274,7 @@ describe('CourseActivity', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
 
-      act(() => filters.props().onStudentsChange(['8', '20', '32']));
+      act(() => filters.prop('students').onChange(['8', '20', '32']));
 
       assert.equal(
         location.search,
@@ -292,22 +295,26 @@ describe('CourseActivity', () => {
       assert.equal(location.search, '?foo=bar');
     });
 
-    it('navigates to home preserving current query when no course is selected', () => {
-      const wrapper = createComponent();
-      const filters = wrapper.find('DashboardActivityFilters');
+    [
+      {
+        currentSearch: 'current=query',
+        expectedDestination: '?current=query',
+      },
+      {
+        currentSearch: '',
+        expectedDestination: '',
+      },
+    ].forEach(({ currentSearch, expectedDestination }) => {
+      it('navigates to home preserving current query when selected course is cleared', () => {
+        fakeUseSearch.returns(currentSearch);
 
-      act(() => filters.props().onCoursesChange([]));
+        const wrapper = createComponent();
+        const filters = wrapper.find('DashboardActivityFilters');
 
-      assert.calledWith(fakeNavigate, '?current=query');
-    });
+        act(() => filters.prop('courses').onClear());
 
-    it('navigates to the first selected course which is not the active one', () => {
-      const wrapper = createComponent();
-      const filters = wrapper.find('DashboardActivityFilters');
-
-      act(() => filters.props().onCoursesChange(['123', '789']));
-
-      assert.calledWith(fakeNavigate, '/courses/789?current=query');
+        assert.calledWith(fakeNavigate, expectedDestination);
+      });
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/6490

Following the decision tracked in https://github.com/hypothesis/lms/issues/6490#issuecomment-2271562287, this PR updates the `DashboardActivityFilters` so that:

1. It brings some of the API changes made in https://github.com/hypothesis/lms/pull/6524, expecting `courses`, `assignments` and `students` as the main props.
2. Making `courses` and `assignments` accept two shapes:
    * `ActivityFilterSelection`: 
      ```ts
      {
        selectedIds: string[];
        onChange: (newSelectedIds: string[]) => void;
      }
      ```
      This makes everything work as it has been so far. Courses are loaded from the API, and the props determine which are selected, and what to do when selection changes.
    * `ActivityFilterItem<T extends Course | Assignment>`:
      ```ts
      {
        activeItem: T;
        onClear: () => void;
      }
      ```
      This skips loading the list of courses/assignments from the API, and fills the dropdown only with the active item, which also becomes selected.
      The only possible action is clearing the selection, either by clicking in that item or the "All <items>" option.

Additionally, we take advantage of this new approach to change the courses dropdown in the course section. 

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/lms/pull/6532/files?w=1).

### Considerations

Initially, we discussed that the "Clear filters" button would clear everything, like it does in "All courses".

However, while working on this I realized that means you have to navigate back to the home page, meaning, there's no way to clear both assignments and students while staying in the active course page.

I have finally not changed that, to align it with the broader product team. Adding that behavior would not be too hard if we decide to go that way.