### PR TITLE
Move HUser h_username and h_userid generation to helper functions

### DIFF
--- a/lms/models/h_user.py
+++ b/lms/models/h_user.py
@@ -3,6 +3,14 @@ from typing import NamedTuple
 from lms.models._hashed_id import hashed_id
 
 
+def get_h_username(guid: str, lms_user_id: str):
+    return hashed_id(guid, lms_user_id)[:30]
+
+
+def get_h_userid(authority: str, h_username: str):
+    return f"acct:{h_username}@{authority}"
+
+
 class HUser(NamedTuple):
     """
     An 'h' user.
@@ -29,7 +37,7 @@ class HUser(NamedTuple):
     """The "provider_unique_id" string to pass to the h API for this user."""
 
     def userid(self, authority):
-        return f"acct:{self.username}@{authority}"
+        return get_h_userid(authority, self.username)
 
     @classmethod
     def from_lti_user(cls, lti_user):
@@ -37,7 +45,7 @@ class HUser(NamedTuple):
         provider_unique_id = lti_user.user_id
 
         return cls(
-            username=hashed_id(provider, provider_unique_id)[:30],
+            username=get_h_username(provider, provider_unique_id),
             display_name=lti_user.display_name,
             provider=provider,
             provider_unique_id=provider_unique_id,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


This avoids the need to create a HUser (which we only create from an LTIUser) when we need to generate IDs for H.

We need to use this to generate user rows for the roster members, we don't have an LTI user for them so this small refactors make it easier.