### PR TITLE
Disambiguate assignment names in dashboard filters dropdown

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -183,6 +183,8 @@ export type CoursesMetricsResponse = {
 export type Assignment = {
   id: number;
   title: string;
+  /** Date in which the assignment was created, in ISO format */
+  created: string;
 };
 
 export type Student = {

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../../api-types';
 import { useConfig } from '../../config';
 import { usePaginatedAPIFetch } from '../../utils/api';
+import { formatDateTime } from '../../utils/date';
 
 /**
  * Allow the user to select items from a paginated list of all items matching
@@ -260,7 +261,12 @@ export default function DashboardActivityFilters({
                 key={assignment.id}
                 value={`${assignment.id}`}
               >
-                {assignment.title}
+                <div className="flex flex-col gap-0.5">
+                  {assignment.title}
+                  <div className="text-grey-6 text-xs">
+                    {formatDateTime(assignment.created)}
+                  </div>
+                </div>
               </MultiSelect.Option>
             ))}
             {assignmentsResults.isLoading &&

--- a/lms/static/scripts/frontend_apps/components/dashboard/FormattedDate.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/FormattedDate.tsx
@@ -12,6 +12,6 @@ export type FormattedDateProps = {
  * container
  */
 export default function FormattedDate({ date }: FormattedDateProps) {
-  const formattedDate = useMemo(() => formatDateTime(new Date(date)), [date]);
+  const formattedDate = useMemo(() => formatDateTime(date), [date]);
   return <div className="whitespace-nowrap">{formattedDate}</div>;
 }

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -150,7 +150,7 @@ describe('AllCoursesActivity', () => {
 
       assert.equal(
         itemText,
-        last_launched ? formatDateTime(new Date(last_launched)) : '',
+        last_launched ? formatDateTime(last_launched) : '',
       );
     });
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -149,7 +149,7 @@ describe('AssignmentActivity', () => {
     { fieldName: 'replies', expectedValue: '25' },
     {
       fieldName: 'last_activity',
-      expectedValue: formatDateTime(new Date('2024-01-01T10:35:18')),
+      expectedValue: formatDateTime('2024-01-01T10:35:18'),
     },
     // Render "unknown" field name
     { fieldName: 'id', expectedValue: '' },

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -7,6 +7,7 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { Config } from '../../../config';
+import { formatDateTime } from '../../../utils/date';
 import DashboardActivityFilters, {
   $imports,
 } from '../DashboardActivityFilters';
@@ -26,10 +27,12 @@ describe('DashboardActivityFilters', () => {
     {
       id: 1,
       title: 'Assignment 1',
+      created: '2024-08-05T09:55:46.523343',
     },
     {
       id: 2,
       title: 'Assignment 2',
+      created: '2024-06-10T09:55:44.701550',
     },
   ];
   const studentsWithName = [
@@ -194,7 +197,10 @@ describe('DashboardActivityFilters', () => {
     },
     {
       id: 'assignments-select',
-      expectedOptions: ['All assignments', ...assignments.map(a => a.title)],
+      expectedOptions: [
+        'All assignments',
+        ...assignments.map(a => `${a.title}${formatDateTime(a.created)}`),
+      ],
     },
     {
       id: 'students-select',

--- a/lms/static/scripts/frontend_apps/utils/date.ts
+++ b/lms/static/scripts/frontend_apps/utils/date.ts
@@ -45,9 +45,9 @@ function format(
  *
  * @param Intl - Test seam. JS `Intl` API implementation.
  */
-export function formatDateTime(date: Date, Intl?: IntlType): string {
+export function formatDateTime(date: Date | string, Intl?: IntlType): string {
   return format(
-    date,
+    typeof date === 'string' ? new Date(date) : date,
     {
       year: 'numeric',
       month: 'short',


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6554
> Closes #6556 

Add the assignment creation date to the assignments dropdown, to help disambiguate assignments with the same name.

The date is formatted based on the browser's locale.

![image](https://github.com/user-attachments/assets/30067674-0b10-45ad-a2a4-6127d80b66b0)
