### PR TITLE
Enable dashboard for all instructors

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -212,12 +212,7 @@ class LTIUserSecurityPolicy:
         if lti_user.is_instructor:
             permissions.append(Permissions.LTI_CONFIGURE_ASSIGNMENT)
             permissions.append(Permissions.GRADE_ASSIGNMENT)
-
-            if lti_user.application_instance.settings.get(
-                "hypothesis", "instructor_dashboard"
-            ):
-                # Only include this permission if the feature is enabled
-                permissions.append(Permissions.DASHBOARD_VIEW)
+            permissions.append(Permissions.DASHBOARD_VIEW)
 
         return Identity(self._get_userid(lti_user), permissions, lti_user)
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -113,7 +113,6 @@
                         <fieldset class="box">
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
-                            {{ settings_checkbox('Enable instructor dashboard', 'hypothesis', 'instructor_dashboard') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                         </fieldset>
                         <fieldset class="box">

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -220,15 +220,11 @@ class BasicLaunchViews:
                     self.request.lti_params.get("lis_outcome_service_url"),
                 )
 
-        application_instance = self.request.lti_user.application_instance
-
         # Set up the JS config for the front-end
         self.context.js_config.add_document_url(assignment.document_url)
         self.context.js_config.enable_lti_launch_mode(self.course, assignment)
 
-        if self.request.lti_user.is_instructor and application_instance.settings.get(
-            "hypothesis", "instructor_dashboard"
-        ):
+        if self.request.lti_user.is_instructor:
             self.context.js_config.enable_instructor_dashboard_entry_point(assignment)
 
         # If there are any Hypothesis client feature flags that need to be

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.security import Allowed, Denied
 
-from lms.models import ApplicationSettings
 from lms.security import (
     CookiesBearerTokenLTIUserPolicy,
     DeniedWithException,
@@ -277,18 +276,12 @@ class TestLTIUserSecurityPolicy:
         assert not identity.permissions
         assert identity.userid
 
-    @pytest.mark.parametrize(
-        "settings",
-        [{}, {"hypothesis": {"instructor_dashboard": True}}],
-    )
     @pytest.mark.parametrize("is_instructor", [True, False])
     def test_identity_when_theres_an_lti_user(
         self,
         request,
         pyramid_request,
         is_instructor,
-        application_instance,
-        settings,
         policy,
         get_lti_user,
     ):
@@ -296,7 +289,6 @@ class TestLTIUserSecurityPolicy:
             _ = request.getfixturevalue("user_is_instructor")
         else:
             _ = request.getfixturevalue("user_is_learner")
-        settings = application_instance.settings = ApplicationSettings(settings)
         get_lti_user.return_value = pyramid_request.lti_user
 
         identity = policy.identity(pyramid_request)
@@ -313,10 +305,9 @@ class TestLTIUserSecurityPolicy:
                 [
                     Permissions.LTI_CONFIGURE_ASSIGNMENT,
                     Permissions.GRADE_ASSIGNMENT,
+                    Permissions.DASHBOARD_VIEW,
                 ]
             )
-            if settings.get("hypothesis", "instructor_dashboard"):
-                expected_permissions.append(Permissions.DASHBOARD_VIEW)
 
         assert identity.permissions == expected_permissions
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -274,7 +274,6 @@ class TestBasicLaunchViews:
 
     @pytest.mark.parametrize("use_toolbar_editing", [True, False])
     @pytest.mark.parametrize("use_toolbar_grading", [True, False])
-    @pytest.mark.parametrize("instructor_dashboard_enabled", [True, False])
     @pytest.mark.parametrize("is_gradable", [True, False])
     @pytest.mark.parametrize("is_instructor", [True, False])
     def test__show_document_configures_toolbar(
@@ -286,7 +285,6 @@ class TestBasicLaunchViews:
         lti_user,
         use_toolbar_editing,
         use_toolbar_grading,
-        instructor_dashboard_enabled,
         is_gradable,
         is_instructor,
         grading_info_service,
@@ -297,9 +295,6 @@ class TestBasicLaunchViews:
             request.getfixturevalue("user_is_instructor")
         pyramid_request.product.use_toolbar_grading = use_toolbar_grading
         pyramid_request.product.use_toolbar_editing = use_toolbar_editing
-        lti_user.application_instance.settings.set(
-            "hypothesis", "instructor_dashboard", instructor_dashboard_enabled
-        )
 
         result = svc._show_document(assignment)  # noqa: SLF001
 
@@ -309,7 +304,7 @@ class TestBasicLaunchViews:
             else:
                 context.js_config.enable_toolbar_editing.assert_not_called()
 
-        if instructor_dashboard_enabled and is_instructor:
+        if is_instructor:
             context.js_config.enable_instructor_dashboard_entry_point.assert_called_once()
         else:
             context.js_config.enable_instructor_dashboard_entry_point.assert_not_called()


### PR DESCRIPTION
**To merge on 19/8**

Enable the dashboards for all install without altering the DB state. To revert this just revert this PR and we'll read the DB again.


#### Testing
- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- Launch the dashboards.