### PR TITLE
Ensure active assignments are rendered as selected ones

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -69,6 +69,22 @@ function elementScrollIsAtBottom(element: HTMLElement, offset = 20): boolean {
 const firstItem = <T,>(array: T[]) => array[0] as T | undefined;
 
 /**
+ * Represents a `Select.Option` for a specific assignment
+ */
+function AssignmentOption({ assignment }: { assignment: Assignment }) {
+  return (
+    <Select.Option value={`${assignment.id}`}>
+      <div className="flex flex-col gap-0.5">
+        {assignment.title}
+        <div className="text-grey-6 text-xs">
+          {formatDateTime(assignment.created)}
+        </div>
+      </div>
+    </Select.Option>
+  );
+}
+
+/**
  * Renders drop-downs to select courses, assignments and/or students, used to
  * filter dashboard activity metrics.
  */
@@ -253,23 +269,11 @@ export default function DashboardActivityFilters({
       >
         <Select.Option value={undefined}>All assignments</Select.Option>
         {activeAssignment ? (
-          <Select.Option
-            key={activeAssignment.id}
-            value={`${activeAssignment.id}`}
-          >
-            {activeAssignment.title}
-          </Select.Option>
+          <AssignmentOption assignment={activeAssignment} />
         ) : (
           <>
             {assignmentsResults.data?.map(assignment => (
-              <Select.Option key={assignment.id} value={`${assignment.id}`}>
-                <div className="flex flex-col gap-0.5">
-                  {assignment.title}
-                  <div className="text-grey-6 text-xs">
-                    {formatDateTime(assignment.created)}
-                  </div>
-                </div>
-              </Select.Option>
+              <AssignmentOption key={assignment.id} assignment={assignment} />
             ))}
             {assignmentsResults.isLoading &&
               !assignmentsResults.isLoadingFirstPage && (

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -472,10 +472,12 @@ describe('DashboardActivityFilters', () => {
       selectedIds: [],
       onChange: sinon.stub(),
     };
+    const created = '2024-06-10T09:55:44.701550';
     const activeItem = {
       activeItem: {
         id: 123,
         title: 'The active title',
+        created,
       },
       onClear: sinon.stub(),
     };
@@ -490,6 +492,7 @@ describe('DashboardActivityFilters', () => {
         selectId: 'courses-select',
         allOption: 'All courses',
         skippedAPIFetchIndex: 0,
+        expectedOptionTitle: 'The active title',
       },
       {
         props: {
@@ -500,36 +503,45 @@ describe('DashboardActivityFilters', () => {
         selectId: 'assignments-select',
         allOption: 'All assignments',
         skippedAPIFetchIndex: 1,
+        expectedOptionTitle: `The active title${formatDateTime(created)}`,
       },
-    ].forEach(({ props, selectId, allOption, skippedAPIFetchIndex }) => {
-      it('displays active item', () => {
-        const wrapper = createComponentWithProps(props);
-        const select = getSelectContent(wrapper, selectId);
+    ].forEach(
+      ({
+        props,
+        selectId,
+        allOption,
+        skippedAPIFetchIndex,
+        expectedOptionTitle,
+      }) => {
+        it('displays active item', () => {
+          const wrapper = createComponentWithProps(props);
+          const select = getSelectContent(wrapper, selectId);
 
-        assert.equal(select, 'The active title');
-      });
+          assert.equal(select, 'The active title');
+        });
 
-      it('displays only two options in select', () => {
-        const wrapper = createComponentWithProps(props);
-        const select = getSelect(wrapper, selectId);
-        const options = select.find(Select.Option);
+        it('displays only two options in select', () => {
+          const wrapper = createComponentWithProps(props);
+          const select = getSelect(wrapper, selectId);
+          const options = select.find(Select.Option);
 
-        assert.equal(options.length, 2);
-        assert.equal(options.at(0).text(), allOption);
-        assert.equal(options.at(1).text(), 'The active title');
-      });
+          assert.equal(options.length, 2);
+          assert.equal(options.at(0).text(), allOption);
+          assert.equal(options.at(1).text(), expectedOptionTitle);
+        });
 
-      it('does not load list of items', () => {
-        createComponentWithProps(props);
+        it('does not load list of items', () => {
+          createComponentWithProps(props);
 
-        assert.calledWith(
-          fakeUsePaginatedAPIFetch.getCall(skippedAPIFetchIndex),
-          sinon.match.string,
-          null, // The path should be null
-          sinon.match.any,
-        );
-      });
-    });
+          assert.calledWith(
+            fakeUsePaginatedAPIFetch.getCall(skippedAPIFetchIndex),
+            sinon.match.string,
+            null, // The path should be null
+            sinon.match.any,
+          );
+        });
+      },
+    );
   });
 
   it(


### PR DESCRIPTION
This PR fixes an overlook from https://github.com/hypothesis/lms/pull/6557, where the active assignment in the assignment view will render without a date in the filters listbox.

In that view that's the only assignment to be displayed, so disambiguating is not as critical, but the inconsistency with other views might be confusing.

This PR makes sure the date is rendered in that case as well.

Before:

![image](https://github.com/user-attachments/assets/afa015a8-4e28-4297-a39c-ce45426619d1)

After:

![image](https://github.com/user-attachments/assets/ce434c76-4570-4e50-b5cc-bb90d05e4ca0)

> [!NOTE]  
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/lms/pull/6566/files?w=1)