### PR TITLE
Celery task to schedule fetching rosters

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -3,7 +3,6 @@ from lms.services.application_instance import ApplicationInstanceNotFound
 from lms.services.assignment import AssignmentService
 from lms.services.canvas import CanvasService
 from lms.services.canvas_studio import CanvasStudioService
-from lms.services.course_roster import CourseRosterService
 from lms.services.d2l_api.client import D2LAPIClient
 from lms.services.digest import DigestService
 from lms.services.email_preferences import EmailPreferencesService, EmailPrefs
@@ -36,6 +35,7 @@ from lms.services.ltia_http import LTIAHTTPService
 from lms.services.moodle import MoodleAPIClient
 from lms.services.organization import InvalidPublicId, OrganizationService
 from lms.services.organization_usage_report import OrganizationUsageReportService
+from lms.services.roster import RosterService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -150,9 +150,7 @@ def includeme(config):
         "lms.services.youtube.factory", iface=YouTubeService
     )
     config.register_service_factory(MoodleAPIClient.factory, iface=MoodleAPIClient)
-    config.register_service_factory(
-        "lms.services.course_roster.factory", iface=CourseRosterService
-    )
+    config.register_service_factory("lms.services.roster.factory", iface=RosterService)
 
     # Plugins are not the same as top level services but we want to register them as pyramid services too
     # Importing them here to:

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -20,7 +20,7 @@ from lms.services.upsert import bulk_upsert
 LOG = getLogger(__name__)
 
 
