### PR TITLE
Use a subquery instead of a join for the assignment user filter

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -275,16 +275,18 @@ class AssignmentService:
         )
 
         if h_userids:
-            query = (
-                query.join(AssignmentMembership)
-                .join(User)
-                .where(User.h_userid.in_(h_userids))
+            query = query.where(
+                Assignment.id.in_(
+                    select(AssignmentMembership.assignment_id)
+                    .join(User)
+                    .where(User.h_userid.in_(h_userids))
+                )
             )
 
         if course_ids:
             query = query.where(Assignment.course_id.in_(course_ids))
 
-        return query.order_by(Assignment.title, Assignment.id).distinct()
+        return query.order_by(Assignment.title, Assignment.id)
 
     def get_courses_assignments_count(self, **kwargs) -> dict[int, int]:
         """Get the number of assignments a given list of courses has."""


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6523

In general a subquery is better for filtering, in this case because:

- It allows us to compose a query better, we don't have to worry about missing/duplicating a join

- It can be faster for non-correlated subqueries (ie queries that produce the same values for all rows). This should be the case here.

- They don't introduce duplicate rows, we can remove the distinct here.

###

No behaviour changes, to sanity check:

- Launch the dashboard and list assignments in the dropdown and for one particular course. 

- Use the student drop down to filter assignments.