### PR TITLE
Migration for assignment.lti_v13_resource_link_id

### DIFF
--- a/lms/migrations/versions/481968561169_assignment_v13_id.py
+++ b/lms/migrations/versions/481968561169_assignment_v13_id.py
@@ -1,0 +1,17 @@
+"""Assignment v13 ID."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "481968561169"
+down_revision = "9e79650bed37"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assignment", sa.Column("lti_v13_resource_link_id", sa.Unicode(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("assignment", "lti_v13_resource_link_id")


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


Auto Generated from: https://github.com/hypothesis/lms/pull/6615


More context and testing instructions over: https://github.com/hypothesis/lms/pull/6616



## Testing migration


```
tox -e dev --run-command 'alembic upgrade head'
dev run-test-pre: PYTHONHASHSEED='1135265335'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 9e79650bed37 -> 481968561169, Assignment v13 ID.
```