### PR TITLE
Make "clear filters" redirect to dashboard home with no filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -120,11 +120,7 @@ export default function AssignmentActivity() {
             selectedIds: studentIds,
             onChange: studentIds => updateFilters({ studentIds }),
           }}
-          onClearSelection={
-            studentIds.length > 0
-              ? () => updateFilters({ studentIds: [] })
-              : undefined
-          }
+          onClearSelection={() => navigate('')}
         />
       )}
       <OrderableActivityTable

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@hypothesis/frontend-shared';
-import { useCallback, useMemo } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import {
   Link as RouterLink,
   useLocation,
@@ -42,12 +42,6 @@ export default function CourseActivity() {
   const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
   const { assignmentIds, studentIds } = filters;
   const search = useSearch();
-  const hasSelection = assignmentIds.length > 0 || studentIds.length > 0;
-  const onClearSelection = useCallback(
-    // Clear every filter but courses
-    () => updateFilters({ studentIds: [], assignmentIds: [] }),
-    [updateFilters],
-  );
 
   const course = useAPIFetch<Course>(
     replaceURLParams(routes.course, { course_id: courseId }),
@@ -111,7 +105,7 @@ export default function CourseActivity() {
             selectedIds: studentIds,
             onChange: studentIds => updateFilters({ studentIds }),
           }}
-          onClearSelection={hasSelection ? onClearSelection : undefined}
+          onClearSelection={() => navigate('')}
         />
       )}
       <OrderableActivityTable

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -224,22 +224,6 @@ describe('AssignmentActivity', () => {
       });
     });
 
-    [
-      { query: '', expectedHasSelection: false },
-      { query: '?foo=bar', expectedHasSelection: false },
-      { query: '?student_id=3', expectedHasSelection: true },
-      { query: '?student_id=1&student_id=3', expectedHasSelection: true },
-    ].forEach(({ query, expectedHasSelection }) => {
-      it('has `onClearSelection` if at least one student is selected', () => {
-        setCurrentURL(query);
-
-        const wrapper = createComponent();
-        const filters = wrapper.find('DashboardActivityFilters');
-
-        assert.equal(!!filters.prop('onClearSelection'), expectedHasSelection);
-      });
-    });
-
     it('updates query when selected students change', () => {
       const wrapper = createComponent();
       const filters = wrapper.find('DashboardActivityFilters');
@@ -249,7 +233,7 @@ describe('AssignmentActivity', () => {
       assert.equal(location.search, '?student_id=3&student_id=7');
     });
 
-    it('clears selected students on clear selection', () => {
+    it('redirects to home with no filters when selection is cleared', () => {
       setCurrentURL('?foo=bar&student_id=8&student_id=20&student_id=32');
 
       const wrapper = createComponent();
@@ -257,7 +241,7 @@ describe('AssignmentActivity', () => {
 
       act(() => filters.props().onClearSelection());
 
-      assert.equal(location.search, '?foo=bar');
+      assert.calledWith(fakeNavigate, '');
     });
 
     it('navigates to home page preserving assignment and students when course is cleared', () => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -279,23 +279,6 @@ describe('CourseActivity', () => {
       });
     });
 
-    [
-      { query: '', expectedHasSelection: false },
-      { query: '?foo=bar', expectedHasSelection: false },
-      { query: '?assignment_id=1', expectedHasSelection: true },
-      { query: '?student_id=3', expectedHasSelection: true },
-      { query: '?assignment_id=1&student_id=3', expectedHasSelection: true },
-    ].forEach(({ query, expectedHasSelection }) => {
-      it('has `onClearSelection` if one student or one assignment is selected', () => {
-        setCurrentURL(query);
-
-        const wrapper = createComponent();
-        const filters = wrapper.find('DashboardActivityFilters');
-
-        assert.equal(!!filters.prop('onClearSelection'), expectedHasSelection);
-      });
-    });
-
     it('updates query when selected assignments change', () => {
       const wrapper = createComponent();
 
@@ -315,7 +298,7 @@ describe('CourseActivity', () => {
       );
     });
 
-    it('clears selected students and assignments on clear selection', () => {
+    it('redirects to home with no filters when selection is cleared', () => {
       setCurrentURL(
         '?foo=bar&assignment_id=3&assignment_id=7&student_id=8&student_id=20&student_id=32',
       );
@@ -325,7 +308,7 @@ describe('CourseActivity', () => {
 
       act(() => filters.props().onClearSelection());
 
-      assert.equal(location.search, '?foo=bar');
+      assert.calledWith(fakeNavigate, '');
     });
 
     [


### PR DESCRIPTION
Make the "clear filters" button redirect to the home/"All courses" view with no filters when clicked in the Course or Assignment views.

This is the behavior that was originally proposed and tracked in https://github.com/hypothesis/lms/issues/6490#issuecomment-2271562287, but it was later implemented differently due to some UX concerns.

I won't merge this PR yet, but it may be needed depending on the outcome of the discussion started here https://hypothes-is.slack.com/archives/C2C2U40LW/p1723115834000729