### PR TITLE
Store LTI1.3 context_memberships_url in LMSCourse when available

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -19,7 +19,8 @@ class LTIParams(dict):
 
     def __init__(self, v11: dict, v13: dict | None = None):
         super().__init__(v11)
-        self.v13 = v13
+        # Always have a dictionary in v13. Avoids a None comparison to callers
+        self.v13 = v13 if v13 else {}
 
     @property
     def v11(self):

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -61,6 +61,11 @@ class TestLTIParams:
 
         assert params == params.v11 == pyramid_request.json_body
 
+    def test_v13_when_empty(self):
+        lti_params = LTIParams({})
+
+        assert not lti_params.v13.get("ANY KEY")
+
     def test_it_doesnt_set_partial_keys(self, pyramid_request):
         pyramid_request.lti_jwt = {
             "https://purl.imsglobal.org/spec/lti/claim/custom": {


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


Store the url of the LTI1.3 context membership service.

This will allow us to call it outside the scope of a launch. It will also, more immediately, give us a good indication of for how many courses we receive this information at the moment.


### Testing

- Launch https://hypothesis.instructure.com/courses/125/assignments/873, nothing changes, nothing explodes.

- Launch an LTI1.3 assignment, https://hypothesis.instructure.com/courses/319/assignments/3308


The service URL gets recorded in the LMSCourse table:


```select  * from lms_course where lti_context_memberships_url is not null```