### PR TITLE
Keep LMSCourse and LMSUser up to date on every launch

### DIFF
--- a/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
+++ b/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
@@ -1,0 +1,39 @@
+"""Fix lms_course_membership user FK."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1b80d29976d6"
+down_revision = "f13a876b8877"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        "lms_user",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        "lms_course",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -71,7 +71,7 @@ class LMSCourseMembership(CreatedUpdatedMixin, Base):
     )
 
     lms_user_id: Mapped[int] = mapped_column(
-        sa.ForeignKey("lms_course.id", ondelete="cascade"), index=True
+        sa.ForeignKey("lms_user.id", ondelete="cascade"), index=True
     )
 
     lti_role_id: Mapped[int] = mapped_column(

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -297,7 +297,6 @@ class CourseService:
                     "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
                     "lti_context_id": course.lms_id,
                     "h_authority_provided_id": course.authority_provided_id,
-                    "copied_from_id": course.copied_from_id,
                     "name": course.lms_name,
                 }
             ],

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -223,7 +223,6 @@ class TestCourseService:
                             "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
                             "lti_context_id": course.lms_id,
                             "h_authority_provided_id": course.authority_provided_id,
-                            "copied_from_id": course.copied_from_id,
                             "name": course.lms_name,
                         }
                     ],

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -3,8 +3,9 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
+from sqlalchemy import select
 
-from lms.models import RoleScope, RoleType, User
+from lms.models import LMSUser, RoleScope, RoleType, User
 from lms.services import UserService
 from lms.services.user import UserNotFound, factory
 from tests import factories
@@ -30,6 +31,7 @@ class TestUserService:
             }
         )
         assert saved_user == user
+        self.assert_lms_user(db_session, user)
 
     @pytest.mark.usefixtures("user_is_learner")
     def test_upsert_user_doesnt_save_email_for_students(
@@ -40,6 +42,7 @@ class TestUserService:
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
+        self.assert_lms_user(db_session, saved_user)
 
     @pytest.mark.usefixtures("user")
     def test_upsert_user_with_an_existing_user(self, service, lti_user, db_session):
@@ -49,6 +52,7 @@ class TestUserService:
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
         assert user == saved_user
+        self.assert_lms_user(db_session, user)
 
     @pytest.mark.usefixtures("user")
     def test_upsert_user_doesnt_save_email_for_existing_students(
@@ -61,6 +65,7 @@ class TestUserService:
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
+        self.assert_lms_user(db_session, saved_user)
 
     def test_get(self, user, service):
         db_user = service.get(user.application_instance, user.user_id)
@@ -168,6 +173,17 @@ class TestUserService:
         )
 
         assert db_session.scalars(query).all() == [student_in_assigment]
+
+    def assert_lms_user(self, db_session, user):
+        """Assert the corresponding LMSUser to user exists in the DB with the same attributes."""
+
+        lms_user = db_session.scalars(
+            select(LMSUser).where(LMSUser.h_userid == user.h_userid)
+        ).one()
+
+        assert lms_user.display_name == user.display_name
+        assert lms_user.email == user.email
+        assert lms_user.updated == user.updated
 
     @pytest.fixture
     def course(self, application_instance, db_session):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575


This the revert-of-a-revert PR

I reverted https://github.com/hypothesis/lms/pull/6588 due to a bug, fixed in this commit: d3a7c9c0ee7d7ffffd05ef0222c5e11f3669caf0. 

We should not try to upsert "copied_from_id" in the new table as the reference to the original courses might not yet exists in the DB. We can only do that once backfill the table.


- Original PR: https://github.com/hypothesis/lms/pull/6576
- Revert: https://github.com/hypothesis/lms/pull/6588