-class CourseRosterService:
+class RosterService:
     def __init__(
         self,
         db,
@@ -136,7 +136,7 @@ class CourseRosterService:
 
 
 def factory(_context, request):
-    return CourseRosterService(
+    return RosterService(
         db=request.db,
         lti_names_roles_service=request.find_service(LTINamesRolesService),
         lti_role_service=request.find_service(LTIRoleService),

--- a/lms/tasks/course_roster.py
+++ b/lms/tasks/course_roster.py
@@ -1,8 +1,63 @@
 """Celery tasks for fetching course rosters."""
 
-from lms.models import LMSCourse
+from datetime import datetime, timedelta
+
+from sqlalchemy import exists, select
+
+from lms.models import Course, CourseRoster, Event, LMSCourse
 from lms.services.course_roster import CourseRosterService
 from lms.tasks.celery import app
+
+COURSE_LAUNCHED_WINDOW = timedelta(hours=24)
+"""How recent we need to have seen a launch from a course before we stop fetching rosters for it."""
+
+ROSTER_REFRESH_WINDOW = timedelta(hours=24 * 7)
+"""How frequenly should we fetch roster for the same course"""
+
+ROSTER_COURSE_LIMIT = 5
+"""How many roster should we fetch per executing of the schedule task."""
+
+
+@app.task()
+def schedule_fetching_rosters() -> None:
+    """Schedule fetching course rosters based on their last lunches and the most recent roster fetch."""
+
+    # We use the python version (and not func.now()) for easier mocking during tests
+    now = datetime.now()
+
+    # Only fetch roster for courses that don't have recent roster information
+    no_recent_roster_clause = ~exists(
+        select(CourseRoster).where(
+            CourseRoster.lms_course_id == LMSCourse.id,
+            CourseRoster.updated >= now - ROSTER_REFRESH_WINDOW,
+        )
+    )
+
+    # Only fetch rosters for courses that have been recently launched
+    recent_launches_cluase = exists(
+        select(Event)
+        .join(Course, Event.course_id == Course.id)
+        .where(
+            Event.timestamp >= now - COURSE_LAUNCHED_WINDOW,
+            Course.authority_provided_id == LMSCourse.h_authority_provided_id,
+        )
+    )
+
+    with app.request_context() as request:
+        with request.tm:
+            query = (
+                select(LMSCourse.id)
+                .where(
+                    # Courses for which we have a LTIA membership service URL
+                    LMSCourse.lti_context_memberships_url.is_not(None),
+                    no_recent_roster_clause,
+                    recent_launches_cluase,
+                )
+                # Schedule only a few roster per call to this method
+                .limit(ROSTER_COURSE_LIMIT)
+            )
+            for lms_course_id in request.db.scalars(query).all():
+                fetch_roster.delay(lms_course_id=lms_course_id)
 
 
 @app.task(
@@ -14,7 +69,6 @@ from lms.tasks.celery import app
 )
 def fetch_roster(*, lms_course_id) -> None:
     """Fetch the roster for one course."""
-
     with app.request_context() as request:
         roster_service = request.find_service(CourseRosterService)
         with request.tm:

--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import exists, select
 
 from lms.models import Course, CourseRoster, Event, LMSCourse
-from lms.services.course_roster import CourseRosterService
+from lms.services.roster import RosterService
 from lms.tasks.celery import app
 
 COURSE_LAUNCHED_WINDOW = timedelta(hours=24)
@@ -70,7 +70,7 @@ def schedule_fetching_rosters() -> None:
 def fetch_roster(*, lms_course_id) -> None:
     """Fetch the roster for one course."""
     with app.request_context() as request:
-        roster_service = request.find_service(CourseRosterService)
+        roster_service = request.find_service(RosterService)
         with request.tm:
             lms_course = request.db.get(LMSCourse, lms_course_id)
             roster_service.fetch_roster(lms_course)

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -5,7 +5,7 @@ from h_matchers import Any
 from sqlalchemy import select
 
 from lms.models import CourseRoster
-from lms.services.course_roster import CourseRosterService, factory
+from lms.services.roster import RosterService, factory
 from tests import factories
 
 
@@ -80,7 +80,7 @@ class TestLTINameRolesServices:
 
     @pytest.fixture
     def svc(self, lti_names_roles_service, lti_role_service, db_session):
-        return CourseRosterService(
+        return RosterService(
             db_session,
             lti_names_roles_service=lti_names_roles_service,
             lti_role_service=lti_role_service,
@@ -93,20 +93,20 @@ class TestFactory:
         self,
         pyramid_request,
         db_session,
-        CourseRosterService,
+        RosterService,
         lti_names_roles_service,
         lti_role_service,
     ):
         service = factory(sentinel.context, pyramid_request)
 
-        CourseRosterService.assert_called_once_with(
+        RosterService.assert_called_once_with(
             db=db_session,
             lti_names_roles_service=lti_names_roles_service,
             lti_role_service=lti_role_service,
             h_authority=pyramid_request.registry.settings["h_authority"],
         )
-        assert service == CourseRosterService.return_value
+        assert service == RosterService.return_value
 
     @pytest.fixture
-    def CourseRosterService(self, patch):
-        return patch("lms.services.course_roster.CourseRosterService")
+    def RosterService(self, patch):
+        return patch("lms.services.roster.RosterService")

--- a/tests/unit/lms/tasks/course_roster_test.py
+++ b/tests/unit/lms/tasks/course_roster_test.py
@@ -1,8 +1,10 @@
 from contextlib import contextmanager
+from datetime import datetime
 
 import pytest
+from freezegun import freeze_time
 
-from lms.tasks.course_roster import fetch_roster
+from lms.tasks.course_roster import fetch_roster, schedule_fetching_rosters
 from tests import factories
 
 
@@ -14,6 +16,66 @@ class TestFetchRoster:
         fetch_roster(lms_course_id=lms_course.id)
 
         course_roster_service.fetch_roster.assert_called_once_with(lms_course)
+
+
+@freeze_time("2024-08-28")
+class TestScheduleFetchingRosters:
+    @pytest.mark.usefixtures(
+        "lms_course_with_no_launch",
+        "lms_course_with_no_service_url",
+        "lms_course_with_launch_and_recent_roster",
+    )
+    def test_it(self, lms_course_with_recent_launch, db_session, fetch_roster):
+        db_session.flush()
+
+        schedule_fetching_rosters()
+
+        fetch_roster.delay.assert_called_once_with(
+            lms_course_id=lms_course_with_recent_launch.id
+        )
+
+    @pytest.fixture
+    def lms_course_with_no_service_url(self):
+        return factories.LMSCourse()
+
+    @pytest.fixture
+    def lms_course_with_no_launch(self):
+        return factories.LMSCourse(lti_context_memberships_url="URL")
+
+    @pytest.fixture
+    def lms_course_with_recent_launch(self):
+        course = factories.Course()
+        factories.Event(
+            course=course,
+            timestamp=datetime(2024, 8, 28),
+        )
+
+        return factories.LMSCourse(
+            lti_context_memberships_url="URL",
+            h_authority_provided_id=course.authority_provided_id,
+        )
+
+    @pytest.fixture
+    def lms_course_with_launch_and_recent_roster(self):
+        course = factories.Course()
+        factories.Event(course=course)
+        lms_course = factories.LMSCourse(
+            lti_context_memberships_url="URL",
+            h_authority_provided_id=course.authority_provided_id,
+        )
+        factories.CourseRoster(
+            lms_course=lms_course,
+            lms_user=factories.LMSUser(),
+            lti_role=factories.LTIRole(),
+            active=True,
+            updated=datetime(2024, 8, 25),
+        )
+
+        return lms_course
+
+    @pytest.fixture
+    def fetch_roster(self, patch):
+        return patch("lms.tasks.course_roster.fetch_roster")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lms/tasks/roster_test.py
+++ b/tests/unit/lms/tasks/roster_test.py
@@ -4,18 +4,18 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from lms.tasks.course_roster import fetch_roster, schedule_fetching_rosters
+from lms.tasks.roster import fetch_roster, schedule_fetching_rosters
 from tests import factories
 
 
 class TestFetchRoster:
-    def test_it(self, course_roster_service, db_session):
+    def test_it(self, roster_service, db_session):
         lms_course = factories.LMSCourse()
         db_session.flush()
 
         fetch_roster(lms_course_id=lms_course.id)
 
-        course_roster_service.fetch_roster.assert_called_once_with(lms_course)
+        roster_service.fetch_roster.assert_called_once_with(lms_course)
 
 
 @freeze_time("2024-08-28")
@@ -75,12 +75,12 @@ class TestScheduleFetchingRosters:
 
     @pytest.fixture
     def fetch_roster(self, patch):
-        return patch("lms.tasks.course_roster.fetch_roster")
+        return patch("lms.tasks.roster.fetch_roster")
 
 
 @pytest.fixture(autouse=True)
 def app(patch, pyramid_request):
-    app = patch("lms.tasks.course_roster.app")
+    app = patch("lms.tasks.roster.app")
 
     @contextmanager
     def request_context():

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -18,7 +18,6 @@ from lms.services.blackboard_api.client import BlackboardAPIClient
 from lms.services.canvas_api import CanvasAPIClient
 from lms.services.canvas_studio import CanvasStudioService
 from lms.services.course import CourseService
-from lms.services.course_roster import CourseRosterService
 from lms.services.d2l_api import D2LAPIClient
 from lms.services.dashboard import DashboardService
 from lms.services.digest import DigestService
@@ -48,6 +47,7 @@ from lms.services.oauth1 import OAuth1Service
 from lms.services.oauth2_token import OAuth2TokenService
 from lms.services.oauth_http import OAuthHTTPService
 from lms.services.organization_usage_report import OrganizationUsageReportService
+from lms.services.roster import RosterService
 from lms.services.rsa_key import RSAKeyService
 from lms.services.user import UserService
 from lms.services.user_preferences import UserPreferencesService
@@ -68,7 +68,6 @@ __all__ = (
     "canvas_service",
     "canvas_studio_service",
     "course_service",
-    "course_roster_service",
     "d2l_api_client",
     "dashboard_service",
     "digest_service",
@@ -99,6 +98,7 @@ __all__ = (
     "oauth_http_service",
     "organization_service",
     "organization_usage_report_service",
+    "roster_service",
     "rsa_key_service",
     "user_service",
     "user_preferences_service",
@@ -190,8 +190,8 @@ def course_service(mock_service):
 
 
 @pytest.fixture
-def course_roster_service(mock_service):
-    return mock_service(CourseRosterService)
+def roster_service(mock_service):
+    return mock_service(RosterService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


For now the criteria to fetch rosters is:

- We have a LTI Names and Roles service URL for the course.
- The course has recent launches (1 day)
- The course doesn't have a recent roster (1 week)
- Only a number of rosterd (5) per scheduled time (??, hourly?). This needs to be set in h-periodic.

## Testing

- Launch at least one LTI1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/3308

- In `make sql`, remove any roster in your local DB

```
truncate course_roster;
````


Schedule rosters
```
from lms.tasks.course_roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```

```
Task lms.tasks.course_roster.schedule_fetching_rosters[83dfc791-e29c-4315-a094-2f56c4d98c14] received
lms.tasks.course_roster.schedule_fetching_rosters
Task lms.tasks.course_roster.schedule_fetching_rosters[83dfc791-e29c-4315-a094-2f56c4d98c14] succeeded in 0.03237636999983806s: None
Task lms.tasks.course_roster.fetch_roster[f36d29c3-fb6a-47d0-b748-4e396d82a015] received
lms.tasks.course_roster.fetch_roster[f36d29c3-fb6a-47d0-b748-4e396d82a015] 
Task lms.tasks.course_roster.fetch_roster[f36d29c3-fb6a-47d0-b748-4e396d82a015] succeeded in 3.7568937620017095s: None
```

both the schedule task and a roster fetch are executed.

- Run the celery task again, only the scheduled task gets executed
- Truncate the roster table again, both task are executed again
- Truncate the roster, but change the event dates (the launch data) to be further in the past:

```
update event set timestamp = '2024-01-01';
```

Only the scheduled task gets executed.







