### PR TITLE
Count both annotation and page notes towards the annotation count

### DIFF
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -175,7 +175,7 @@ class HAPI:
         group_by: str,
         h_userids: list[str] | None = None,
         resource_link_ids: list[str] | None = None,
-    ):
+    ) -> dict:
         filters = {
             "groups": group_authority_ids,
             "assignment_ids": resource_link_ids,

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -152,7 +152,7 @@ class AssignmentViews:
         for assignment in assignments:
             if h_stats := stats_by_assignment.get(assignment.resource_link_id):
                 metrics = AnnotationMetrics(
-                    annotations=h_stats["annotations"],
+                    annotations=h_stats["annotations"] + h_stats["page_notes"],
                     replies=h_stats["replies"],
                     last_activity=h_stats["last_activity"],
                 )

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -137,7 +137,7 @@ class UserViews:
                         lms_id=user.user_id,
                         display_name=s["display_name"],
                         annotation_metrics=AnnotationMetrics(
-                            annotations=s["annotations"],
+                            annotations=s["annotations"] + s["page_notes"],
                             replies=s["replies"],
                             last_activity=s["last_activity"],
                         ),

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -115,7 +115,7 @@ class TestAssignmentViews:
                         "title": course.lms_name,
                     },
                     "annotation_metrics": {
-                        "annotations": sentinel.annotations,
+                        "annotations": 4,
                         "replies": sentinel.replies,
                         "last_activity": sentinel.last_activity,
                     },
@@ -141,7 +141,8 @@ class TestAssignmentViews:
         return [
             {
                 "assignment_id": assignment.resource_link_id,
-                "annotations": sentinel.annotations,
+                "annotations": 2,
+                "page_notes": 2,
                 "replies": sentinel.replies,
                 "userid": "TEACHER",
                 "last_activity": sentinel.last_activity,

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -76,7 +76,8 @@ class TestUserViews:
         stats = [
             {
                 "display_name": student.display_name,
-                "annotations": sentinel.annotations,
+                "annotations": 2,
+                "page_notes": 2,
                 "replies": sentinel.replies,
                 "userid": student.h_userid,
                 "last_activity": sentinel.last_activity,
@@ -84,6 +85,7 @@ class TestUserViews:
             {
                 "display_name": sentinel.display_name,
                 "annotations": sentinel.annotations,
+                "page_notes": sentinel.page_notes,
                 "replies": sentinel.replies,
                 "userid": "TEACHER",
                 "last_activity": sentinel.last_activity,
@@ -110,7 +112,7 @@ class TestUserViews:
                     "lms_id": student.user_id,
                     "display_name": student.display_name,
                     "annotation_metrics": {
-                        "annotations": sentinel.annotations,
+                        "annotations": 4,
                         "replies": sentinel.replies,
                         "last_activity": sentinel.last_activity,
                     },


### PR DESCRIPTION
Needs: https://github.com/hypothesis/h/pull/8872

We are currently not counting page notes for the dashboards, include them in the count of annotations.


Slack thread: https://hypothes-is.slack.com/archives/C2C2U40LW/p1722868549707479?thread_ts=1722628855.186809&cid=C2C2U40LW


## Testing

- As an instructor go to:

https://hypothesis.instructure.com/courses/125/assignments/873

- Open the dashboards and see the annotations counts
- Open the same assignment as a student, make a page note
- Number goes up!