### PR TITLE
Celery task to fetch course roster asynchronously

### DIFF
--- a/lms/tasks/course_roster.py
+++ b/lms/tasks/course_roster.py
@@ -1,0 +1,22 @@
+"""Celery tasks for fetching course rosters."""
+
+from lms.models import LMSCourse
+from lms.services.course_roster import CourseRosterService
+from lms.tasks.celery import app
+
+
+@app.task(
+    acks_late=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    retry_backoff=3600,
+    retry_backoff_max=7200,
+)
+def fetch_roster(*, lms_course_id) -> None:
+    """Fetch the roster for one course."""
+
+    with app.request_context() as request:
+        roster_service = request.find_service(CourseRosterService)
+        with request.tm:
+            lms_course = request.db.get(LMSCourse, lms_course_id)
+            roster_service.fetch_roster(lms_course)

--- a/tests/unit/lms/tasks/course_roster_test.py
+++ b/tests/unit/lms/tasks/course_roster_test.py
@@ -1,0 +1,29 @@
+from contextlib import contextmanager
+
+import pytest
+
+from lms.tasks.course_roster import fetch_roster
+from tests import factories
+
+
+class TestFetchRoster:
+    def test_it(self, course_roster_service, db_session):
+        lms_course = factories.LMSCourse()
+        db_session.flush()
+
+        fetch_roster(lms_course_id=lms_course.id)
+
+        course_roster_service.fetch_roster.assert_called_once_with(lms_course)
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.course_roster.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -18,6 +18,7 @@ from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.canvas_studio import CanvasStudioService
 from lms.services.course import CourseService
+from lms.services.course_roster import CourseRosterService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.dashboard import DashboardService
 from lms.services.digest import DigestService
@@ -67,6 +68,7 @@ __all__ = (
     "canvas_service",
     "canvas_studio_service",
     "course_service",
+    "course_roster_service",
     "d2l_api_client",
     "dashboard_service",
     "digest_service",
@@ -185,6 +187,11 @@ def canvas_studio_service(mock_service):
 @pytest.fixture
 def course_service(mock_service):
     return mock_service(CourseService, service_name="course")
+
+
+@pytest.fixture
+def course_roster_service(mock_service):
+    return mock_service(CourseRosterService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


A celery task that just forwards the call to the service.


## Testing

- Launch at least one LTI1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/3308

- In `make shell`


Fech one roster asynchronously

```
from lms.tasks.course_roster import fetch_roster


fetch_roster.delay(lms_course_id=db.query(models.LMSCourse).filter(models.LMSCourse.lti_context_memberships_url.is_not(None)).first().id)
```


In the `make dev` log you'll see something like:


```
INFO/ForkPoolWorker-16] lms.tasks.course_roster.fetch_roster[fdac8f5e-976c-4421-806a-9781c6c45cbe] Task lms.tasks.course_roster.fetch_roster[fdac8f5e-976c-4421-806a-9781c6c45cbe] succeeded in 3.8122543759982364s: None
```

