### PR TITLE
Keep LMSCourseMembership up to date on every launch

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from lms.db import Base, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.json_settings import JSONSettings
+from lms.models.lms_course import LMSCourse
 
 if TYPE_CHECKING:
     from lms.models import Assignment
@@ -191,6 +192,11 @@ class Course(Grouping):
         secondary="assignment_grouping", viewonly=True
     )
     """Assignments that belong to this course."""
+
+    lms_course: Mapped[LMSCourse] = sa.orm.relationship(
+        LMSCourse,
+        primaryjoin="Grouping.authority_provided_id == foreign(LMSCourse.h_authority_provided_id)",
+    )
 
     def set_group_sets(self, group_sets: list[dict]):
         """

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
+from lms.models.lms_user import LMSUser
 
 
 class User(CreatedUpdatedMixin, Base):
@@ -47,3 +48,7 @@ class User(CreatedUpdatedMixin, Base):
 
     display_name: Mapped[str | None] = mapped_column(sa.Unicode, index=True)
     """The user's display name."""
+
+    lms_user: Mapped[LMSUser] = sa.orm.relationship(
+        LMSUser, primaryjoin="User.h_userid == foreign(LMSUser.h_userid)"
+    )

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -15,6 +15,8 @@ from lms.models import (
     GroupingMembership,
     LMSCourse,
     LMSCourseApplicationInstance,
+    LMSCourseMembership,
+    LMSUser,
     LTIRole,
     Organization,
     RoleScope,
@@ -316,6 +318,28 @@ class CourseService:
             update_columns=["updated"],
         )
         return lms_course
+
+    def upsert_lms_course_membership(
+        self, lms_user: LMSUser, lms_course: LMSCourse, lti_roles: list[LTIRole]
+    ):
+        values = [
+            {
+                "lms_user_id": lms_user.id,
+                "lms_course_id": lms_course.id,
+                "lti_role_id": lti_role.id,
+            }
+            for lti_role in lti_roles
+        ]
+
+        return list(
+            bulk_upsert(
+                self._db,
+                model_class=LMSCourseMembership,
+                values=values,
+                index_elements=["lms_user_id", "lms_course_id", "lti_role_id"],
+                update_columns=["updated"],
+            )
+        )
 
     def find_group_set(self, group_set_id=None, name=None, context_id=None):
         """

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -28,6 +28,8 @@ from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
 from tests.factories.hubspot_company import HubSpotCompany
 from tests.factories.jwt_oauth2_token import JWTOAuth2Token
+from tests.factories.lms_course import LMSCourse
+from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/lms_course.py
+++ b/tests/factories/lms_course.py
@@ -1,0 +1,14 @@
+from factory import Faker, Sequence, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID
+
+LMSCourse = make_factory(
+    models.LMSCourse,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
+    lti_context_id=Faker("hexify", text="^" * 40),
+    h_authority_provided_id=Faker("hexify", text="^" * 40),
+    name=Sequence(lambda n: f"Course {n}"),
+)

--- a/tests/factories/lms_user.py
+++ b/tests/factories/lms_user.py
@@ -1,0 +1,12 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import H_USERID, USER_ID
+
+LMSUser = make_factory(
+    models.LMSUser,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    lti_user_id=USER_ID,
+    h_userid=H_USERID,
+)

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -40,7 +40,11 @@ class TestBasicLaunchViews:
             user=pyramid_request.user,
             groups=[course_service.get_from_launch.return_value],
         )
-
+        course_service.upsert_lms_course_membership.assert_called_once_with(
+            lms_course=course_service.get_from_launch.return_value.lms_course,
+            lms_user=pyramid_request.user.lms_user,
+            lti_roles=lti_user.lti_roles,
+        )
         pyramid_request.lti_user.application_instance.check_guid_aligns.assert_called_once_with(
             pyramid_request.lti_params["tool_consumer_instance_guid"]
         )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575

Insert one row per user,course,role tuple in LMSCourseMembership.

We keep inserting mostly the same information in AssignmentMembership for now.



### Testing

- Make any local launch: https://hypothesis.instructure.com/courses/125/assignments/873
- Check your local DB for the new rows:

```
docker compose exec postgres psql -U postgres -c "select * from lms_course_membership;"
 id | lms_course_id | lms_user_id | lti_role_id |          created           |          updated           
----+---------------+-------------+-------------+----------------------------+----------------------------
  1 |             7 |           1 |          21 | 2024-08-22 07:06:05.357006 | 2024-08-22 07:06:13.540303
```
