### PR TITLE
Match dashboard cookie and token lifetimes and increase its duration

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from datetime import timedelta
 from enum import Enum
 from typing import Any
 
@@ -251,9 +252,15 @@ class JSConfig:
             )
         )
 
-    def enable_dashboard_mode(self) -> None:
+    def enable_dashboard_mode(self, token_lifetime_seconds: int) -> None:
         self._config.update(
             {
+                "api": {
+                    # We use a different lifetime for the token on the dashboards (that matches the cookies max_age)
+                    "authToken": BearerTokenSchema(self._request).authorization_param(
+                        self._lti_user, timedelta(seconds=token_lifetime_seconds)
+                    )
+                },
                 "mode": JSConfig.Mode.DASHBOARD,
                 "dashboard": DashboardConfig(
                     user=self._get_user_info(),

--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -45,7 +45,9 @@ class BearerTokenSchema(PyramidRequestSchema):
         self._lti_user_service = request.find_service(iface=LTIUserService)
         self._secret = request.registry.settings["jwt_secret"]
 
-    def authorization_param(self, lti_user: LTIUser) -> str:
+    def authorization_param(
+        self, lti_user: LTIUser, lifetime: timedelta = timedelta(hours=24)
+    ) -> str:
         """
         Return ``lti_user`` serialized into an authorization param.
 
@@ -53,11 +55,12 @@ class BearerTokenSchema(PyramidRequestSchema):
         value of an authorization param.
 
         :arg lti_user: the LTI user to return an auth param for
+        :arg lifetime: how long the token should be valid for
         """
         token = self._jwt_service.encode_with_secret(
             self._lti_user_service.serialize(lti_user) if lti_user else {},
             self._secret,
-            lifetime=timedelta(hours=24),
+            lifetime=lifetime,
         )
 
         return f"Bearer {token}"


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6550


There are three relevant duration here:

- The length of the cookie for the dashboard
- The length of the token that is encoded in the cookies
- The length of the token that's part of JSConfig

This PR makes sure that all these match and increases its duration to 7
days.



### Testing 

- Open the dashboard as a LMS user check the duration of the cookie in the browser.
- Take the value from the cookie, the JWT, it should have a exp value matching the cookie's
- Check the API calls make to the API endpoints, this token's exp value should also be one week long.

