### PR TITLE
Grant access to single assignments based on course membership

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -43,7 +43,8 @@ class DashboardService:
             # Organization admins have access to all the assignments in their organizations
             return assignment
 
-        if not self._assignment_service.is_member(assignment, request.user.h_userid):
+        # Access to the assignment is determined by access to its course.
+        if not self._course_service.is_member(assignment.course, request.user.h_userid):
             raise HTTPUnauthorized()
 
         return assignment

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -18,9 +18,9 @@ class TestDashboardService:
         with pytest.raises(HTTPNotFound):
             svc.get_request_assignment(pyramid_request)
 
-    def test_get_request_assignment_403(self, pyramid_request, assignment_service, svc):
+    def test_get_request_assignment_403(self, pyramid_request, course_service, svc):
         pyramid_request.matchdict["assignment_id"] = sentinel.id
-        assignment_service.is_member.return_value = False
+        course_service.is_member.return_value = False
 
         with pytest.raises(HTTPUnauthorized):
             svc.get_request_assignment(pyramid_request)
@@ -34,14 +34,17 @@ class TestDashboardService:
 
         assert svc.get_request_assignment(pyramid_request)
 
-    def test_get_request_assignment(self, pyramid_request, assignment_service, svc):
+    def test_get_request_assignment(
+        self, pyramid_request, course_service, svc, assignment_service
+    ):
         pyramid_request.matchdict["assignment_id"] = sentinel.id
-        assignment_service.is_member.return_value = True
+        course_service.is_member.return_value = True
 
         assert svc.get_request_assignment(pyramid_request)
 
-        assignment_service.is_member.assert_called_once_with(
-            assignment_service.get_by_id.return_value, pyramid_request.user.h_userid
+        course_service.is_member.assert_called_once_with(
+            assignment_service.get_by_id.return_value.course,
+            pyramid_request.user.h_userid,
         )
 
     def test_get_request_assignment_for_admin(


### PR DESCRIPTION
Fixes:

- https://github.com/hypothesis/lms/issues/6534


LTI roles are course based but we were granting access to individual assignments based on the instructor having launched it in the past.

Previous commits fixed this for queries spanning multiple elements but here we are fixing the permission check for individual assignments.


## Testing

#### In `main` (in `fix-query-membership-bug` actually)
- Login with `eng+canvasteacher2@hypothes.is`, launch an assignment you didn't launch before, for example:

https://hypothesis.instructure.com/courses/125/assignments/6527

- Access the dashboard, the assignment will be visible and you can access it.

- Login with `eng+canvasteacher2@hypothes.is`
- Access the dashboard without accessing the same assignment.
- The assignment would be listed but you'll get an error when trying to access it


#### In this branch

- Repeat the last step, you get access to the assignment this time.