### PR TITLE
Allow single selection in dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -54,16 +54,21 @@ export default function AllCoursesActivity() {
       <h2 className="text-lg text-brand font-semibold">All courses</h2>
       <DashboardActivityFilters
         students={{
-          selectedIds: studentIds,
-          onChange: studentIds => updateFilters({ studentIds }),
+          selectedId: studentIds[0],
+          onChange: studentId =>
+            updateFilters({ studentIds: studentId ? [studentId] : [] }),
         }}
         assignments={{
-          selectedIds: assignmentIds,
-          onChange: assignmentIds => updateFilters({ assignmentIds }),
+          selectedId: assignmentIds[0],
+          onChange: assignmentId =>
+            updateFilters({
+              assignmentIds: assignmentId ? [assignmentId] : [],
+            }),
         }}
         courses={{
-          selectedIds: courseIds,
-          onChange: courseIds => updateFilters({ courseIds }),
+          selectedId: courseIds[0],
+          onChange: courseId =>
+            updateFilters({ courseIds: courseId ? [courseId] : [] }),
         }}
         onClearSelection={() =>
           updateFilters({ studentIds: [], assignmentIds: [], courseIds: [] })

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -117,8 +117,9 @@ export default function AssignmentActivity() {
             },
           }}
           students={{
-            selectedIds: studentIds,
-            onChange: studentIds => updateFilters({ studentIds }),
+            selectedId: studentIds[0],
+            onChange: studentId =>
+              updateFilters({ studentIds: studentId ? [studentId] : [] }),
           }}
           onClearSelection={
             studentIds.length > 0

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -104,12 +104,16 @@ export default function CourseActivity() {
             onClear: () => navigate(search.length > 0 ? `?${search}` : ''),
           }}
           assignments={{
-            selectedIds: assignmentIds,
-            onChange: assignmentIds => updateFilters({ assignmentIds }),
+            selectedId: assignmentIds[0],
+            onChange: assignmentId =>
+              updateFilters({
+                assignmentIds: assignmentId ? [assignmentId] : [],
+              }),
           }}
           students={{
-            selectedIds: studentIds,
-            onChange: studentIds => updateFilters({ studentIds }),
+            selectedId: studentIds[0],
+            onChange: studentId =>
+              updateFilters({ studentIds: studentId ? [studentId] : [] }),
           }}
           onClearSelection={hasSelection ? onClearSelection : undefined}
         />

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -1,4 +1,4 @@
-import { MultiSelect } from '@hypothesis/frontend-shared';
+import { Select } from '@hypothesis/frontend-shared';
 import {
   checkAccessibility,
   mockImportedComponents,
@@ -156,7 +156,7 @@ describe('DashboardActivityFilters', () => {
   }
 
   function getSelect(wrapper, id) {
-    return wrapper.find(`MultiSelect[data-testid="${id}"]`);
+    return wrapper.find(`Select[data-testid="${id}"]`);
   }
 
   function getSelectContent(wrapper, id) {
@@ -209,7 +209,7 @@ describe('DashboardActivityFilters', () => {
     it('renders corresponding options', () => {
       const wrapper = createComponent();
       const select = getSelect(wrapper, id);
-      const options = select.find(MultiSelect.Option);
+      const options = select.find(Select.Option);
 
       assert.equal(options.length, expectedOptions.length);
       options.forEach((option, index) => {
@@ -228,17 +228,17 @@ describe('DashboardActivityFilters', () => {
   [
     {
       id: 'courses-select',
-      selection: courses.map(c => `${c.id}`),
+      selection: `${courses[0].id}`,
       getExpectedCallback: () => onCoursesChange,
     },
     {
       id: 'assignments-select',
-      selection: assignments.map(a => `${a.id}`),
+      selection: `${assignments[0].id}`,
       getExpectedCallback: () => onAssignmentsChange,
     },
     {
       id: 'students-select',
-      selection: studentsWithName.map(s => s.h_userid),
+      selection: studentsWithName[0].h_userid,
       getExpectedCallback: () => onStudentsChange,
     },
   ].forEach(({ id, selection, getExpectedCallback }) => {
@@ -247,7 +247,7 @@ describe('DashboardActivityFilters', () => {
       const select = getSelect(wrapper, id);
 
       select.props().onChange(selection);
-      assert.calledWith(getExpectedCallback(), selection);
+      assert.calledWith(getExpectedCallback(), [selection]);
     });
   });
 
@@ -506,7 +506,7 @@ describe('DashboardActivityFilters', () => {
       it('displays only two options in select', () => {
         const wrapper = createComponentWithProps(props);
         const select = getSelect(wrapper, selectId);
-        const options = select.find(MultiSelect.Option);
+        const options = select.find(Select.Option);
 
         assert.equal(options.length, 2);
         assert.equal(options.at(0).text(), allOption);


### PR DESCRIPTION
> Alternative implementation to https://github.com/hypothesis/lms/pull/6562

We have found some edge cases, grey areas and users confused by how our multi-select dashboard filters work.

We have plans to address those, by improving the UI and UX of the selects, making it more clear when you can select multiple items, and how to do it, but in the meantime, this PR changes filters to be single-select for now.

[Grabación de pantalla desde 2024-08-14 08-59-03.webm](https://github.com/user-attachments/assets/1d72e440-72b4-468a-9a54-28c6e558b060)

This will make it less confusing when we add the new multi-selects, as users which have already used the previous ones will see a clear visual change matching the new behavior.

### Implementation details

This PR changes the use of `MultiSelect` with `Select` inside `DashboardActivityFilters`, but it also changes its API to expect single filters instead of an array of filters.

This makes it more ovbious and has less side effects, but has more changes that we will have to roll back when the new select UI has been implemented.

### Todo

- [ ] Fix broken tests.