### PR TITLE
Create index to find non empty titles for assignments

### DIFF
--- a/lms/migrations/versions/b39108c0cd35_index_on_assignment_title_is_not_null.py
+++ b/lms/migrations/versions/b39108c0cd35_index_on_assignment_title_is_not_null.py
@@ -1,0 +1,32 @@
+"""Index on assignment.title is not null."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b39108c0cd35"
+down_revision = "3d0c022c716c"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY can't be used inside a transaction. Finish the current one.
+    op.execute("COMMIT")
+
+    op.create_index(
+        "ix__assignment_title_is_not_null",
+        "assignment",
+        ["title"],
+        unique=False,
+        postgresql_where=sa.text("title IS NOT NULL"),
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+
+    op.drop_index(
+        "ix__assignment_title_is_not_null",
+        table_name="assignment",
+        postgresql_where=sa.text("title IS NOT NULL"),
+        postgresql_concurrently=True,
+    )

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -25,9 +25,6 @@ class Assignment(CreatedUpdatedMixin, Base):
     """
 
     __tablename__ = "assignment"
-    __table_args__ = (
-        sa.UniqueConstraint("resource_link_id", "tool_consumer_instance_guid"),
-    )
 
     id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
 
@@ -90,6 +87,15 @@ class Assignment(CreatedUpdatedMixin, Base):
     course_id: Mapped[int | None] = mapped_column(sa.ForeignKey(Course.id), index=True)
 
     course: Mapped[Course | None] = relationship(Course)
+
+    __table_args__ = (
+        sa.UniqueConstraint("resource_link_id", "tool_consumer_instance_guid"),
+        sa.Index(
+            "ix__assignment_title_is_not_null",
+            "title",
+            postgresql_where=title.is_not(None),
+        ),
+    )
 
     def get_canvas_mapped_file_id(self, file_id):
         return self.extra.get("canvas_file_mappings", {}).get(file_id, file_id)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6523


A big time of the query time of get_assignments is spent finding assignments with not null titles.

Create an index on that condition trying to speed it up.


From the query plan:

```
Parallel Index Scan using ix__assignment_title on assignment  (cost=1833.94..114225.07 rows=74535 width=582) (actual time=5.866..60.334 rows=140 loops=3)
                          Index Cond: (title IS NOT NULL)
```

That 60ms out of a total of 80.


How much the query will improve will depend on the table stats, around 30 percent of the assignments have empty titles (imported from another table when we first created the assignment table), more info in https://stackoverflow.com/a/31966616


