### PR TITLE
Make LTI http service take an LTIRegistration

### DIFF
--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -16,6 +16,7 @@ def service_factory(_context, request):
             ltia_service=request.find_service(LTIAHTTPService),
             product_family=request.product.family,
             misc_plugin=request.product.plugin.misc,
+            lti_registration=request.lti_user.application_instance.lti_registration,
         )
 
     return LTI11GradingService(

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -31,6 +31,7 @@ class TestFactory:
             ltia_http_service,
             pyramid_request.product.family,
             misc_plugin,
+            pyramid_request.lti_user.application_instance.lti_registration,
         )
         assert svc == LTI13GradingService.return_value
 
@@ -48,6 +49,7 @@ class TestFactory:
             ltia_http_service,
             pyramid_request.product.family,
             misc_plugin,
+            pyramid_request.lti_user.application_instance.lti_registration,
         )
         assert svc == LTI13GradingService.return_value
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


Until now all call to LTIA API happen on the context of a launch so it made sense to always scope them to the registration of that launch.

In preparation for start fetching course rosters, likely on a celery task, outside the context of a launch, take an explicit registration for LTIA calls.



### Testing

This should be just a pure refactor, lets sanity check the changes:

- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View?ou=6782 as an instructor, 
- Fetch a grade for an student  (this calls the LTIA grade API).
- Submit a new one grade (another LTIA grade API call).