### PR TITLE
Propagate filters when navigating between dashboard views

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'wouter-preact';
 
 import type { CoursesMetricsResponse } from '../../api-types';
 import { useConfig } from '../../config';
-import { urlPath, useAPIFetch } from '../../utils/api';
+import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { courseURL } from '../../utils/dashboard/navigation';
 import { useDocumentTitle } from '../../utils/hooks';
@@ -30,7 +30,7 @@ export default function AllCoursesActivity() {
   useDocumentTitle('All courses');
 
   const { organizationPublicId } = useParams();
-  const { filters, updateFilters } = useDashboardFilters();
+  const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
   const { courseIds, assignmentIds, studentIds } = filters;
 
   const courses = useAPIFetch<CoursesMetricsResponse>(routes.courses_metrics, {
@@ -105,14 +105,25 @@ export default function AllCoursesActivity() {
           }
 
           return (
-            <RouterLink href={urlPath`/courses/${String(stats.id)}`} asChild>
+            <RouterLink
+              href={urlWithFilters(
+                { assignmentIds, studentIds },
+                { path: courseURL(stats.id) },
+              )}
+              asChild
+            >
               <Link underline="always" variant="text">
                 {stats.title}
               </Link>
             </RouterLink>
           );
         }}
-        navigateOnConfirmRow={stats => courseURL(stats.id)}
+        navigateOnConfirmRow={stats =>
+          urlWithFilters(
+            { assignmentIds, studentIds },
+            { path: courseURL(stats.id) },
+          )
+        }
       />
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -6,11 +6,11 @@ import type {
   StudentsMetricsResponse,
 } from '../../api-types';
 import { useConfig } from '../../config';
-import { urlPath, useAPIFetch } from '../../utils/api';
+import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { courseURL } from '../../utils/dashboard/navigation';
 import { useDocumentTitle } from '../../utils/hooks';
-import { recordToQueryString, replaceURLParams } from '../../utils/url';
+import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
@@ -35,7 +35,7 @@ export default function AssignmentActivity() {
     organizationPublicId?: string;
   }>();
 
-  const { filters, updateFilters } = useDashboardFilters();
+  const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
   const { studentIds } = filters;
   const search = useSearch();
   const [, navigate] = useLocation();
@@ -74,10 +74,14 @@ export default function AssignmentActivity() {
         {assignment.data && (
           <div className="mb-3 mt-1 w-full">
             <DashboardBreadcrumbs
+              allCoursesLink={urlWithFilters({ studentIds }, { path: '' })}
               links={[
                 {
                   title: assignment.data.course.title,
-                  href: urlPath`/courses/${String(assignment.data.course.id)}`,
+                  href: urlWithFilters(
+                    { studentIds },
+                    { path: courseURL(assignment.data.course.id) },
+                  ),
                 },
               ]}
             />
@@ -97,10 +101,10 @@ export default function AssignmentActivity() {
             // active assignment and students
             onClear: () =>
               navigate(
-                recordToQueryString({
-                  student_id: studentIds,
-                  assignment_id: assignmentId,
-                }),
+                urlWithFilters(
+                  { studentIds, assignmentIds: [assignmentId] },
+                  { path: '' },
+                ),
               ),
           }}
           assignments={{

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -39,7 +39,7 @@ export default function CourseActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
 
-  const { filters, updateFilters } = useDashboardFilters();
+  const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
   const { assignmentIds, studentIds } = filters;
   const search = useSearch();
   const hasSelection = assignmentIds.length > 0 || studentIds.length > 0;
@@ -82,7 +82,12 @@ export default function CourseActivity() {
     <div className="flex flex-col gap-y-5">
       <div>
         <div className="mb-3 mt-1 w-full">
-          <DashboardBreadcrumbs />
+          <DashboardBreadcrumbs
+            allCoursesLink={urlWithFilters(
+              { assignmentIds, studentIds },
+              { path: '' },
+            )}
+          />
         </div>
         <h2 className="text-lg text-brand font-semibold" data-testid="title">
           {course.isLoading && 'Loading...'}
@@ -145,7 +150,13 @@ export default function CourseActivity() {
             return <div className="text-right">{stats[field]}</div>;
           } else if (field === 'title') {
             return (
-              <RouterLink href={assignmentURL(stats.id)} asChild>
+              <RouterLink
+                href={urlWithFilters(
+                  { studentIds },
+                  { path: assignmentURL(stats.id) },
+                )}
+                asChild
+              >
                 <Link underline="always" variant="text">
                   {stats.title}
                 </Link>
@@ -157,7 +168,9 @@ export default function CourseActivity() {
             stats.last_activity && <FormattedDate date={stats.last_activity} />
           );
         }}
-        navigateOnConfirmRow={stats => assignmentURL(stats.id)}
+        navigateOnConfirmRow={stats =>
+          urlWithFilters({ studentIds }, { path: assignmentURL(stats.id) })
+        }
       />
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
@@ -13,6 +13,9 @@ export type BreadcrumbLink = {
 };
 
 export type DashboardBreadcrumbsProps = {
+  /** Link to the "All courses" view. Defaults to '' */
+  allCoursesLink?: string;
+  /** More links to append to the breadcrumb after the "All courses" one */
   links?: BreadcrumbLink[];
 };
 
@@ -35,11 +38,15 @@ function BreadcrumbLink({ title, href }: BreadcrumbLink) {
  * Navigation breadcrumbs showing a list of links
  */
 export default function DashboardBreadcrumbs({
+  allCoursesLink = '',
   links = [],
 }: DashboardBreadcrumbsProps) {
   const linksWithHome = useMemo(
-    (): BreadcrumbLink[] => [{ title: 'All courses', href: '' }, ...links],
-    [links],
+    (): BreadcrumbLink[] => [
+      { title: 'All courses', href: allCoursesLink },
+      ...links,
+    ],
+    [allCoursesLink, links],
   );
 
   return (

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -270,7 +270,7 @@ describe('AssignmentActivity', () => {
 
       assert.calledWith(
         fakeNavigate,
-        '?student_id=8&student_id=20&student_id=32&assignment_id=123',
+        '?assignment_id=123&student_id=8&student_id=20&student_id=32',
       );
     });
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
@@ -19,6 +19,15 @@ describe('DashboardBreadcrumbs', () => {
     });
   });
 
+  [undefined, '/foo', '/home?foo=bar'].forEach(allCoursesLink => {
+    it('uses all courses link if provided', () => {
+      const wrapper = createComponent({ allCoursesLink, links: [] });
+      const firstLink = wrapper.find('BreadcrumbLink').first();
+
+      assert.equal(firstLink.prop('href'), allCoursesLink ?? '');
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility({

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -5,6 +5,7 @@ import { useConfig } from '../config';
 import { APIError } from '../errors';
 import { useFetch } from './fetch';
 import type { FetchResult, Fetcher } from './fetch';
+import type { QueryParams } from './url';
 import { recordToQueryString } from './url';
 
 /**
@@ -48,7 +49,7 @@ export type APICallOptions = {
   path: string;
 
   /** Query parameters. */
-  params?: Record<string, string | string[] | undefined>;
+  params?: QueryParams;
 
   /** JSON-serializable body of request. */
   data?: object;
@@ -189,7 +190,7 @@ export function urlPath(strings: TemplateStringsArray, ...params: string[]) {
  */
 export function useAPIFetch<T = unknown>(
   path: string | null,
-  params?: Record<string, string | string[] | undefined>,
+  params?: QueryParams,
 ): FetchResult<T> {
   const {
     api: { authToken },
@@ -236,7 +237,7 @@ export function usePaginatedAPIFetch<
 >(
   prop: Prop,
   path: string | null,
-  params?: Record<string, string | string[] | undefined>,
+  params?: QueryParams,
 ): PaginatedFetchResult<ListType> {
   const [nextPageURL, setNextPageURL] = useState<string>();
   const [currentList, setCurrentList] = useState<ListType>();

--- a/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/test/hooks-test.js
@@ -4,7 +4,7 @@ import { useDashboardFilters } from '../hooks';
 
 describe('useDashboardFilters', () => {
   function FakeComponent() {
-    const { filters, updateFilters } = useDashboardFilters();
+    const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
 
     return (
       <div>
@@ -34,12 +34,16 @@ describe('useDashboardFilters', () => {
         >
           Update students
         </button>
+
+        <div data-testid="url-with-filters">
+          {urlWithFilters(filters, { path: '/hello/world' })}
+        </div>
       </div>
     );
   }
 
-  function setCurrentURL(queryString) {
-    history.replaceState(null, '', queryString);
+  function setCurrentURL(url) {
+    history.replaceState(null, '', url);
   }
 
   beforeEach(() => {
@@ -61,6 +65,10 @@ describe('useDashboardFilters', () => {
 
   function getCurrentStudents(wrapper) {
     return wrapper.find('[data-testid="student-ids"]').text();
+  }
+
+  function getURLWithFilters(wrapper) {
+    return wrapper.find('[data-testid="url-with-filters"]').text();
   }
 
   [
@@ -158,5 +166,33 @@ describe('useDashboardFilters', () => {
 
     assert.equal('?course_id=111&course_id=222&course_id=333', location.search);
     assert.equal('/foo/bar', location.pathname);
+  });
+
+  [
+    {
+      buttonId: 'update-courses',
+      expectedURL: '/hello/world?course_id=111&course_id=222&course_id=333',
+    },
+    {
+      buttonId: 'update-assignments',
+      expectedURL:
+        '/hello/world?assignment_id=123&assignment_id=456&assignment_id=789',
+    },
+    {
+      buttonId: 'update-students',
+      expectedURL: '/hello/world?student_id=abc&student_id=def',
+    },
+  ].forEach(({ buttonId, expectedURL }) => {
+    it('builds URLs with filters', () => {
+      // Current URL should be ignored
+      setCurrentURL('/foo/bar');
+
+      const wrapper = createComponent();
+
+      assert.equal(getURLWithFilters(wrapper), '/hello/world');
+
+      wrapper.find(`[data-testid="${buttonId}"]`).simulate('click');
+      assert.equal(getURLWithFilters(wrapper), expectedURL);
+    });
   });
 });

--- a/lms/static/scripts/frontend_apps/utils/url.ts
+++ b/lms/static/scripts/frontend_apps/utils/url.ts
@@ -29,13 +29,13 @@ export function replaceURLParams<Param>(
   return url;
 }
 
+export type QueryParams = Record<string, string | string[] | undefined>;
+
 /**
  * Converts a record into a URLSearchParams object.
  * Any param which is an array will be appended for every one of its values.
  */
-export function recordToSearchParams(
-  params: Record<string, string | string[] | undefined>,
-): URLSearchParams {
+export function recordToSearchParams(params: QueryParams): URLSearchParams {
   const queryParams = new URLSearchParams();
   Object.entries(params).forEach(([name, value]) => {
     // Skip params if their value is undefined
@@ -63,9 +63,7 @@ export function recordToSearchParams(
  *    { foo: 'bar' } -> '?foo=bar'
  *    { foo: 'bar', something: ['hello', 'world'] } -> '?foo=bar&something=hello&something=world'
  */
-export function recordToQueryString(
-  params: Record<string, string | string[] | undefined>,
-): string {
+export function recordToQueryString(params: QueryParams): string {
   const queryString = recordToSearchParams(params).toString();
   return queryString.length > 0 ? `?${queryString}` : '';
 }


### PR DESCRIPTION
Closes #6539 

Ensure links between dashboard views honor currently selected filters, so for example if we have selected a set of assignments in the "All courses" view and click on a course, those assignments are still selected when we go there.

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/lms/pull/6540/files?w=1)

### Testing steps

The implemented logic and decision on what parameters to forward is described in https://github.com/hypothesis/lms/issues/6539, so just sanity check that it works as described there.

### Considerations

There are some edge cases I did not implement here, but we may need to later, like if you are in the assignment view, should the breadcrumbs include `assignment_id={id}` for the active assignment?

For now only filters manually selected by the user will be propagated.