### PR TITLE
Add index for the users deduplication step

### DIFF
--- a/lms/migrations/versions/7858a12c4e4a_add_index_for_user_deduplication.py
+++ b/lms/migrations/versions/7858a12c4e4a_add_index_for_user_deduplication.py
@@ -1,0 +1,24 @@
+"""Add index for user deduplication."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7858a12c4e4a"
+down_revision = "f6c442c861c4"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        "ix__user_h_user_updated",
+        "user",
+        ["h_userid", sa.text("updated DESC")],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix__user_h_user_updated", table_name="user")

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -20,6 +20,7 @@ class User(CreatedUpdatedMixin, Base):
             "h_userid",
             name="uq__user__application_instance_id__h_userid",
         ),
+        sa.Index("ix__user_h_user_updated", "h_userid", sa.desc("updated")),
     )
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)


### PR DESCRIPTION
For:
- https://github.com/hypothesis/lms/issues/6523


This shows as an expensive step on user queries query plans:

```Sort Key: user_1.h_userid, user_1.updated DESC```

which originates here:

https://github.com/hypothesis/lms/blob/main/lms/services/user.py#L183


Add an explicit index for it to speed it up.

This should also helpful for any work that refactors the "user" table and/or denormalizing this information.


## Testing



`tox -e dev --run-command 'alembic upgrade head'`                           ```

```
dev run-test-pre: PYTHONHASHSEED='1727528162'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f6c442c861c4 -> 7858a12c4e4a, Add index for user deduplication.
```


```
 make sql
psql (15.6)
Type "help" for help.

postgres=# \d "user"
                                               Table "public.user"
         Column          |            Type             | Collation | Nullable |             Default              
-------------------------+-----------------------------+-----------+----------+----------------------------------
 id                      | integer                     |           | not null | nextval('user_id_seq'::regclass)
 application_instance_id | integer                     |           | not null | 
 user_id                 | character varying           |           | not null | 
 roles                   | character varying           |           |          | 
 h_userid                | character varying           |           | not null | 
 email                   | character varying           |           |          | 
 display_name            | character varying           |           |          | 
 created                 | timestamp without time zone |           | not null | now()
 updated                 | timestamp without time zone |           | not null | now()
Indexes:
    "pk__user" PRIMARY KEY, btree (id)
    ...
    "id__h_user_updated_for_deduplication" btree (h_userid, updated DESC)
    ...
```
