### PR TITLE
Allow single selection in dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -1,8 +1,4 @@
-import {
-  CancelIcon,
-  IconButton,
-  MultiSelect,
-} from '@hypothesis/frontend-shared';
+import { CancelIcon, IconButton, Select } from '@hypothesis/frontend-shared';
 import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
 
@@ -24,7 +20,18 @@ import { formatDateTime } from '../../utils/date';
  * The set of currently selected items are maintained by the parent component.
  */
 export type ActivityFilterSelection = {
+  /**
+   * Currently, only the first item here is taken into consideration.
+   * This will change as soon as we support multi-selection, without having to
+   * change the component's props API.
+   */
   selectedIds: string[];
+
+  /**
+   * Invoked when selected items change.
+   * It will be called with an array of 1 or 0 items, indicating either one item
+   * or no items are selected.
+   */
   onChange: (newSelectedIds: string[]) => void;
 };
 
@@ -57,6 +64,9 @@ function elementScrollIsAtBottom(element: HTMLElement, offset = 20): boolean {
   const triggerPoint = element.scrollHeight - offset;
   return distanceToTop >= triggerPoint;
 }
+
+/** Get first item from an array, if any */
+const firstItem = <T,>(array: T[]) => array[0] as T | undefined;
 
 /**
  * Renders drop-downs to select courses, assignments and/or students, used to
@@ -156,12 +166,12 @@ export default function DashboardActivityFilters({
 
   return (
     <div className="flex gap-2 flex-wrap">
-      <MultiSelect
+      <Select
         disabled={coursesResult.isLoadingFirstPage}
-        value={selectedCourseIds}
-        onChange={newCourseIds =>
+        value={firstItem(selectedCourseIds)}
+        onChange={newCourseId =>
           'onChange' in courses
-            ? courses.onChange(newCourseIds)
+            ? courses.onChange(newCourseId ? [newCourseId] : [])
             : courses.onClear()
         }
         aria-label="Select courses"
@@ -187,37 +197,34 @@ export default function DashboardActivityFilters({
           }
         }}
       >
-        <MultiSelect.Option value={undefined}>All courses</MultiSelect.Option>
+        <Select.Option value={undefined}>All courses</Select.Option>
         {activeCourse ? (
-          <MultiSelect.Option
-            key={activeCourse.id}
-            value={`${activeCourse.id}`}
-          >
+          <Select.Option key={activeCourse.id} value={`${activeCourse.id}`}>
             {activeCourse.title}
-          </MultiSelect.Option>
+          </Select.Option>
         ) : (
           <>
             {coursesResult.data?.map(course => (
-              <MultiSelect.Option key={course.id} value={`${course.id}`}>
+              <Select.Option key={course.id} value={`${course.id}`}>
                 {course.title}
-              </MultiSelect.Option>
+              </Select.Option>
             ))}
             {coursesResult.isLoading && !coursesResult.isLoadingFirstPage && (
-              <MultiSelect.Option disabled value={undefined}>
+              <Select.Option disabled value={undefined}>
                 <span className="italic" data-testid="loading-more-courses">
                   Loading more courses...
                 </span>
-              </MultiSelect.Option>
+              </Select.Option>
             )}
           </>
         )}
-      </MultiSelect>
-      <MultiSelect
+      </Select>
+      <Select
         disabled={assignmentsResults.isLoadingFirstPage}
-        value={selectedAssignmentIds}
-        onChange={newAssignmentIds =>
+        value={firstItem(selectedAssignmentIds)}
+        onChange={newAssignmentId =>
           'onChange' in assignments
-            ? assignments.onChange(newAssignmentIds)
+            ? assignments.onChange(newAssignmentId ? [newAssignmentId] : [])
             : assignments.onClear()
         }
         aria-label="Select assignments"
@@ -244,49 +251,46 @@ export default function DashboardActivityFilters({
           }
         }}
       >
-        <MultiSelect.Option value={undefined}>
-          All assignments
-        </MultiSelect.Option>
+        <Select.Option value={undefined}>All assignments</Select.Option>
         {activeAssignment ? (
-          <MultiSelect.Option
+          <Select.Option
             key={activeAssignment.id}
             value={`${activeAssignment.id}`}
           >
             {activeAssignment.title}
-          </MultiSelect.Option>
+          </Select.Option>
         ) : (
           <>
             {assignmentsResults.data?.map(assignment => (
-              <MultiSelect.Option
-                key={assignment.id}
-                value={`${assignment.id}`}
-              >
+              <Select.Option key={assignment.id} value={`${assignment.id}`}>
                 <div className="flex flex-col gap-0.5">
                   {assignment.title}
                   <div className="text-grey-6 text-xs">
                     {formatDateTime(assignment.created)}
                   </div>
                 </div>
-              </MultiSelect.Option>
+              </Select.Option>
             ))}
             {assignmentsResults.isLoading &&
               !assignmentsResults.isLoadingFirstPage && (
-                <MultiSelect.Option disabled value={undefined}>
+                <Select.Option disabled value={undefined}>
                   <span
                     className="italic"
                     data-testid="loading-more-assignments"
                   >
                     Loading more assignments...
                   </span>
-                </MultiSelect.Option>
+                </Select.Option>
               )}
           </>
         )}
-      </MultiSelect>
-      <MultiSelect
+      </Select>
+      <Select
         disabled={studentsResult.isLoadingFirstPage}
-        value={students.selectedIds}
-        onChange={students.onChange}
+        value={firstItem(students.selectedIds)}
+        onChange={newStudentId =>
+          students.onChange(newStudentId ? [newStudentId] : [])
+        }
         aria-label="Select students"
         containerClasses="!w-auto min-w-[180px]"
         buttonContent={
@@ -309,9 +313,9 @@ export default function DashboardActivityFilters({
           }
         }}
       >
-        <MultiSelect.Option value={undefined}>All students</MultiSelect.Option>
+        <Select.Option value={undefined}>All students</Select.Option>
         {studentsWithFallbackName?.map(student => (
-          <MultiSelect.Option key={student.lms_id} value={student.h_userid}>
+          <Select.Option key={student.lms_id} value={student.h_userid}>
             <span
               className={student.has_display_name ? undefined : 'italic'}
               title={
@@ -323,16 +327,16 @@ export default function DashboardActivityFilters({
             >
               {student.display_name}
             </span>
-          </MultiSelect.Option>
+          </Select.Option>
         ))}
         {studentsResult.isLoading && !studentsResult.isLoadingFirstPage && (
-          <MultiSelect.Option disabled value={undefined}>
+          <Select.Option disabled value={undefined}>
             <span className="italic" data-testid="loading-more-students">
               Loading more students...
             </span>
-          </MultiSelect.Option>
+          </Select.Option>
         )}
-      </MultiSelect>
+      </Select>
       {hasSelection && onClearSelection && (
         <IconButton
           title="Clear filters"

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -1,4 +1,4 @@
-import { MultiSelect } from '@hypothesis/frontend-shared';
+import { Select } from '@hypothesis/frontend-shared';
 import {
   checkAccessibility,
   mockImportedComponents,
@@ -159,7 +159,7 @@ describe('DashboardActivityFilters', () => {
   }
 
   function getSelect(wrapper, id) {
-    return wrapper.find(`MultiSelect[data-testid="${id}"]`);
+    return wrapper.find(`Select[data-testid="${id}"]`);
   }
 
   function getSelectContent(wrapper, id) {
@@ -215,7 +215,7 @@ describe('DashboardActivityFilters', () => {
     it('renders corresponding options', () => {
       const wrapper = createComponent();
       const select = getSelect(wrapper, id);
-      const options = select.find(MultiSelect.Option);
+      const options = select.find(Select.Option);
 
       assert.equal(options.length, expectedOptions.length);
       options.forEach((option, index) => {
@@ -234,17 +234,17 @@ describe('DashboardActivityFilters', () => {
   [
     {
       id: 'courses-select',
-      selection: courses.map(c => `${c.id}`),
+      selection: `${courses[0].id}`,
       getExpectedCallback: () => onCoursesChange,
     },
     {
       id: 'assignments-select',
-      selection: assignments.map(a => `${a.id}`),
+      selection: `${assignments[0].id}`,
       getExpectedCallback: () => onAssignmentsChange,
     },
     {
       id: 'students-select',
-      selection: studentsWithName.map(s => s.h_userid),
+      selection: studentsWithName[0].h_userid,
       getExpectedCallback: () => onStudentsChange,
     },
   ].forEach(({ id, selection, getExpectedCallback }) => {
@@ -253,7 +253,7 @@ describe('DashboardActivityFilters', () => {
       const select = getSelect(wrapper, id);
 
       select.props().onChange(selection);
-      assert.calledWith(getExpectedCallback(), selection);
+      assert.calledWith(getExpectedCallback(), [selection]);
     });
   });
 
@@ -512,7 +512,7 @@ describe('DashboardActivityFilters', () => {
       it('displays only two options in select', () => {
         const wrapper = createComponentWithProps(props);
         const select = getSelect(wrapper, selectId);
-        const options = select.find(MultiSelect.Option);
+        const options = select.find(Select.Option);
 
         assert.equal(options.length, 2);
         assert.equal(options.at(0).text(), allOption);


### PR DESCRIPTION
We have found some edge cases, grey areas and users confused by how our multi-select dashboard filters work.

We have plans to address those, by improving the UI and UX of the selects, making it more clear when you can select multiple items, and how to do it, but in the meantime, this PR changes filters to be single-select for now.

[Grabación de pantalla desde 2024-08-14 08-59-03.webm](https://github.com/user-attachments/assets/1d72e440-72b4-468a-9a54-28c6e558b060)

This will make it less confusing when we add the new multi-selects, as users which have already used the previous ones will see a clear visual change matching the new behavior.

### Implementation details

This PR only replaces the use of `MultiSelect` with `Select`, but keeps the `DashboardActivityFilters` API untouched.

That means all changes we'll have to eventually rollback are constrained to that component, but has the drawback that the API suggests an array of filters is supported, but then it internally only picks the first one and ignores the rest.

I'll provide an alternative PR with all the changes to make a more consistent API, so that we can decide which one makes more sense to merge in the short term.