### PR TITLE
Migration: Backfill LMSCourseApplication instance

### DIFF
--- a/lms/migrations/versions/9e79650bed37_backfill_lms_course_application_instance.py
+++ b/lms/migrations/versions/9e79650bed37_backfill_lms_course_application_instance.py
@@ -1,0 +1,43 @@
+"""LMSCourseApplicationInstance backfill."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9e79650bed37"
+down_revision = "e13fb37c96e5"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            SELECT
+                "grouping".created,
+                "grouping".updated,
+                lms_course.id lms_course_id,
+                "grouping".application_instance_id
+            FROM "grouping"
+            JOIN lms_course on lms_course.h_authority_provided_id = "grouping".authority_provided_id
+        )
+        INSERT INTO lms_course_application_instance (
+             created,
+             updated,
+             lms_course_id,
+             application_instance_id
+        )
+        SELECT
+           created,
+           updated,
+           lms_course_id,
+           application_instance_id
+        FROM backfill
+        ON CONFLICT (lms_course_id, application_instance_id) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575

### Testing

```
tox -e dev --run-command 'alembic upgrade head'        

dev run-test-pre: PYTHONHASHSEED='427507881'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade e13fb37c96e5 -> 9e79650bed37, LMSCourseApplicationInstance backfill.
```
