### PR TITLE
Add error handling to dashboard filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.3.0",
+    "@hypothesis/frontend-shared": "^8.4.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,15 +2081,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "@hypothesis/frontend-shared@npm:8.3.0"
+"@hypothesis/frontend-shared@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "@hypothesis/frontend-shared@npm:8.4.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: e08dfe4c290f8c8aa3f18a64ca1dfca52180e1fe82fe4c3c45ea08a293fb59acdcc37d48d07ade6dd6179d694ea3fcc708b2a04fa2a8e0b92809ca291df56345
+  checksum: 34d7ae1cab013825be55504c5a9af582b0f20962a358192e66dad19097dfaa6ee052129399dcec9e317c41ba5a2e4b595f33b40b639404ab5f9e997b27cc93e1
   languageName: node
   linkType: hard
 
@@ -7321,7 +7321,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.3.0
+    "@hypothesis/frontend-shared": ^8.4.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1


### PR DESCRIPTION
Closes #6531

Depends on https://github.com/hypothesis/frontend-shared/pull/1685

Display an error message with a button to retry when loading items for any filtering dropdown fails.

The same kind of message is displayed regardless of the page that failed, so if the first page fails, we show the error after the "All {entity}" option, and if a subsequent page fails, we show the message after the already loaded options.

https://github.com/user-attachments/assets/e5bed471-b23a-48f3-9782-983b50e2c1c3

https://github.com/user-attachments/assets/e29675ae-408f-41ad-82dd-855db8850740

### Considerations

- The icon in the retry button is not the one I was looking for, but we don't have the typical "refresh" circle arrow, so I'll leave this one for now.
- When the first page is the one failing and we retry, the select transitions into a "disabled with ellispis" state. Ideally this should happen only the first time, not when retrying, but I think handling that is not worth the complexity it would introduce.

### Todo

- [x] Try to keep listbox open when "retry" is clicked.
- [x] Add tests

### Testing steps

Apply this diff to test the error when loading first page:

```diff
diff --git a/lms/static/scripts/frontend_apps/utils/api.ts b/lms/static/scripts/frontend_apps/utils/api.ts
index ad3479399..0efde41bb 100644
--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -196,6 +196,7 @@ export function useAPIFetch<T = unknown>(
     api: { authToken },
   } = useConfig(['api']);
 
+  const callNum = useRef(0);
   const fetcher: Fetcher<T> | undefined = path
     ? signal =>
         apiCall({
@@ -203,6 +204,16 @@ export function useAPIFetch<T = unknown>(
           path,
           params,
           signal,
+        }).then(res => {
+          if (path.includes('/api/dashboard/assignments')) {
+            callNum.current++;
+
+            if (callNum.current < 2) {
+              throw new Error('There was an error loading');
+            }
+          }
+
+          return res as T;
         })
     : undefined;
 
diff --git a/lms/views/dashboard/pagination.py b/lms/views/dashboard/pagination.py
index 680843cdd..396c7d893 100644
--- a/lms/views/dashboard/pagination.py
+++ b/lms/views/dashboard/pagination.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-MAX_ITEMS_PER_PAGE = 100
+MAX_ITEMS_PER_PAGE = 15
 """Maximum number of items to return in paginated endpoints"""


```

Apply the same diff but with `if (callNum.current === 2)` to test the error when loading a follow-up page.

In both cases, clicking "retry" should load the data properly.