### PR TITLE
Expose assignment creation dates on the API

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -56,6 +56,7 @@ class APICourses(TypedDict):
 class APIAssignment(TypedDict):
     id: int
     title: str
+    created: str
     course: NotRequired[APICourse]
     annotation_metrics: NotRequired[AnnotationMetrics]
 

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -80,7 +80,11 @@ class AssignmentViews:
         )
         return {
             "assignments": [
-                APIAssignment(id=assignment.id, title=assignment.title)
+                APIAssignment(
+                    id=assignment.id,
+                    title=assignment.title,
+                    created=assignment.created.isoformat(),
+                )
                 for assignment in assignments
             ],
             "pagination": pagination,
@@ -97,7 +101,11 @@ class AssignmentViews:
         return APIAssignment(
             id=assignment.id,
             title=assignment.title,
-            course=APICourse(id=assignment.course.id, title=assignment.course.lms_name),
+            created=assignment.created.isoformat(),
+            course=APICourse(
+                id=assignment.course.id,
+                title=assignment.course.lms_name,
+            ),
         )
 
     @view_config(
@@ -166,6 +174,7 @@ class AssignmentViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
+                    created=assignment.created.isoformat(),
                     course=api_course,
                     annotation_metrics=metrics,
                 )


### PR DESCRIPTION
Often assignments have the same names and belong to courses with also the same names.

To help disambiguate them we expose the creation dates of the assignments in the API.

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1722947283308589


## Testing

The assignment creation date can be found in the responses of:

- Dropdown API call
- Single assignment API GET
- Course assignments list with metrics