### PR TITLE
Avoid unnecessary joins to filter entities by organization IDs

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -12,7 +12,6 @@ from lms.models import (
     Course,
     Grouping,
     LTIRole,
-    Organization,
     RoleScope,
     RoleType,
     User,
@@ -267,8 +266,7 @@ class AssignmentService:
                 select(Assignment.id)
                 .join(Course)
                 .join(ApplicationInstance)
-                .join(Organization)
-                .where(Organization.id.in_(admin_organization_ids))
+                .where(ApplicationInstance.organization_id.in_(admin_organization_ids))
             )
         # instructor_h_userid and admin_organization_ids are about access rather than filtering.
         # we apply them both as an or to fetch assignments where the users is either an instructor or an admin

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -178,9 +178,9 @@ class CourseService:
             )
         if admin_organization_ids:
             admin_organization_ids_clause = Course.application_instance_id.in_(
-                select(ApplicationInstance.id)
-                .join(Organization)
-                .where(Organization.id.in_(admin_organization_ids))
+                select(ApplicationInstance.id).where(
+                    ApplicationInstance.organization_id.in_(admin_organization_ids)
+                )
             )
         # instructor_h_userid and admin_organization_ids are about access rather than filtering.
         # we apply them both as an or to fetch courses where the users is either an instructor or an admin

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -11,7 +11,6 @@ from lms.models import (
     AssignmentMembership,
     LTIRole,
     LTIUser,
-    Organization,
     RoleScope,
     RoleType,
     User,
@@ -152,11 +151,10 @@ class UserService:
             )
 
         if admin_organization_ids:
-            admin_organization_ids_clause = User.id.in_(
-                select(User.id)
-                .join(ApplicationInstance)
-                .join(Organization)
-                .where(Organization.id.in_(admin_organization_ids))
+            admin_organization_ids_clause = User.application_instance_id.in_(
+                select(ApplicationInstance.id).where(
+                    ApplicationInstance.organization_id.in_(admin_organization_ids)
+                )
             )
 
         # instructor_h_userid and admin_organization_ids are about access rather than filtering.


### PR DESCRIPTION
Improve performance of these queries removing the organization join on the admin_organization_ids clause's subquery.


#### Testing 

No behaviour changes required, no test needed tweaking either, just a sanity check open the dashboard as an admin (ie from the admin pages) and navigate around.

