### PR TITLE
Upsert lms_course.copied_form_id

### DIFF
--- a/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
+++ b/lms/migrations/versions/1b80d29976d6_fix_lms_course_membership_user_fk.py
@@ -1,0 +1,39 @@
+"""Fix lms_course_membership user FK."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1b80d29976d6"
+down_revision = "f13a876b8877"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        "lms_user",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk__lms_course_membership__lms_user_id__lms_user"),
+        "lms_course_membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk__lms_course_membership__lms_user_id__lms_course",
+        "lms_course_membership",
+        "lms_course",
+        ["lms_user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )

--- a/lms/migrations/versions/9e79650bed37_backfill_lms_course_application_instance.py
+++ b/lms/migrations/versions/9e79650bed37_backfill_lms_course_application_instance.py
@@ -1,0 +1,43 @@
+"""LMSCourseApplicationInstance backfill."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9e79650bed37"
+down_revision = "e13fb37c96e5"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            SELECT
+                "grouping".created,
+                "grouping".updated,
+                lms_course.id lms_course_id,
+                "grouping".application_instance_id
+            FROM "grouping"
+            JOIN lms_course on lms_course.h_authority_provided_id = "grouping".authority_provided_id
+        )
+        INSERT INTO lms_course_application_instance (
+             created,
+             updated,
+             lms_course_id,
+             application_instance_id
+        )
+        SELECT
+           created,
+           updated,
+           lms_course_id,
+           application_instance_id
+        FROM backfill
+        ON CONFLICT (lms_course_id, application_instance_id) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/lms/migrations/versions/aef6a6460d0d_backfill_lmsuser.py
+++ b/lms/migrations/versions/aef6a6460d0d_backfill_lmsuser.py
@@ -1,0 +1,62 @@
+"""Backfill LMSUser."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "aef6a6460d0d"
+down_revision = "1b80d29976d6"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            SELECT
+                -- Deduplicate "user" on h_userid
+                distinct on (h_userid)
+                "user".created,
+                "user".updated,
+                tool_consumer_instance_guid,
+                h_userid,
+                user_id,
+                email,
+                -- Query display_name in case the most recently updated "user" is not the  one that has display_name
+                coalesce(
+                  display_name,
+                  (select display_name from "user" as user_2 where user_2.h_userid = "user".h_userid and display_name is not null limit 1)
+                ) as display_name
+            FROM "user"
+            -- join on application_instances to get the GUID
+            JOIN application_instances on application_instances.id = "user".application_instance_id
+            -- Pick the most recent "user" info when there are duplicates
+            order by h_userid, "user".updated desc
+        )
+        INSERT INTO lms_user (
+             created,
+             updated,
+             tool_consumer_instance_guid,
+             h_userid,
+             lti_user_id,
+             email,
+             display_name
+        )
+        SELECT
+           created,
+           updated,
+           tool_consumer_instance_guid,
+           h_userid,
+           user_id,
+           email,
+           display_name
+        FROM backfill
+        -- We are already inserting rows in lms_user in the python code, leave those alone
+        ON CONFLICT (h_userid) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/lms/migrations/versions/e13fb37c96e5_backfill_lms_user_application_instance.py
+++ b/lms/migrations/versions/e13fb37c96e5_backfill_lms_user_application_instance.py
@@ -1,0 +1,43 @@
+"""Backfill lms_user_application_instance."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e13fb37c96e5"
+down_revision = "f61cb94edfc8"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            SELECT
+                "user".created,
+                "user".updated,
+                lms_user.id lms_user_id,
+                "user".application_instance_id
+            FROM "user"
+            JOIN lms_user on lms_user.h_userid = "user".h_userid
+        )
+        INSERT INTO lms_user_application_instance (
+             created,
+             updated,
+             lms_user_id,
+             application_instance_id
+        )
+        SELECT
+           created,
+           updated,
+           lms_user_id,
+           application_instance_id
+        FROM backfill
+        ON CONFLICT (lms_user_id, application_instance_id) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/lms/migrations/versions/f61cb94edfc8_backfill_lms_course.py
+++ b/lms/migrations/versions/f61cb94edfc8_backfill_lms_course.py
@@ -1,0 +1,56 @@
+"""LMSCourse backfill."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f61cb94edfc8"
+down_revision = "aef6a6460d0d"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            -- Deduplicate "grouping" courses on authority_provided_id
+            SELECT DISTINCT ON (authority_provided_id)
+                "grouping".created,
+                "grouping".updated,
+                tool_consumer_instance_guid,
+                authority_provided_id,
+                lms_name,
+                lms_id
+            FROM "grouping"
+            -- join on application_instances to get the GUID
+            JOIN application_instances on application_instances.id = "grouping".application_instance_id
+            -- Pick only courses, not sections or groups
+            WHERE grouping.type ='course'
+            -- Pick the most recent "grouping" there are duplicates
+            ORDER BY authority_provided_id, "grouping".updated desc
+        )
+        INSERT INTO lms_course (
+             created,
+             updated,
+             tool_consumer_instance_guid,
+             h_authority_provided_id,
+             lti_context_id,
+             name
+        )
+        SELECT
+           created,
+           updated,
+           tool_consumer_instance_guid,
+           authority_provided_id,
+           lms_id,
+           lms_name
+        FROM backfill
+        -- We are already inserting rows in lms_course in the python code, leave those alone
+        ON CONFLICT (h_authority_provided_id) DO NOTHING
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from lms.db import Base, varchar_enum
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.json_settings import JSONSettings
+from lms.models.lms_course import LMSCourse
 
 if TYPE_CHECKING:
     from lms.models import Assignment
@@ -191,6 +192,11 @@ class Course(Grouping):
         secondary="assignment_grouping", viewonly=True
     )
     """Assignments that belong to this course."""
+
+    lms_course: Mapped[LMSCourse] = sa.orm.relationship(
+        LMSCourse,
+        primaryjoin="Grouping.authority_provided_id == foreign(LMSCourse.h_authority_provided_id)",
+    )
 
     def set_group_sets(self, group_sets: list[dict]):
         """

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -135,10 +135,12 @@ class Grouping(CreatedUpdatedMixin, Base):
         "GroupingMembership", lazy="dynamic", viewonly=True, back_populates="grouping"
     )
 
