### PR TITLE
Add UI components to configure assignments auto-grading

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AutoGradingConfigurator.tsx
+++ b/lms/static/scripts/frontend_apps/components/AutoGradingConfigurator.tsx
@@ -1,0 +1,215 @@
+import {
+  Checkbox,
+  CheckboxCheckedFilledIcon,
+  Input,
+  RadioGroup,
+} from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useId } from 'preact/hooks';
+
+export type GradingType = 'all_or_nothing' | 'scaled';
+
+export type AutoGradingConfig = {
+  /** Whether auto grading is enabled for the assignment or not */
+  enabled?: boolean;
+
+  /**
+   * - all_or_nothing: students need to meet a minimum value, making them get
+   *                   either 0% or 100%
+   * - scaled: students may get a proportional grade based on the amount of
+   *           annotations. If requirement is 4, and they created 3, they'll
+   *           get a 75%
+   */
+  gradingType: GradingType;
+
+  /**
+   * - cumulative: both annotations and replies will be counted together for
+   *               the grade calculation
+   * - separate: students will have different annotation and reply goals.
+   */
+  activityCalculation: 'cumulative' | 'separate';
+
+  /**
+   * Required number of annotations if activityCalculation is 'separate' or
+   * combined number of annotations and replies otherwise.
+   */
+  requiredAnnotations: number;
+
+  /**
+   * Required number of replies if activityCalculation is 'separate'
+   */
+  requiredReplies?: number;
+};
+
+type AnnotationsGoalInputProps = {
+  children?: ComponentChildren;
+  gradingType: GradingType;
+  value: number;
+  onChange: (newValue: number) => void;
+
+  /** Minimum required value for the input. Defaults to 1 */
+  min?: number;
+};
+
+/**
+ * Controls containing a number input to set the amount of required annotations
+ * or replies
+ */
+function AnnotationsGoalInput({
+  children,
+  gradingType,
+  value,
+  onChange,
+  min = 1,
+}: AnnotationsGoalInputProps) {
+  const inputId = useId();
+
+  return (
+    <div className="flex gap-2 items-center">
+      <label
+        className="grow flex justify-between items-center"
+        htmlFor={inputId}
+      >
+        {children}
+        <span className="uppercase font-semibold">
+          {gradingType === 'all_or_nothing' ? 'Minimum' : 'Goal'}
+        </span>
+      </label>
+      <Input
+        id={inputId}
+        classes="max-w-14"
+        type="number"
+        required
+        min={min}
+        step={1}
+        value={value}
+        onChange={e => onChange(Number((e.target as HTMLInputElement).value))}
+      />
+    </div>
+  );
+}
+
+export type AutoGradingConfiguratorProps = {
+  config: AutoGradingConfig;
+  onChange: (newConfig: AutoGradingConfig) => void;
+};
+
+/**
+ * Allows instructors to enable auto grading for an assignment, and provide the
+ * configuration to determine how to calculate each student's grade.
+ */
+export default function AutoGradingConfigurator({
+  config,
+  onChange,
+}: AutoGradingConfiguratorProps) {
+  const {
+    enabled = false,
+    gradingType,
+    activityCalculation,
+    requiredAnnotations,
+    requiredReplies = 0,
+  } = config;
+  const updateConfig = useCallback(
+    (newConfig: Partial<AutoGradingConfig>) =>
+      onChange({ ...config, ...newConfig }),
+    [config, onChange],
+  );
+
+  const gradingTypeId = useId();
+  const activityCalculationId = useId();
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Checkbox
+        checked={enabled}
+        checkedIcon={CheckboxCheckedFilledIcon}
+        onChange={e =>
+          updateConfig({
+            enabled: (e.target as HTMLInputElement).checked,
+          })
+        }
+      >
+        Enable automatic participation grading
+      </Checkbox>
+      {enabled && (
+        <>
+          <div>
+            <h3 id={gradingTypeId} className="font-semibold mb-1">
+              Grading type
+            </h3>
+            <RadioGroup
+              data-testid="grading-type-radio-group"
+              aria-labelledby={gradingTypeId}
+              selected={gradingType}
+              onChange={gradingType => updateConfig({ gradingType })}
+            >
+              <RadioGroup.Radio
+                value="all_or_nothing"
+                subtitle={<small>Must meet minimum requirements.</small>}
+              >
+                All or nothing
+              </RadioGroup.Radio>
+              <RadioGroup.Radio
+                value="scaled"
+                subtitle={<small>Proportional to percent completed.</small>}
+              >
+                Scaled
+              </RadioGroup.Radio>
+            </RadioGroup>
+          </div>
+          <div>
+            <h3 id={activityCalculationId} className="font-semibold mb-1">
+              Activity calculation
+            </h3>
+            <RadioGroup
+              data-testid="activity-calculation-radio-group"
+              aria-labelledby={activityCalculationId}
+              selected={activityCalculation}
+              onChange={activityCalculation =>
+                updateConfig({ activityCalculation })
+              }
+            >
+              <RadioGroup.Radio
+                value="cumulative"
+                subtitle={
+                  <small>Annotations and replies tallied together.</small>
+                }
+              >
+                Calculate cumulative
+              </RadioGroup.Radio>
+              <RadioGroup.Radio
+                value="separate"
+                subtitle={
+                  <small>Annotations and replies tallied separately.</small>
+                }
+              >
+                Calculate separately
+              </RadioGroup.Radio>
+            </RadioGroup>
+          </div>
+          <AnnotationsGoalInput
+            gradingType={gradingType}
+            value={requiredAnnotations}
+            onChange={requiredAnnotations =>
+              updateConfig({ requiredAnnotations })
+            }
+          >
+            {activityCalculation === 'cumulative'
+              ? 'Annotations and replies'
+              : 'Annotations'}
+          </AnnotationsGoalInput>
+          {activityCalculation === 'separate' && (
+            <AnnotationsGoalInput
+              gradingType={gradingType}
+              value={requiredReplies}
+              onChange={requiredReplies => updateConfig({ requiredReplies })}
+              min={0}
+            >
+              Replies
+            </AnnotationsGoalInput>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/GroupConfigSelector.tsx
@@ -1,4 +1,9 @@
-import { Checkbox, Link, Select } from '@hypothesis/frontend-shared';
+import {
+  Checkbox,
+  CheckboxCheckedFilledIcon,
+  Link,
+  Select,
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
@@ -245,6 +250,7 @@ export default function GroupConfigSelector({
     <div className="space-y-3">
       <Checkbox
         checked={useGroupSet}
+        checkedIcon={CheckboxCheckedFilledIcon}
         onInput={(e: Event) =>
           onChangeGroupConfig({
             useGroupSet: (e.target as HTMLInputElement).checked,

--- a/lms/static/scripts/frontend_apps/components/test/AutoGradingConfigurator-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AutoGradingConfigurator-test.js
@@ -1,0 +1,166 @@
+import { checkAccessibility } from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import AutoGradingConfigurator from '../AutoGradingConfigurator';
+
+describe('AutoGradingConfigurator', () => {
+  let fakeAutoGradingConfig;
+  let fakeUpdateAutoGradingConfig;
+
+  beforeEach(() => {
+    fakeAutoGradingConfig = {
+      gradingType: 'all_or_nothing',
+      activityCalculation: 'cumulative',
+      requiredAnnotations: 1,
+    };
+    fakeUpdateAutoGradingConfig = sinon.stub();
+  });
+
+  function createComponent() {
+    return mount(
+      <AutoGradingConfigurator
+        config={fakeAutoGradingConfig}
+        onChange={fakeUpdateAutoGradingConfig}
+      />,
+    );
+  }
+
+  function dispatchOnChange(wrapper, selector, event) {
+    act(() => wrapper.find(selector).props().onChange(event));
+  }
+
+  [true, false].forEach(enabled => {
+    it('renders components if auto grading is enabled', () => {
+      fakeAutoGradingConfig.enabled = enabled;
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.exists('RadioGroup'), enabled);
+    });
+
+    it('updates config when checkbox is changed', () => {
+      const wrapper = createComponent();
+
+      dispatchOnChange(wrapper, 'Checkbox', {
+        target: { checked: enabled },
+      });
+
+      assert.calledWith(fakeUpdateAutoGradingConfig, sinon.match({ enabled }));
+    });
+  });
+
+  context('when auto grading is enabled', () => {
+    beforeEach(() => {
+      fakeAutoGradingConfig.enabled = true;
+    });
+
+    ['cumulative', 'separate'].forEach(activityCalculation => {
+      it('updates config when changing activity calculation', () => {
+        const wrapper = createComponent();
+
+        dispatchOnChange(
+          wrapper,
+          '[data-testid="activity-calculation-radio-group"]',
+          activityCalculation,
+        );
+
+        assert.calledWith(
+          fakeUpdateAutoGradingConfig,
+          sinon.match({ activityCalculation }),
+        );
+      });
+
+      it('renders inputs based on activity calculation value', () => {
+        fakeAutoGradingConfig.activityCalculation = activityCalculation;
+
+        const wrapper = createComponent();
+        const inputs = wrapper.find('AnnotationsGoalInput');
+        const firstInput = inputs.first();
+
+        assert.equal(inputs.length, activityCalculation === 'separate' ? 2 : 1);
+        assert.equal(
+          firstInput.text(),
+          `Annotations${activityCalculation === 'cumulative' ? ' and replies' : ''}Minimum`,
+        );
+      });
+    });
+
+    ['all_or_nothing', 'scaled'].forEach(gradingType => {
+      it('updates config when changing grading type', () => {
+        const wrapper = createComponent();
+
+        dispatchOnChange(
+          wrapper,
+          '[data-testid="grading-type-radio-group"]',
+          gradingType,
+        );
+
+        assert.calledWith(
+          fakeUpdateAutoGradingConfig,
+          sinon.match({ gradingType }),
+        );
+      });
+
+      it('renders different input label depending on grading type value', () => {
+        fakeAutoGradingConfig.gradingType = gradingType;
+
+        const wrapper = createComponent();
+        const input = wrapper.find('AnnotationsGoalInput').first();
+
+        assert.isTrue(
+          input
+            .text()
+            .endsWith(gradingType === 'all_or_nothing' ? 'Minimum' : 'Goal'),
+        );
+      });
+    });
+
+    [
+      {
+        inputIndex: 0,
+        value: '15',
+        expectedConfig: { requiredAnnotations: 15 },
+      },
+      {
+        inputIndex: 1,
+        value: '3',
+        expectedConfig: { requiredReplies: 3 },
+      },
+    ].forEach(({ inputIndex, value, expectedConfig }) => {
+      it('updates config when inputs change', () => {
+        fakeAutoGradingConfig.activityCalculation = 'separate';
+
+        const wrapper = createComponent();
+        const inputs = wrapper.find('AnnotationsGoalInput');
+
+        act(() =>
+          inputs.at(inputIndex).find('Input').props().onChange({
+            target: { value },
+          }),
+        );
+
+        assert.calledWith(
+          fakeUpdateAutoGradingConfig,
+          sinon.match(expectedConfig),
+        );
+      });
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        name: 'disabled',
+        content: () => createComponent(),
+      },
+      {
+        name: 'enabled',
+        content: () => {
+          fakeAutoGradingConfig.enabled = true;
+          return createComponent();
+        },
+      },
+    ]),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -194,8 +194,9 @@ describe('FilePickerApp', () => {
         data: {
           ...deepLinkingAPIData,
           content: { type: 'url', url: 'https://example.com' },
-          group_set: null,
           title: null,
+          group_set: null,
+          auto_grading_config: null,
         },
       });
 
@@ -552,6 +553,18 @@ describe('FilePickerApp', () => {
       clickButton(wrapper, 'edit-content');
       clickButton(wrapper, 'cancel-edit-content');
       assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    [true, false].forEach(autoGradingEnabled => {
+      it('displays auto grading configurator when it is enabled', () => {
+        fakeConfig.filePicker.autoGradingEnabled = autoGradingEnabled;
+        const wrapper = renderFilePicker();
+
+        assert.equal(
+          wrapper.exists('AutoGradingConfigurator'),
+          autoGradingEnabled,
+        );
+      });
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.4.0",
+    "@hypothesis/frontend-shared": "^8.4.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -47,7 +47,7 @@
     "preact": "10.23.2",
     "rollup": "^4.19.1",
     "sass": "^1.76.0",
-    "tailwindcss": "^3.3.3",
+    "tailwindcss": "^3.4.10",
     "tiny-emitter": "^2.1.0",
     "wouter-preact": "^3.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,15 +2169,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "@hypothesis/frontend-shared@npm:8.4.0"
+"@hypothesis/frontend-shared@npm:^8.4.3":
+  version: 8.4.3
+  resolution: "@hypothesis/frontend-shared@npm:8.4.3"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 34d7ae1cab013825be55504c5a9af582b0f20962a358192e66dad19097dfaa6ee052129399dcec9e317c41ba5a2e4b595f33b40b639404ab5f9e997b27cc93e1
+  checksum: 78a7951f8acd9cb8aa67f4b34b175db558d47933d1db93b4bd63e857ef17fa966a55d29ed1668008212150d63d192f84f8a1213c50b5c6a881fee97c71c00bb6
   languageName: node
   linkType: hard
 
@@ -5371,7 +5371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -5381,6 +5381,19 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: 900e4979f4dbc3313840078419245621259f349950411ca2fa445a2f9a1a6d98c3b5e7e0660c5ccd563aa61abe133a21765c6c0dec8e57da1ba71d8000b05ec1
   languageName: node
   linkType: hard
 
@@ -7130,12 +7143,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.18.2":
-  version: 1.18.2
-  resolution: "jiti@npm:1.18.2"
+"jiti@npm:^1.21.0":
+  version: 1.21.6
+  resolution: "jiti@npm:1.21.6"
   bin:
     jiti: bin/jiti.js
-  checksum: 46c41cd82d01c6efdee3fc0ae9b3e86ed37457192d6366f19157d863d64961b07982ab04e9d5879576a1af99cc4d132b0b73b336094f86a5ce9fb1029ec2d29f
+  checksum: 9ea4a70a7bb950794824683ed1c632e2ede26949fbd348e2ba5ec8dc5efa54dc42022d85ae229cadaa60d4b95012e80ea07d625797199b688cc22ab0e8891d32
   languageName: node
   linkType: hard
 
@@ -7437,7 +7450,7 @@ __metadata:
     "@babel/preset-react": ^7.24.7
     "@babel/preset-typescript": ^7.24.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.4.0
+    "@hypothesis/frontend-shared": ^8.4.3
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^26.0.1
@@ -7485,7 +7498,7 @@ __metadata:
     rollup: ^4.19.1
     sass: ^1.76.0
     sinon: ^17.0.1
-    tailwindcss: ^3.3.3
+    tailwindcss: ^3.4.10
     tiny-emitter: ^2.1.0
     typescript: ^5.2.2
     wouter-preact: ^3.3.0
@@ -10199,19 +10212,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "tailwindcss@npm:3.3.3"
+"tailwindcss@npm:^3.4.10":
+  version: 3.4.10
+  resolution: "tailwindcss@npm:3.4.10"
   dependencies:
     "@alloc/quick-lru": ^5.2.0
     arg: ^5.0.2
     chokidar: ^3.5.3
     didyoumean: ^1.2.2
     dlv: ^1.1.3
-    fast-glob: ^3.2.12
+    fast-glob: ^3.3.0
     glob-parent: ^6.0.2
     is-glob: ^4.0.3
-    jiti: ^1.18.2
+    jiti: ^1.21.0
     lilconfig: ^2.1.0
     micromatch: ^4.0.5
     normalize-path: ^3.0.0
@@ -10228,7 +10241,7 @@ __metadata:
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: 0195c7a3ebb0de5e391d2a883d777c78a4749f0c532d204ee8aea9129f2ed8e701d8c0c276aa5f7338d07176a3c2a7682c1d0ab9c8a6c2abe6d9325c2954eb50
+  checksum: aa8db3514ec5110b2dee0bf5b35b84ebedf0c23a0dcafc870a5176bc2bad7d581956e0692ed6d888d602c114d2c54d7aa8fdb7028456880bd28b326078c8ba6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add UI components in assignment configuration so that it is possible to enable auto grading.

The config generated by this UI is currently ignored by the BE. We have aligned the structure, so it should work once https://github.com/hypothesis/lms/pull/6634 is merged, but additional changes may be needed later.

https://github.com/user-attachments/assets/2d39e4f4-ad70-4b65-9779-6e29337bafbe

> [!WARNING]  
> There are some fundamental differences with [the designs](https://www.figma.com/design/ctCnzwkAyYArSNBYEshiCm/Hypothesis---LMS-Assignment-Grading?node-id=496-221&node-type=CANVAS&t=kT7pEfMy0RgzyH2F-0), mostly in font color and font size.
>
> Those are a side effect of the base styles in this page, which I think are mostly there for historical reasons.
> We could decide to change those, but I think it makes sense to do that as a task of its own, and do it consistently in the whole LMS UI, so I'll probably leave it as is for now.
>
> Additionally, we have some constraints in horizontal size that are making some texts to wrap multiple lines. We need to discuss that.

### Considerations

- This PR updates tailwind to ^3.4, because it adds spacing utilities to `max-w-*`, which are used here: https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.0
- This UI has been tested with Canvas only, and may not behave as expected when editing assignments in other LMSes.
    We have decided this is going to be our initial priority, and I will test other contexts later, and adjust logic where needed.

### Testing steps

1. Check out this branch.
2. Verify the new UI is not displayed when configuring an assignment in Canvas.
3. Enable the feature by going to http://localhost:8001/admin/instances/8/settings (for the instance you are working with)
    ![image](https://github.com/user-attachments/assets/3e5188df-1636-4ed4-a61f-59459f883cb8)
4. Configure an assignment in Canvas again. It should now display the new UI controls, as displayed in the video recording above.