### PR TITLE
Create indexes for foreign keys missing them

### DIFF
--- a/lms/migrations/versions/3d0c022c716c_add_missing_indexes_for_fks.py
+++ b/lms/migrations/versions/3d0c022c716c_add_missing_indexes_for_fks.py
@@ -1,0 +1,78 @@
+"""Add missing indexes for FKs."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "3d0c022c716c"
+down_revision = "7858a12c4e4a"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        op.f("ix__assignment_grouping_assignment_id"),
+        "assignment_grouping",
+        ["assignment_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__assignment_grouping_grouping_id"),
+        "assignment_grouping",
+        ["grouping_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__assignment_membership_assignment_id"),
+        "assignment_membership",
+        ["assignment_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__grouping_membership_user_id"),
+        "grouping_membership",
+        ["user_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+    op.create_index(
+        op.f("ix__assignment_course_id"),
+        "assignment",
+        ["course_id"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+
+    op.drop_index(
+        op.f("ix__grouping_membership_user_id"),
+        table_name="grouping_membership",
+        postgresql_concurrently=True,
+    )
+    op.drop_index(
+        op.f("ix__assignment_membership_assignment_id"),
+        table_name="assignment_membership",
+        postgresql_concurrently=True,
+    )
+    op.drop_index(
+        op.f("ix__assignment_grouping_grouping_id"),
+        table_name="assignment_grouping",
+        postgresql_concurrently=True,
+    )
+    op.drop_index(
+        op.f("ix__assignment_grouping_assignment_id"),
+        table_name="assignment_grouping",
+        postgresql_concurrently=True,
+    )
+    op.drop_index(
+        op.f("ix__assignment_course_id"),
+        table_name="assignment",
+        postgresql_concurrently=True,
+    )

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -87,7 +87,7 @@ class Assignment(CreatedUpdatedMixin, Base):
         "AssignmentMembership", lazy="dynamic", viewonly=True
     )
 
-    course_id: Mapped[int | None] = mapped_column(sa.ForeignKey(Course.id))
+    course_id: Mapped[int | None] = mapped_column(sa.ForeignKey(Course.id), index=True)
 
     course: Mapped[Course | None] = relationship(Course)
 

--- a/lms/models/assignment_grouping.py
+++ b/lms/models/assignment_grouping.py
@@ -13,6 +13,7 @@ class AssignmentGrouping(CreatedUpdatedMixin, Base):
         sa.Integer(),
         sa.ForeignKey("assignment.id", ondelete="cascade"),
         primary_key=True,
+        index=True,
     )
     assignment = sa.orm.relationship(
         "Assignment", foreign_keys=[assignment_id], backref="assignment_grouping"
@@ -20,7 +21,10 @@ class AssignmentGrouping(CreatedUpdatedMixin, Base):
     """The assignment."""
 
     grouping_id = sa.Column(
-        sa.Integer(), sa.ForeignKey("grouping.id", ondelete="cascade"), primary_key=True
+        sa.Integer(),
+        sa.ForeignKey("grouping.id", ondelete="cascade"),
+        primary_key=True,
+        index=True,
     )
     grouping = sa.orm.relationship(
         "Grouping", foreign_keys=[grouping_id], backref="groupings"

--- a/lms/models/assignment_membership.py
+++ b/lms/models/assignment_membership.py
@@ -13,6 +13,7 @@ class AssignmentMembership(CreatedUpdatedMixin, Base):
         sa.Integer(),
         sa.ForeignKey("assignment.id", ondelete="cascade"),
         primary_key=True,
+        index=True,
     )
     assignment = sa.orm.relationship("Assignment", foreign_keys=[assignment_id])
     """The assignment the user is a member of."""

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -267,7 +267,10 @@ class GroupingMembership(CreatedUpdatedMixin, Base):
     grouping = sa.orm.relationship("Grouping", back_populates="memberships")
 
     user_id = sa.Column(
-        sa.Integer(), sa.ForeignKey("user.id", ondelete="cascade"), primary_key=True
+        sa.Integer(),
+        sa.ForeignKey("user.id", ondelete="cascade"),
+        primary_key=True,
+        index=True,
     )
 
     user = sa.orm.relationship("User")


### PR DESCRIPTION
Non-unique FKs don't get automated indexes on the referencing side. 
`AssignmentGrouping` and `AssignmentMembership` have a primary key composed of two foreign keys, while the PK has an index there's no index on the individual columns that we often use in isolation.

- Assignment.course_id, FK without an index
- GroupingMembership.user_id, FK without an index
- AssignmentGrouping.assignment_id, FK without and index, although part of the PK of AssignmentGrouping
- AssignmentGrouping.grouping_id, FK without and index, although part of the PK of AssignmentGrouping
- AssignmentMembership.assignment_id, FK without and index, although part of the PK of AssignmentMembership


--- 
### Testing

```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='4146439829'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 7858a12c4e4a -> 3d0c022c716c, Add missing indexes for FKs
```