-    copied_from_id = sa.Column(
-        sa.Integer(), sa.ForeignKey("grouping.id"), nullable=True
-    )
+    copied_from_id: Mapped[int | None] = mapped_column(sa.ForeignKey("grouping.id"))
     """ID of the course grouping this one was copied from using the course copy feature in the LMS."""
+
+    copied_from = sa.orm.relationship(
+        "Grouping", foreign_keys=[copied_from_id], uselist=False, remote_side=[id]
+    )
 
     @property
     def name(self):

--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -71,7 +71,7 @@ class LMSCourseMembership(CreatedUpdatedMixin, Base):
     )
 
     lms_user_id: Mapped[int] = mapped_column(
-        sa.ForeignKey("lms_course.id", ondelete="cascade"), index=True
+        sa.ForeignKey("lms_user.id", ondelete="cascade"), index=True
     )
 
     lti_role_id: Mapped[int] = mapped_column(

--- a/lms/models/user.py
+++ b/lms/models/user.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
+from lms.models.lms_user import LMSUser
 
 
 class User(CreatedUpdatedMixin, Base):
@@ -47,3 +48,7 @@ class User(CreatedUpdatedMixin, Base):
 
     display_name: Mapped[str | None] = mapped_column(sa.Unicode, index=True)
     """The user's display name."""
+
+    lms_user: Mapped[LMSUser] = sa.orm.relationship(
+        LMSUser, primaryjoin="User.h_userid == foreign(LMSUser.h_userid)"
+    )

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -297,7 +297,6 @@ class CourseService:
                     "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
                     "lti_context_id": course.lms_id,
                     "h_authority_provided_id": course.authority_provided_id,
-                    "copied_from_id": course.copied_from_id,
                     "name": course.lms_name,
                 }
             ],

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -299,6 +299,9 @@ class CourseService:
                     "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
                     "lti_context_id": course.lms_id,
                     "h_authority_provided_id": course.authority_provided_id,
+                    "copied_from_id": course.copied_from.lms_course.id
+                    if course.copied_from
+                    else None,
                     "name": course.lms_name,
                 }
             ],

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -15,6 +15,8 @@ from lms.models import (
     GroupingMembership,
     LMSCourse,
     LMSCourseApplicationInstance,
+    LMSCourseMembership,
+    LMSUser,
     LTIRole,
     Organization,
     RoleScope,
@@ -316,6 +318,28 @@ class CourseService:
             update_columns=["updated"],
         )
         return lms_course
