### PR TITLE
Fix query instructor_h_userid filter for assignments and users

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -19,7 +19,7 @@ from lms.models import (
     RoleType,
     User,
 )
-from lms.product import Product
+from lms.product.family import Family
 from lms.services.grouping import GroupingService
 
 
@@ -49,7 +49,7 @@ class CourseService:
             .count()
         )
 
-    def get_from_launch(self, product, lti_params) -> Course:
+    def get_from_launch(self, product_family: Family, lti_params) -> Course:
         """Get the course this LTI launch based on the request's params."""
         historical_course = None
 
@@ -58,7 +58,7 @@ class CourseService:
             extra = existing_course.extra
         else:
             extra = {}
-            if product.family == Product.Family.CANVAS:
+            if product_family == Family.CANVAS:
                 extra = {
                     "canvas": {
                         "custom_canvas_course_id": lti_params.get(

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -43,7 +43,8 @@ class DashboardService:
             # Organization admins have access to all the assignments in their organizations
             return assignment
 
-        if not self._assignment_service.is_member(assignment, request.user.h_userid):
+        # Access to the assignment is determined by access to its course.
+        if not self._course_service.is_member(assignment.course, request.user.h_userid):
             raise HTTPUnauthorized()
 
         return assignment

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -246,7 +246,7 @@ class BasicLaunchViews:
 
     def _record_course(self):
         course = self.request.find_service(name="course").get_from_launch(
-            self.request.product, self.request.lti_params
+            self.request.product.family, self.request.lti_params
         )
         self.request.find_service(name="grouping").upsert_grouping_memberships(
             user=self.request.user, groups=[course]

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -67,7 +67,7 @@ def deep_linking_launch(context, request):
         request.lti_user.application_instance, request.lti_params
     )
     course = request.find_service(name="course").get_from_launch(
-        request.product, request.lti_params
+        request.product.family, request.lti_params
     )
     request.find_service(name="lti_h").sync([course], request.params)
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -300,7 +300,7 @@ class TestAssignmentService:
 
         assert db_session.scalars(query).all() == [assignment]
 
-    def test_get_assignments_all_assignments_for_instructor(
+    def test_get_assignments_returns_all_assignments_for_instructor(
         self, db_session, svc, assignment, instructor_in_assignment, course
     ):
         # assignment belongs to course and we have membership via `instructor_in_assignment`

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -106,13 +106,12 @@ class TestCourseService:
         assert course == upsert_course.return_value
 
     def test_get_from_launch_when_new_and_canvas(
-        self, svc, upsert_course, get_by_context_id, product
+        self, svc, upsert_course, get_by_context_id
     ):
         get_by_context_id.return_value = None
-        product.family = Product.Family.CANVAS
 
         course = svc.get_from_launch(
-            product,
+            Product.Family.CANVAS,
             lti_params={
                 "context_id": sentinel.context_id,
                 "context_title": sentinel.context_title,

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -18,9 +18,9 @@ class TestDashboardService:
         with pytest.raises(HTTPNotFound):
             svc.get_request_assignment(pyramid_request)
 
-    def test_get_request_assignment_403(self, pyramid_request, assignment_service, svc):
+    def test_get_request_assignment_403(self, pyramid_request, course_service, svc):
         pyramid_request.matchdict["assignment_id"] = sentinel.id
-        assignment_service.is_member.return_value = False
+        course_service.is_member.return_value = False
 
         with pytest.raises(HTTPUnauthorized):
             svc.get_request_assignment(pyramid_request)
@@ -34,14 +34,17 @@ class TestDashboardService:
 
         assert svc.get_request_assignment(pyramid_request)
 
-    def test_get_request_assignment(self, pyramid_request, assignment_service, svc):
+    def test_get_request_assignment(
+        self, pyramid_request, course_service, svc, assignment_service
+    ):
         pyramid_request.matchdict["assignment_id"] = sentinel.id
-        assignment_service.is_member.return_value = True
+        course_service.is_member.return_value = True
 
         assert svc.get_request_assignment(pyramid_request)
 
-        assignment_service.is_member.assert_called_once_with(
-            assignment_service.get_by_id.return_value, pyramid_request.user.h_userid
+        course_service.is_member.assert_called_once_with(
+            assignment_service.get_by_id.return_value.course,
+            pyramid_request.user.h_userid,
         )
 
     def test_get_request_assignment_for_admin(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -34,7 +34,7 @@ class TestBasicLaunchViews:
         BasicLaunchViews(context, pyramid_request)
 
         course_service.get_from_launch.assert_called_once_with(
-            pyramid_request.product, pyramid_request.lti_params
+            pyramid_request.product.family, pyramid_request.lti_params
         )
         grouping_service.upsert_grouping_memberships.assert_called_once_with(
             user=pyramid_request.user,

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -29,7 +29,7 @@ class TestDeepLinkingLaunch:
             pyramid_request.lti_user.application_instance, pyramid_request.lti_params
         )
         course_service.get_from_launch.assert_called_once_with(
-            pyramid_request.product, pyramid_request.lti_params
+            pyramid_request.product.family, pyramid_request.lti_params
         )
         lti_h_service.sync.assert_called_once_with(
             [course_service.get_from_launch.return_value], pyramid_request.params


### PR DESCRIPTION
Fixes:

- https://github.com/hypothesis/lms/issues/6516


LTI roles apply only to the course level although we currently store
them at the assignment level (AssignmentMembership).

When we use instructor_h_userid to get the list of assignments a
instructor has access to we should base the decision on:

- Courses/Assignments/Users that belongs to a course where the user is an instructor.

instead of the current:

- Courses/Assignments/Users this user launched as an instructor.

This PR change the behaviour for assignments and users to settle on the course level access.



### Testing

Sanity check the whole dashboard behaviour navigating around at the courses, assignment and students levels.