### PR TITLE
Rename public_id query param to org_public_id

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -106,7 +106,7 @@ class DashboardService:
     def get_request_admin_organizations(self, request) -> list[Organization]:
         """Get the organization the current user is an admin in."""
         if request.has_permission(Permissions.STAFF) and (
-            request_public_id := request.params.get("public_id")
+            request_public_id := request.params.get("org_public_id")
         ):
             # We handle permissions and filtering specially for staff members
             # If the request contains a filter for one organization, we will proceed as if the staff member

--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -37,7 +37,7 @@ export default function AllCoursesActivity() {
     h_userid: studentIds,
     assignment_id: assignmentIds,
     course_id: courseIds,
-    public_id: organizationPublicId,
+    org_public_id: organizationPublicId,
   });
   const rows: CoursesTableRow[] = useMemo(
     () =>

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -49,7 +49,7 @@ export default function AssignmentActivity() {
     {
       h_userid: studentIds,
       assignment_id: assignmentId,
-      public_id: organizationPublicId,
+      org_public_id: organizationPublicId,
     },
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -59,7 +59,7 @@ export default function CourseActivity() {
     {
       assignment_id: assignmentIds,
       h_userid: studentIds,
-      public_id: organizationPublicId,
+      org_public_id: organizationPublicId,
     },
   );
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -94,7 +94,7 @@ export default function DashboardActivityFilters({
     () => ({
       h_userid: students.selectedIds,
       assignment_id: selectedAssignmentIds,
-      public_id: organizationPublicId,
+      org_public_id: organizationPublicId,
     }),
     [organizationPublicId, selectedAssignmentIds, students.selectedIds],
   );
@@ -113,7 +113,7 @@ export default function DashboardActivityFilters({
     () => ({
       h_userid: students.selectedIds,
       course_id: selectedCourseIds,
-      public_id: organizationPublicId,
+      org_public_id: organizationPublicId,
     }),
     [organizationPublicId, selectedCourseIds, students.selectedIds],
   );
@@ -132,7 +132,7 @@ export default function DashboardActivityFilters({
     () => ({
       assignment_id: selectedAssignmentIds,
       course_id: selectedCourseIds,
-      public_id: organizationPublicId,
+      org_public_id: organizationPublicId,
     }),
     [organizationPublicId, selectedAssignmentIds, selectedCourseIds],
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -183,7 +183,7 @@ describe('AllCoursesActivity', () => {
       h_userid: ['123', '456'],
       assignment_id: [],
       course_id: [],
-      public_id: undefined,
+      org_public_id: undefined,
     });
 
     updateFilter('assignments', ['1', '2']);
@@ -191,7 +191,7 @@ describe('AllCoursesActivity', () => {
       h_userid: [],
       assignment_id: ['1', '2'],
       course_id: [],
-      public_id: undefined,
+      org_public_id: undefined,
     });
 
     updateFilter('courses', ['3', '8', '9']);
@@ -199,7 +199,7 @@ describe('AllCoursesActivity', () => {
       h_userid: [],
       assignment_id: [],
       course_id: ['3', '8', '9'],
-      public_id: undefined,
+      org_public_id: undefined,
     });
   });
 
@@ -208,15 +208,13 @@ describe('AllCoursesActivity', () => {
       fakeUseParams.returns({ organizationPublicId: 'the-org-public-id' });
     });
 
-    it('propagates public_id to API calls', () => {
+    it('propagates org_public_id to API calls', () => {
       createComponent();
 
       assert.calledWith(
         fakeUseAPIFetch.lastCall,
         sinon.match.string,
-        sinon.match({
-          public_id: 'the-org-public-id',
-        }),
+        sinon.match({ org_public_id: 'the-org-public-id' }),
       );
     });
   });
@@ -232,7 +230,7 @@ describe('AllCoursesActivity', () => {
       h_userid: [],
       assignment_id: [],
       course_id: [],
-      public_id: undefined,
+      org_public_id: undefined,
     });
   });
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -220,7 +220,7 @@ describe('AssignmentActivity', () => {
       assert.calledWith(fakeUseAPIFetch.lastCall, sinon.match.string, {
         h_userid: ['1', '2'],
         assignment_id: '123',
-        public_id: undefined,
+        org_public_id: undefined,
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -240,7 +240,7 @@ describe('CourseActivity', () => {
       assert.calledWith(fakeUseAPIFetch.lastCall, sinon.match.string, {
         assignment_id: ['1', '2'],
         h_userid: ['3'],
-        public_id: undefined,
+        org_public_id: undefined,
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -389,7 +389,7 @@ describe('DashboardActivityFilters', () => {
         {
           h_userid: selectedStudentIds,
           assignment_id: selectedAssignmentIds,
-          public_id: undefined,
+          org_public_id: undefined,
         },
       );
       assert.calledWith(
@@ -399,7 +399,7 @@ describe('DashboardActivityFilters', () => {
         {
           h_userid: selectedStudentIds,
           course_id: selectedCourseIds,
-          public_id: undefined,
+          org_public_id: undefined,
         },
       );
       assert.calledWith(
@@ -409,7 +409,7 @@ describe('DashboardActivityFilters', () => {
         {
           assignment_id: selectedAssignmentIds,
           course_id: selectedCourseIds,
-          public_id: undefined,
+          org_public_id: undefined,
         },
       );
     });

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -151,7 +151,7 @@ class TestDashboardService:
         }
 
     def test_get_request_admin_organizations_for_non_staff(self, pyramid_request, svc):
-        pyramid_request.params = {"public_id": sentinel.public_id}
+        pyramid_request.params = {"org_public_id": sentinel.public_id}
 
         assert not svc.get_request_admin_organizations(pyramid_request)
 
@@ -167,7 +167,7 @@ class TestDashboardService:
     ):
         pyramid_config.testing_securitypolicy(permissive=True)
         organization_service.get_by_public_id.return_value = None
-        pyramid_request.params = {"public_id": sentinel.public_id}
+        pyramid_request.params = {"org_public_id": sentinel.public_id}
 
         with pytest.raises(HTTPNotFound):
             svc.get_request_admin_organizations(pyramid_request)
@@ -178,7 +178,7 @@ class TestDashboardService:
         pyramid_config.testing_securitypolicy(permissive=True)
         organization_service.get_by_public_id.return_value = organization
         organization_service.get_hierarchy_ids.return_value = [organization.id]
-        pyramid_request.params = {"public_id": sentinel.public_id}
+        pyramid_request.params = {"org_public_id": sentinel.public_id}
 
         assert svc.get_request_admin_organizations(pyramid_request) == [organization]
         organization_service.get_by_public_id.assert_called_once_with(
@@ -189,7 +189,7 @@ class TestDashboardService:
         self, svc, pyramid_config, pyramid_request, organization, organization_service
     ):
         pyramid_config.testing_securitypolicy(permissive=True)
-        pyramid_request.params = {"public_id": sentinel.id}
+        pyramid_request.params = {"org_public_id": sentinel.id}
         organization_service.get_by_public_id.return_value = organization
         organization_service.get_hierarchy_ids.return_value = [organization.id]
 


### PR DESCRIPTION
Closes #6541 

Rename `public_id` to `org_public_id` to make it more clear what entity it refers to.

### Testing steps

Go to the [admin](http://localhost:8001/admin), find an organization, launch the dashboard from there, and sanity-check that data is correct.