### PR TITLE
List the LTI1.1 parameter for course history

### DIFF
--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -357,6 +357,7 @@ class CourseService:
 
         history_params = [
             "custom_Context.id.history",  # LTI 1.3
+            "custom_context_id_history",  # LTI 1.1
         ]
 
         for param in history_params:


### PR DESCRIPTION
This allows us to keep track of the original course in LTI1.1 installs that include this parameter.


### Testing


- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- Launch the copy of that, https://hypothesis.instructure.com/courses/252/assignments/1323 (this only happens during the creation of the course, delete the local row if launched before).


- Check copied_from status stored in the DB:


```
select original.lms_name, grouping.lms_name from grouping join grouping original on original.id = grouping.copied_from_id;
                  lms_name                   |                      lms_name                       
---------------------------------------------+-----------------------------------------------------
 Developer Test Course with Sections Enabled | Copy of Developer Test Course with Sections Enabled
(1 row)
```
