### PR TITLE
Redirect to slash-appended routes on notfound_view_config

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -245,35 +245,35 @@ def includeme(config):  # noqa: PLR0915
     )
 
     config.add_route(
-        "dashboard.launch.assignment", "/dashboard/launch/assignments/{assignment_id}"
+        "dashboard.launch.assignment", "/dashboard/launch/assignments/{assignment_id}/"
     )
 
     config.add_route(
         "dashboard.assignment",
-        "/dashboard/assignments/{assignment_id}",
+        "/dashboard/assignments/{assignment_id}/",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
         "dashboard.course",
-        "/dashboard/courses/{course_id}",
+        "/dashboard/courses/{course_id}/",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
-        "dashboard", "/dashboard", factory="lms.resources.dashboard.DashboardResource"
+        "dashboard", "/dashboard/", factory="lms.resources.dashboard.DashboardResource"
     )
     config.add_route(
         "dashboard.organization",
-        "/dashboard/orgs/{public_id}",
+        "/dashboard/orgs/{public_id}/",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
         "dashboard.organization.assignment",
-        "/dashboard/orgs/{public_id}/assignments/{assignment_id}",
+        "/dashboard/orgs/{public_id}/assignments/{assignment_id}/",
         factory="lms.resources.dashboard.DashboardResource",
     )
     config.add_route(
         "dashboard.organization.course",
-        "/dashboard/orgs/{public_id}/courses/{course_id}",
+        "/dashboard/orgs/{public_id}/courses/{course_id}/",
         factory="lms.resources.dashboard.DashboardResource",
     )
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -74,7 +74,7 @@ export default function AssignmentActivity() {
         {assignment.data && (
           <div className="mb-3 mt-1 w-full">
             <DashboardBreadcrumbs
-              allCoursesLink={urlWithFilters({ studentIds }, { path: '' })}
+              allCoursesLink={urlWithFilters({ studentIds }, { path: '/' })}
               links={[
                 {
                   title: assignment.data.course.title,
@@ -103,7 +103,7 @@ export default function AssignmentActivity() {
               navigate(
                 urlWithFilters(
                   { studentIds, assignmentIds: [assignmentId] },
-                  { path: '' },
+                  { path: '/' },
                 ),
               ),
           }}

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -85,7 +85,7 @@ export default function CourseActivity() {
           <DashboardBreadcrumbs
             allCoursesLink={urlWithFilters(
               { assignmentIds, studentIds },
-              { path: '' },
+              { path: '/' },
             )}
           />
         </div>
@@ -101,7 +101,7 @@ export default function CourseActivity() {
             activeItem: course.data,
             // When selected course is cleared, navigate to the home page,
             // AKA "All courses"
-            onClear: () => navigate(search.length > 0 ? `?${search}` : ''),
+            onClear: () => navigate(search.length > 0 ? `/?${search}` : '/'),
           }}
           assignments={{
             selectedIds: assignmentIds,

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -39,13 +39,13 @@ export default function DashboardApp() {
       <div className="flex-grow px-3">
         <div className="mx-auto max-w-6xl">
           <Switch>
-            <Route path="/assignments/:assignmentId">
+            <Route path="/assignments/:assignmentId/">
               <AssignmentActivity />
             </Route>
-            <Route path="/courses/:courseId">
+            <Route path="/courses/:courseId/">
               <CourseActivity />
             </Route>
-            <Route path="">
+            <Route path="/">
               <AllCoursesActivity />
             </Route>
           </Switch>

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
@@ -13,7 +13,7 @@ export type BreadcrumbLink = {
 };
 
 export type DashboardBreadcrumbsProps = {
-  /** Link to the "All courses" view. Defaults to '' */
+  /** Link to the "All courses" view. Defaults to '/' */
   allCoursesLink?: string;
   /** More links to append to the breadcrumb after the "All courses" one */
   links?: BreadcrumbLink[];
@@ -38,7 +38,7 @@ function BreadcrumbLink({ title, href }: BreadcrumbLink) {
  * Navigation breadcrumbs showing a list of links
  */
 export default function DashboardBreadcrumbs({
-  allCoursesLink = '',
+  allCoursesLink = '/',
   links = [],
 }: DashboardBreadcrumbsProps) {
   const linksWithHome = useMemo(

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -139,7 +139,7 @@ describe('AllCoursesActivity', () => {
       const itemWrapper = mount(item);
 
       assert.equal(itemWrapper.text(), title);
-      assert.equal(itemWrapper.prop('href'), `/courses/${id}`);
+      assert.equal(itemWrapper.prop('href'), `/courses/${id}/`);
     });
 
     it('renders last launched date', () => {
@@ -175,7 +175,7 @@ describe('AllCoursesActivity', () => {
     [12, 35, 1, 500].forEach(courseId => {
       it('builds expected links for row confirmation', () => {
         const wrapper = createComponent();
-        assert.equal(getLinkForId(wrapper, courseId), `/courses/${courseId}`);
+        assert.equal(getLinkForId(wrapper, courseId), `/courses/${courseId}/`);
       });
     });
 
@@ -183,17 +183,17 @@ describe('AllCoursesActivity', () => {
       {
         prop: 'students',
         arg: ['123', '456'],
-        expectedLink: '/courses/123?student_id=123&student_id=456',
+        expectedLink: '/courses/123/?student_id=123&student_id=456',
       },
       {
         prop: 'assignments',
         arg: ['123'],
-        expectedLink: '/courses/123?assignment_id=123',
+        expectedLink: '/courses/123/?assignment_id=123',
       },
       {
         prop: 'courses',
         arg: ['11', '33', '88'],
-        expectedLink: '/courses/123', // Selected courses are not propagated
+        expectedLink: '/courses/123/', // Selected courses are not propagated
       },
     ].forEach(({ prop, arg, expectedLink }) => {
       it('preserves filters', () => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -270,18 +270,18 @@ describe('AssignmentActivity', () => {
 
       assert.calledWith(
         fakeNavigate,
-        '?assignment_id=123&student_id=8&student_id=20&student_id=32',
+        '/?assignment_id=123&student_id=8&student_id=20&student_id=32',
       );
     });
 
     [
       {
         currentSearch: 'current=query',
-        expectedDestination: '/courses/12?current=query',
+        expectedDestination: '/courses/12/?current=query',
       },
       {
         currentSearch: '',
-        expectedDestination: '/courses/12',
+        expectedDestination: '/courses/12/',
       },
     ].forEach(({ currentSearch, expectedDestination }) => {
       it('navigates to course preserving current query when selected assignment is cleared', () => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/CourseActivity-test.js
@@ -214,7 +214,7 @@ describe('CourseActivity', () => {
       assert.equal(itemWrapper.text(), expectedValue);
 
       if (fieldName === 'title') {
-        assert.equal(itemWrapper.prop('href'), '/assignments/123');
+        assert.equal(itemWrapper.prop('href'), '/assignments/123/');
       }
     });
   });
@@ -232,7 +232,7 @@ describe('CourseActivity', () => {
         const wrapper = createComponent();
         assert.equal(
           getLinkForId(wrapper, assignmentId),
-          `/assignments/${assignmentId}`,
+          `/assignments/${assignmentId}/`,
         );
       });
     });
@@ -241,12 +241,12 @@ describe('CourseActivity', () => {
       {
         prop: 'students',
         arg: ['123', '456'],
-        expectedLink: '/assignments/123?student_id=123&student_id=456',
+        expectedLink: '/assignments/123/?student_id=123&student_id=456',
       },
       {
         prop: 'assignments',
         arg: ['999'],
-        expectedLink: '/assignments/123', // Selected assignments are not propagated
+        expectedLink: '/assignments/123/', // Selected assignments are not propagated
       },
     ].forEach(({ prop, arg, expectedLink }) => {
       it('preserves filters', () => {
@@ -331,11 +331,11 @@ describe('CourseActivity', () => {
     [
       {
         currentSearch: 'current=query',
-        expectedDestination: '?current=query',
+        expectedDestination: '/?current=query',
       },
       {
         currentSearch: '',
-        expectedDestination: '',
+        expectedDestination: '/',
       },
     ].forEach(({ currentSearch, expectedDestination }) => {
       it('navigates to home preserving current query when selected course is cleared', () => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
@@ -24,7 +24,7 @@ describe('DashboardBreadcrumbs', () => {
       const wrapper = createComponent({ allCoursesLink, links: [] });
       const firstLink = wrapper.find('BreadcrumbLink').first();
 
-      assert.equal(firstLink.prop('href'), allCoursesLink ?? '');
+      assert.equal(firstLink.prop('href'), allCoursesLink ?? '/');
     });
   });
 

--- a/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/hooks.ts
@@ -68,13 +68,7 @@ export function useDashboardFilters(): UseDashboardFilters {
         newQueryParams.student_id = studentIds;
       }
 
-      // The router's base URL is represented in `location` as '/', even if
-      // that URL does not actually end with `/` (eg. `/dashboard`).
-      // When we update the query string, we want to avoid modifying the path
-      // unless a path was explicitly provided.
-      const normalizedPath = path === '/' ? '' : path;
-
-      return `${normalizedPath}${recordToQueryString(newQueryParams)}`;
+      return `${path}${recordToQueryString(newQueryParams)}`;
     },
     [location, queryParams],
   );

--- a/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/navigation.ts
@@ -1,9 +1,9 @@
 import { urlPath } from '../api';
 
 export function assignmentURL(id: number) {
-  return urlPath`/assignments/${String(id)}`;
+  return urlPath`/assignments/${String(id)}/`;
 }
 
 export function courseURL(id: number | string) {
-  return urlPath`/courses/${String(id)}`;
+  return urlPath`/courses/${String(id)}/`;
 }

--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -25,7 +25,7 @@ class ExceptionViews:
         self.exception = exception
         self.request = request
 
-    @notfound_view_config()
+    @notfound_view_config(append_slash=True)
     def notfound(self):
         LOG.info("Page not found: %s", self.request.url)
         return self.error_response(404, _("Page not found"))

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -751,7 +751,7 @@ class TestEnableInstructorDashboardEntryPoint:
         assert config["hypothesisClient"]["dashboard"] == {
             "showEntryPoint": True,
             "authTokenRPCMethod": "requestAuthToken",
-            "entryPointURL": f"http://example.com/dashboard/launch/assignments/{assignment.id}",
+            "entryPointURL": f"http://example.com/dashboard/launch/assignments/{assignment.id}/",
             "authFieldName": "authorization",
         }
 

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -57,7 +57,7 @@ class TestAdminAssignmentViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/assignments/{assignment.id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/assignments/{assignment.id}/",
             }
         )
 

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -59,7 +59,7 @@ class TestAdminCourseViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/courses/{course.id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/courses/{course.id}/",
             }
         )
 

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -356,7 +356,7 @@ class TestAdminOrganizationViews:
         pyramid_request.registry.notify.has_call_with(AuditTrailEvent.return_value)
         assert response == Any.instance_of(HTTPFound).with_attrs(
             {
-                "location": f"http://example.com/dashboard/orgs/{organization.public_id}",
+                "location": f"http://example.com/dashboard/orgs/{organization.public_id}/",
             }
         )
 

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -33,7 +33,7 @@ class TestDashboardViews:
             lifetime=timedelta(seconds=AUTHORIZATION_DURATION_SECONDS),
         )
         assert response == Any.instance_of(HTTPFound).with_attrs(
-            {"location": "http://example.com/dashboard/assignments/sentinel.id"}
+            {"location": "http://example.com/dashboard/assignments/sentinel.id/"}
         )
         self.assert_cookie_value(response)
 


### PR DESCRIPTION
Make the user facing dashboard URLs (ie the ones that appear on the browser's address bar) canonical version the slash-ending version.

Missing the slash on those will issue a temporary redirect (307) to the slash version.

Not applying this change to API routes, we expect the correct version of those to be used all the time, emitting a 404 otherwise.

See:
https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/urldispatch.html#redirecting-to-slash-appended-routes


## Testing

- Access the dashboards via both:

http://localhost:8001/dashboard/

and 

http://localhost:8001/dashboard (which should redirect to the former)