### PR TITLE
Migration: fix lms_course_membership.lms_user_id FK to point to the right table

### DIFF
--- a/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
+++ b/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
@@ -1,0 +1,39 @@
+"""Fix lms_course_membership user FK."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1b80d29976d6"
+down_revision = "f13a876b8877"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        "lms_user",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        "lms_course",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -71,7 +71,7 @@ class LMSCourseMembership(CreatedUpdatedMixin, Base):
     )
 
     lms_user_id: Mapped[int] = mapped_column(
-        sa.ForeignKey("lms_course.id", ondelete="cascade"), index=True
+        sa.ForeignKey("lms_user.id", ondelete="cascade"), index=True
     )
 
     lti_role_id: Mapped[int] = mapped_column(


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575


Wrong value on the initial table definition (classic copy/paste).

Fixing the model and DB schema with a migration.