+
+    def upsert_lms_course_membership(
+        self, lms_user: LMSUser, lms_course: LMSCourse, lti_roles: list[LTIRole]
+    ):
+        values = [
+            {
+                "lms_user_id": lms_user.id,
+                "lms_course_id": lms_course.id,
+                "lti_role_id": lti_role.id,
+            }
+            for lti_role in lti_roles
+        ]
+
+        return list(
+            bulk_upsert(
+                self._db,
+                model_class=LMSCourseMembership,
+                values=values,
+                index_elements=["lms_user_id", "lms_course_id", "lti_role_id"],
+                update_columns=["updated"],
+            )
+        )
 
     def find_group_set(self, group_set_id=None, name=None, context_id=None):
         """

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -28,6 +28,8 @@ from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
 from tests.factories.hubspot_company import HubSpotCompany
 from tests.factories.jwt_oauth2_token import JWTOAuth2Token
+from tests.factories.lms_course import LMSCourse
+from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride
 from tests.factories.lti_user import LTIUser

--- a/tests/factories/lms_course.py
+++ b/tests/factories/lms_course.py
@@ -1,0 +1,14 @@
+from factory import Faker, Sequence, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID
+
+LMSCourse = make_factory(
+    models.LMSCourse,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
+    lti_context_id=Faker("hexify", text="^" * 40),
+    h_authority_provided_id=Faker("hexify", text="^" * 40),
+    name=Sequence(lambda n: f"Course {n}"),
+)

--- a/tests/factories/lms_user.py
+++ b/tests/factories/lms_user.py
@@ -1,0 +1,12 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.attributes import H_USERID, USER_ID
+
+LMSUser = make_factory(
+    models.LMSUser,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    lti_user_id=USER_ID,
+    h_userid=H_USERID,
+)

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -223,7 +223,6 @@ class TestCourseService:
                             "tool_consumer_instance_guid": course.application_instance.tool_consumer_instance_guid,
                             "lti_context_id": course.lms_id,
                             "h_authority_provided_id": course.authority_provided_id,
-                            "copied_from_id": course.copied_from_id,
                             "name": course.lms_name,
                         }
                     ],

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -3,8 +3,9 @@ from unittest.mock import sentinel
 
 import pytest
 from h_matchers import Any
+from sqlalchemy import select
 
-from lms.models import RoleScope, RoleType, User
+from lms.models import LMSUser, RoleScope, RoleType, User
 from lms.services import UserService
 from lms.services.user import UserNotFound, factory
 from tests import factories
@@ -30,6 +31,7 @@ class TestUserService:
             }
         )
         assert saved_user == user
+        self.assert_lms_user(db_session, user)
 
     @pytest.mark.usefixtures("user_is_learner")
     def test_upsert_user_doesnt_save_email_for_students(
@@ -40,6 +42,7 @@ class TestUserService:
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
+        self.assert_lms_user(db_session, saved_user)
 
     @pytest.mark.usefixtures("user")
     def test_upsert_user_with_an_existing_user(self, service, lti_user, db_session):
@@ -49,6 +52,7 @@ class TestUserService:
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
         assert user == saved_user
+        self.assert_lms_user(db_session, user)
 
     @pytest.mark.usefixtures("user")
     def test_upsert_user_doesnt_save_email_for_existing_students(
@@ -61,6 +65,7 @@ class TestUserService:
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
+        self.assert_lms_user(db_session, saved_user)
 
     def test_get(self, user, service):
         db_user = service.get(user.application_instance, user.user_id)
@@ -168,6 +173,17 @@ class TestUserService:
         )
 
         assert db_session.scalars(query).all() == [student_in_assigment]
+
+    def assert_lms_user(self, db_session, user):
+        """Assert the corresponding LMSUser to user exists in the DB with the same attributes."""
+
+        lms_user = db_session.scalars(
+            select(LMSUser).where(LMSUser.h_userid == user.h_userid)
+        ).one()
+
+        assert lms_user.display_name == user.display_name
+        assert lms_user.email == user.email
+        assert lms_user.updated == user.updated
 
     @pytest.fixture
     def course(self, application_instance, db_session):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -40,7 +40,11 @@ class TestBasicLaunchViews:
             user=pyramid_request.user,
             groups=[course_service.get_from_launch.return_value],
         )
-
+        course_service.upsert_lms_course_membership.assert_called_once_with(
+            lms_course=course_service.get_from_launch.return_value.lms_course,
+            lms_user=pyramid_request.user.lms_user,
+            lti_roles=lti_user.lti_roles,
+        )
         pyramid_request.lti_user.application_instance.check_guid_aligns.assert_called_once_with(
             pyramid_request.lti_params["tool_consumer_instance_guid"]
         )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6575



This could not be done before backfilling all LMSCourses so every (non-duplicated) Course has a corresponding LMSCourse

Use the right LMSCourse via the course relationship.



## Testing

- Clear your local course tables

```docker compose exec postgres psql -U postgres -c "truncate grouping,lms_course cascade;" ```

- Launch a non-copied course:
 
https://hypothesis.instructure.com/courses/125/assignments/873 
(to stimulate the creation of the LMSCourse row by the backfill)

- Launch an assignment on the copied course:

https://hypothesis.instructure.com/courses/252/assignments/1323

- Check we have the right references stored in the DB:

```docker compose exec postgres psql -U postgres -c "select original.name, lms_course.name from lms_course join lms_course original on original.id = lms_course.copied_from_id;"```


```
                   name                     |                        name                         
---------------------------------------------+-----------------------------------------------------
 Developer Test Course with Sections Enabled | Copy of Developer Test Course with Sections Enabled
(1 row)
```
