### PR TITLE
Store LTI1.3 assignment ID explicitly in the DB

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -163,6 +163,11 @@ class AssignmentService:
                 )
             )
 
+        # Set the value for the v13 id for this assignment.
+        assignment.lti_v13_resource_link_id = request.lti_params.v13.get(
+            "https://purl.imsglobal.org/spec/lti/claim/resource_link", {}
+        ).get("id")
+
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -146,6 +146,14 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
 
 @pytest.fixture
+def lti_v13_pyramid_request(pyramid_request, lti_v13_params, lti_v11_params):
+    pyramid_request.lti_jwt = "JWT"
+    pyramid_request.lti_params = LTIParams(v11=lti_v11_params, v13=lti_v13_params)
+
+    return pyramid_request
+
+
+@pytest.fixture
 def product(pyramid_request):
     return pyramid_request.product
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -128,6 +128,17 @@ class TestAssignmentService:
         )
         assert assignment.is_gradable == misc_plugin.is_assignment_gradable.return_value
         assert assignment.course_id == course.id
+        assert (
+            assignment.lti_v13_resource_link_id
+            == pyramid_request.lti_params.v13.get("")
+        )
+
+    def test_get_assignment_for_launch_set_v13_context_id(
+        self, lti_v13_pyramid_request, svc, course
+    ):
+        assignment = svc.get_assignment_for_launch(lti_v13_pyramid_request, course)
+
+        assert assignment.lti_v13_resource_link_id == "RESOURCE_LINK_ID"
 
     def test_get_assignment_returns_None_with_when_no_document(
         self, pyramid_request, svc, misc_plugin, course


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185



To talk to the Name and Roles LTI API we use the service URL sent in LTI1.3 courses.

However to filter that by assignment we need to use the LTI1.3 assignment ID on that same course URL. 

The ID is sent in all launches but if present, we prefer the LTI1.1 (for backwards compatibility).

With this PR we now store explicitly the LTI1.3 ID to later be use the call the LTI API.


### Testing

- Launch a LTI1.1 assigment: https://hypothesis.instructure.com/courses/125/assignments/873

Nothing changes

- Launch a LTI1.3 assignment: https://hypothesis.instructure.com/courses/319/assignments/3308


The LTI1.3 is stored in the DB


- Check the values in the DB:

```
docker compose exec postgres psql -U postgres -c "select  resource_link_id, lti_v13_resource_link_id from assignment;"                                                                                                                                                                                                                                   
             resource_link_id             |       lti_v13_resource_link_id       
------------------------------------------+--------------------------------------
 f330509e8ee8e465a55c4c88a4fcc9ef1ee992bd |  c2e8a1acbf6534de1db7d9dc65f034f69e87735c | acf313e2-e654-47c5-8a2f-2b77becc47bc(2 rows)
```