### PR TITLE
Add lti_context_membership_url to the LMSCourse model

### DIFF
--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -37,6 +37,9 @@ class LMSCourse(CreatedUpdatedMixin, Base):
 
     name: Mapped[str] = mapped_column(index=True)
 
+    lti_context_memberships_url: Mapped[str | None] = mapped_column()
+    """URL for the Names and Roles endpoint, stored during launch to use it outside the launch context."""
+
 
 class LMSCourseApplicationInstance(CreatedUpdatedMixin, Base):
     """Record of on which installs (application instances) we have seen one course."""


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


This will allow us to communicate with the service outside the launch context.

See: https://www.imsglobal.org/spec/lti-nrps/v2p0#lti-1-3-integration



### Testing

See https://github.com/hypothesis/lms/pull/6606