### PR TITLE
Add filters to dashboard assignment section

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -202,8 +202,11 @@ export type StudentsMetricsResponse = {
   students: StudentWithMetrics[];
 };
 
-export type AssignmentWithMetrics = Assignment & {
+export type AssignmentWithCourse = Assignment & {
   course: Course;
+};
+
+export type AssignmentWithMetrics = AssignmentWithCourse & {
   annotation_metrics: AnnotationMetrics;
 };
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -3,6 +3,7 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
@@ -36,22 +37,28 @@ describe('AssignmentActivity', () => {
       },
     },
   ];
+  const activeAssignment = {
+    id: 123,
+    title: 'The title',
+    course: {
+      id: 12,
+      title: 'The course',
+    },
+  };
 
   let fakeUseAPIFetch;
+  let fakeNavigate;
+  let fakeUseSearch;
   let fakeConfig;
+  let wrappers;
 
   beforeEach(() => {
     fakeUseAPIFetch = sinon.stub().callsFake(url => ({
       isLoading: false,
-      data: url.endsWith('metrics')
-        ? { students }
-        : {
-            title: 'The title',
-            course: {
-              title: 'The course',
-            },
-          },
+      data: url.endsWith('metrics') ? { students } : activeAssignment,
     }));
+    fakeNavigate = sinon.stub();
+    fakeUseSearch = sinon.stub().returns('current=query');
     fakeConfig = {
       dashboard: {
         routes: {
@@ -60,6 +67,8 @@ describe('AssignmentActivity', () => {
         },
       },
     };
+
+    wrappers = [];
 
     $imports.$mock(mockImportedComponents());
     $imports.$restore({
@@ -71,19 +80,28 @@ describe('AssignmentActivity', () => {
       '../../utils/api': {
         useAPIFetch: fakeUseAPIFetch,
       },
+      'wouter-preact': {
+        useParams: sinon.stub().returns({ assignmentId: '123' }),
+        useSearch: fakeUseSearch,
+        useLocation: sinon.stub().returns(['', fakeNavigate]),
+      },
     });
   });
 
   afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
     $imports.$restore();
   });
 
   function createComponent() {
-    return mount(
+    const wrapper = mount(
       <Config.Provider value={fakeConfig}>
         <AssignmentActivity />
       </Config.Provider>,
     );
+    wrappers.push(wrapper);
+
+    return wrapper;
   }
 
   it('shows loading indicators while data is loading', () => {
@@ -168,6 +186,114 @@ describe('AssignmentActivity', () => {
       const value = typeof item === 'string' ? item : mount(item).text();
 
       assert.equal(value, expectedValue);
+    });
+  });
+
+  context('when filters are set', () => {
+    function setCurrentURL(url) {
+      history.replaceState(null, '', url);
+    }
+
+    beforeEach(() => {
+      setCurrentURL('?');
+    });
+
+    it('initializes expected filters', () => {
+      setCurrentURL('?student_id=1&student_id=2');
+
+      const wrapper = createComponent();
+      const filters = wrapper.find('DashboardActivityFilters');
+
+      // Active course and assignment are set from the route
+      assert.deepEqual(
+        filters.prop('courses').activeItem,
+        activeAssignment.course,
+      );
+      assert.deepEqual(
+        filters.prop('assignments').activeItem,
+        activeAssignment,
+      );
+      // Students are set from the query
+      assert.deepEqual(filters.prop('students').selectedIds, ['1', '2']);
+
+      // Selected filters are propagated when loading assignment metrics
+      assert.calledWith(fakeUseAPIFetch.lastCall, sinon.match.string, {
+        h_userid: ['1', '2'],
+        assignment_id: '123',
+        public_id: undefined,
+      });
+    });
+
+    [
+      { query: '', expectedHasSelection: false },
+      { query: '?foo=bar', expectedHasSelection: false },
+      { query: '?student_id=3', expectedHasSelection: true },
+      { query: '?student_id=1&student_id=3', expectedHasSelection: true },
+    ].forEach(({ query, expectedHasSelection }) => {
+      it('has `onClearSelection` if at least one student is selected', () => {
+        setCurrentURL(query);
+
+        const wrapper = createComponent();
+        const filters = wrapper.find('DashboardActivityFilters');
+
+        assert.equal(!!filters.prop('onClearSelection'), expectedHasSelection);
+      });
+    });
+
+    it('updates query when selected students change', () => {
+      const wrapper = createComponent();
+      const filters = wrapper.find('DashboardActivityFilters');
+
+      act(() => filters.prop('students').onChange(['3', '7']));
+
+      assert.equal(location.search, '?student_id=3&student_id=7');
+    });
+
+    it('clears selected students on clear selection', () => {
+      setCurrentURL('?foo=bar&student_id=8&student_id=20&student_id=32');
+
+      const wrapper = createComponent();
+      const filters = wrapper.find('DashboardActivityFilters');
+
+      act(() => filters.props().onClearSelection());
+
+      assert.equal(location.search, '?foo=bar');
+    });
+
+    it('navigates to home page preserving assignment and students when course is cleared', () => {
+      setCurrentURL('?student_id=8&student_id=20&student_id=32');
+
+      const wrapper = createComponent();
+      const filters = wrapper.find('DashboardActivityFilters');
+
+      act(() => filters.prop('courses').onClear());
+
+      assert.calledWith(
+        fakeNavigate,
+        '?student_id=8&student_id=20&student_id=32&assignment_id=123',
+      );
+    });
+
+    [
+      {
+        currentSearch: 'current=query',
+        expectedDestination: '/courses/12?current=query',
+      },
+      {
+        currentSearch: '',
+        expectedDestination: '/courses/12',
+      },
+    ].forEach(({ currentSearch, expectedDestination }) => {
+      it('navigates to course preserving current query when selected assignment is cleared', () => {
+        fakeUseSearch.returns(currentSearch);
+
+        const wrapper = createComponent();
+        const filters = wrapper.find('DashboardActivityFilters');
+
+        act(() => filters.prop('assignments').onClear());
+
+        assert.calledWith(fakeNavigate, expectedDestination);
+      });
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/lms/issues/6490

Add filtering controls to the dashboard's assignment view, in a way that it conforms with what's described in https://github.com/hypothesis/lms/issues/6490#issuecomment-2271562287

[Grabación de pantalla desde 2024-08-08 10-41-09.webm](https://github.com/user-attachments/assets/2f0588d5-21f6-4103-9da8-84d4caa526c0)

### Considerations

As it was described in https://github.com/hypothesis/lms/pull/6532, the clear filters button only clears the students filter, as otherwise we would be navigated away from the active page.

Once this is merged I will open a discussion around this, to present the potentially confusing behavior, and make a decision accordingly.