### PR TITLE
Avoid AssignmentMembership join on get_user query

### DIFF
--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -9,6 +9,7 @@ from lms.models import (
     ApplicationInstance,
     Assignment,
     AssignmentMembership,
+    GroupingMembership,
     LTIRole,
     LTIUser,
     RoleScope,
@@ -145,10 +146,10 @@ class UserService:
 
         if instructor_h_userid:
             instructor_h_userid_clause = User.id.in_(
-                select(AssignmentMembership.user_id)
-                .join(Assignment)
-                .where(
-                    Assignment.course_id.in_(
+                # GroupingMembership has membership information, but it lacks role info
+                select(GroupingMembership.user_id).where(
+                    GroupingMembership.grouping_id.in_(
+                        # Get all the courses where instructor_h_userid is an instructor. This will query AssignmentMembership, which includes roles
                         CourseService.course_ids_with_role_query(
                             instructor_h_userid, RoleScope.COURSE, RoleType.INSTRUCTOR
                         )

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -191,6 +191,10 @@ class TestUserService:
             user=student,
             lti_role=factories.LTIRole(scope=RoleScope.COURSE, type=RoleType.LEARNER),
         )
+        factories.GroupingMembership.create(
+            grouping=assignment.course,
+            user=student,
+        )
         return student
 
     @pytest.fixture


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6523


While we do need to query AssignmentMembership to fetch any role related information we can bypass AssignmentMembership and assignment to just test for course membership based on the previous query.



```
SELECT grouping_membership.user_id
FROM grouping_membership
WHERE grouping_membership.grouping_id IN
  (SELECT assignment_grouping.grouping_id
    FROM assignment_grouping
    JOIN assignment_membership ON assignment_membership.assignment_id = assignment_grouping.assignment_id
    JOIN "user" ON "user".id = assignment_membership.user_id
    WHERE "user".h_userid = 'acct:fa9cb7e6030416082ae66e9148abdf@lms.hypothes.is'
    AND assignment_membership.lti_role_id in (SELECT lti_role.id FROM lti_role WHERE lti_role.scope = 'course' AND lti_role.type = 'instructor'))                     
```

vs the old query, no join on assignment at the top level.

``` 
SELECT assignment_membership.user_id
FROM assignment_membership
 JOIN ASSIGNMENT ON assignment.id = assignment_membership.assignment_id
WHERE assignment.course_id IN
  (SELECT assignment_grouping.grouping_id
  FROM assignment_grouping
  JOIN assignment_membership ON assignment_membership.assignment_id = assignment_grouping.assignment_id
 JOIN "user" ON "user".id = assignment_membership.user_id
WHERE "user".h_userid = 'acct:fa9cb7e6030416082ae66e9148abdf@lms.hypothes.is'
 AND assignment_membership.lti_role_id in (SELECT lti_role.id FROM lti_role WHERE lti_role.scope = 'course' AND lti_role.type = 'instructor'))
```
                     



