### PR TITLE
Migration: Backfill LMSUSerApplication instance

### DIFF
--- a/lms/migrations/versions/e13fb37c96e5_backfill_lms_user_application_instance.py
+++ b/lms/migrations/versions/e13fb37c96e5_backfill_lms_user_application_instance.py
@@ -1,0 +1,43 @@
+"""Backfill lms_user_application_instance."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e13fb37c96e5"
+down_revision = "f61cb94edfc8"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            SELECT
+                "user".created,
+                "user".updated,
+                lms_user.id lms_user_id,
+                "user".application_instance_id
+            FROM "user"
+            JOIN lms_user on lms_user.h_userid = "user".h_userid
+        )
+        INSERT INTO lms_user_application_instance (
+             created,
+             updated,
+             lms_user_id,
+             application_instance_id
+        )
+        SELECT
+           created,
+           updated,
+           lms_user_id,
+           application_instance_id
+        FROM backfill
+        ON CONFLICT (lms_user_id, application_instance_id) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575


### Testing


```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='2408596744'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade f61cb94edfc8 -> e13fb37c96e5, Backfill lms_user_application_instance.
```

