### PR TITLE
Reset fetch result when retrying useFetch

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/fetch.ts
+++ b/lms/static/scripts/frontend_apps/utils/fetch.ts
@@ -69,13 +69,15 @@ export function useFetch<T = unknown>(
       controller.abort();
       setResult(r => ({ ...r, error: null, isLoading: false, data: newValue }));
     };
-    setResult({
-      data: null,
-      error: null,
-      isLoading: key !== null,
-      mutate,
-      retry: () => null,
-    });
+    const resetResult = () =>
+      setResult({
+        data: null,
+        error: null,
+        isLoading: key !== null,
+        mutate,
+        retry: () => null,
+      });
+    resetResult();
 
     if (!key) {
       return undefined;
@@ -87,6 +89,7 @@ export function useFetch<T = unknown>(
 
     const fetcher = lastFetcher.current;
     const doFetch = () => {
+      resetResult();
       fetcher(controller.signal)
         .then(data => {
           if (!controller.signal.aborted) {

--- a/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/fetch-test.js
@@ -204,6 +204,7 @@ describe('useFetch', () => {
       fail = false;
       retry(wrapper);
 
+      assert.equal(getResultText(wrapper), 'Loading');
       await waitForFetch(wrapper);
       assert.equal(getResultText(wrapper), 'Data: OK');
     });


### PR DESCRIPTION
Make sure the result from `useFetch` is reset right before retrying.

Without these changes, `isLoading` is kept as false, and the error is still set, if any.