### PR TITLE
Fetch assignment rosters

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -196,6 +196,7 @@ class Course(Grouping):
     lms_course: Mapped[LMSCourse] = sa.orm.relationship(
         LMSCourse,
         primaryjoin="Grouping.authority_provided_id == foreign(LMSCourse.h_authority_provided_id)",
+        backref=sa.orm.backref("course"),
     )
 
     def set_group_sets(self, group_sets: list[dict]):

--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -4,22 +4,34 @@ from datetime import datetime, timedelta
 
 from sqlalchemy import exists, select
 
-from lms.models import Course, CourseRoster, Event, LMSCourse
+from lms.models import (
+    Assignment,
+    AssignmentRoster,
+    Course,
+    CourseRoster,
+    Event,
+    LMSCourse,
+)
 from lms.services.roster import RosterService
 from lms.tasks.celery import app
 
-COURSE_LAUNCHED_WINDOW = timedelta(hours=24)
-"""How recent we need to have seen a launch from a course before we stop fetching rosters for it."""
+LAUNCHED_WINDOW = timedelta(hours=24)
+"""How recent we need to have seen a launch from a course/assignment before we stop fetching rosters for it."""
 
 ROSTER_REFRESH_WINDOW = timedelta(hours=24 * 7)
-"""How frequenly should we fetch roster for the same course"""
+"""How frequenly should we fetch roster for the same course/assignment"""
 
-ROSTER_COURSE_LIMIT = 5
+ROSTER_LIMIT = 5
 """How many roster should we fetch per executing of the schedule task."""
 
 
 @app.task()
 def schedule_fetching_rosters() -> None:
+    schedule_fetching_course_rosters()
+    schedule_fetching_assignment_rosters()
+
+
+def schedule_fetching_course_rosters() -> None:
     """Schedule fetching course rosters based on their last lunches and the most recent roster fetch."""
 
     # We use the python version (and not func.now()) for easier mocking during tests
@@ -38,7 +50,7 @@ def schedule_fetching_rosters() -> None:
         select(Event)
         .join(Course, Event.course_id == Course.id)
         .where(
-            Event.timestamp >= now - COURSE_LAUNCHED_WINDOW,
+            Event.timestamp >= now - LAUNCHED_WINDOW,
             Course.authority_provided_id == LMSCourse.h_authority_provided_id,
         )
     )
@@ -53,11 +65,58 @@ def schedule_fetching_rosters() -> None:
                     no_recent_roster_clause,
                     recent_launches_cluase,
                 )
-                # Schedule only a few roster per call to this method
-                .limit(ROSTER_COURSE_LIMIT)
+                # Schedule only a few rosters per call to this method
+                .limit(ROSTER_LIMIT)
             )
             for lms_course_id in request.db.scalars(query).all():
-                fetch_roster.delay(lms_course_id=lms_course_id)
+                fetch_course_roster.delay(lms_course_id=lms_course_id)
+
+
+def schedule_fetching_assignment_rosters() -> None:
+    """Schedule fetching assignment rosters based on their last lunches and the most recent roster fetch."""
+
+    # We use the python version (and not func.now()) for easier mocking during tests
+    now = datetime.now()
+
+    # Only fetch roster for assignments that don't have recent roster information
+    no_recent_roster_clause = ~exists(
+        select(AssignmentRoster).where(
+            AssignmentRoster.assignment_id == Assignment.id,
+            AssignmentRoster.updated >= now - ROSTER_REFRESH_WINDOW,
+        )
+    )
+
+    # Only fetch rosters for assignments that have been recently launched
+    recent_launches_cluase = exists(
+        select(Event)
+        .join(Assignment, Event.assignment_id == Assignment.id)
+        .where(
+            Event.timestamp >= now - LAUNCHED_WINDOW,
+        )
+    )
+
+    with app.request_context() as request:
+        with request.tm:
+            query = (
+                select(Assignment.id)
+                .join(Course)
+                .join(
+                    LMSCourse,
+                    LMSCourse.h_authority_provided_id == Course.authority_provided_id,
+                )
+                .where(
+                    # Assignments that belongs to courses for which we have a LTIA membership service URL
+                    LMSCourse.lti_context_memberships_url.is_not(None),
+                    # Assignments for which we have stored the LTI1.3 ID
+                    Assignment.lti_v13_resource_link_id.is_not(None),
+                    no_recent_roster_clause,
+                    recent_launches_cluase,
+                )
+                # Schedule only a few roster per call to this method
+                .limit(ROSTER_LIMIT)
+            )
+            for assignment_id in request.db.scalars(query).all():
+                fetch_assignment_roster.delay(assignment_id=assignment_id)
 
 
 @app.task(
@@ -67,10 +126,26 @@ def schedule_fetching_rosters() -> None:
     retry_backoff=3600,
     retry_backoff_max=7200,
 )
-def fetch_roster(*, lms_course_id) -> None:
+def fetch_course_roster(*, lms_course_id) -> None:
     """Fetch the roster for one course."""
     with app.request_context() as request:
         roster_service = request.find_service(RosterService)
         with request.tm:
             lms_course = request.db.get(LMSCourse, lms_course_id)
-            roster_service.fetch_roster(lms_course)
+            roster_service.fetch_course_roster(lms_course)
+
+
+@app.task(
+    acks_late=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    retry_backoff=3600,
+    retry_backoff_max=7200,
+)
+def fetch_assignment_roster(*, assignment_id) -> None:
+    """Fetch the roster for one course."""
+    with app.request_context() as request:
+        roster_service = request.find_service(RosterService)
+        with request.tm:
+            assignment = request.db.get(Assignment, assignment_id)
+            roster_service.fetch_assignment_roster(assignment)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -18,7 +18,6 @@ from tests.factories.attributes import (
     TOOL_CONSUMER_INSTANCE_GUID,
     USER_ID,
 )
-from tests.factories.course_roster import CourseRoster
 from tests.factories.dashboard_admin import DashboardAdmin
 from tests.factories.event import Event
 from tests.factories.file import File
@@ -37,6 +36,7 @@ from tests.factories.lti_user import LTIUser
 from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.organization import Organization
 from tests.factories.organization_usage import OrganizationUsageReport
+from tests.factories.roster import AssignmentRoster, CourseRoster
 from tests.factories.rsa_key import RSAKey
 from tests.factories.task_done import TaskDone
 from tests.factories.user import User

--- a/tests/factories/roster.py
+++ b/tests/factories/roster.py
@@ -4,3 +4,6 @@ from factory.alchemy import SQLAlchemyModelFactory
 from lms import models
 
 CourseRoster = make_factory(models.CourseRoster, FACTORY_CLASS=SQLAlchemyModelFactory)
+AssignmentRoster = make_factory(
+    models.AssignmentRoster, FACTORY_CLASS=SQLAlchemyModelFactory
+)

--- a/tests/unit/lms/tasks/roster_test.py
+++ b/tests/unit/lms/tasks/roster_test.py
@@ -4,34 +4,73 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from lms.tasks.roster import fetch_roster, schedule_fetching_rosters
+from lms.tasks.roster import (
+    fetch_assignment_roster,
+    fetch_course_roster,
+    schedule_fetching_assignment_rosters,
+    schedule_fetching_course_rosters,
+    schedule_fetching_rosters,
+)
 from tests import factories
 
 
-class TestFetchRoster:
-    def test_it(self, roster_service, db_session):
+class TestRosterTasks:
+    def test_fetch_course_roster(self, roster_service, db_session):
         lms_course = factories.LMSCourse()
         db_session.flush()
 
-        fetch_roster(lms_course_id=lms_course.id)
+        fetch_course_roster(lms_course_id=lms_course.id)
 
-        roster_service.fetch_roster.assert_called_once_with(lms_course)
+        roster_service.fetch_course_roster.assert_called_once_with(lms_course)
 
+    def test_fetch_assignment_roster(self, roster_service, db_session):
+        assignment = factories.Assignment()
+        db_session.flush()
 
-@freeze_time("2024-08-28")
-class TestScheduleFetchingRosters:
+        fetch_assignment_roster(assignment_id=assignment.id)
+
+        roster_service.fetch_assignment_roster.assert_called_once_with(assignment)
+
+    def test_schedule_fetching_rosters(
+        self, schedule_fetching_assignment_rosters, schedule_fetching_course_rosters
+    ):
+        schedule_fetching_rosters()
+
+        schedule_fetching_course_rosters.assert_called_once_with()
+        schedule_fetching_assignment_rosters.assert_called_once_with()
+
+    @freeze_time("2024-08-28")
     @pytest.mark.usefixtures(
         "lms_course_with_no_launch",
         "lms_course_with_no_service_url",
         "lms_course_with_launch_and_recent_roster",
     )
-    def test_it(self, lms_course_with_recent_launch, db_session, fetch_roster):
+    def test_schedule_fetching_course_rosters(
+        self, lms_course_with_recent_launch, db_session, fetch_course_roster
+    ):
         db_session.flush()
 
-        schedule_fetching_rosters()
+        schedule_fetching_course_rosters()
 
-        fetch_roster.delay.assert_called_once_with(
+        fetch_course_roster.delay.assert_called_once_with(
             lms_course_id=lms_course_with_recent_launch.id
+        )
+
+    @freeze_time("2024-08-28")
+    @pytest.mark.usefixtures(
+        "assignment_with_no_launch",
+        "assignment_with_no_lti_v13_id",
+        "assignment_with_launch_and_recent_roster",
+    )
+    def test_schedule_fetching_assignment_rosters(
+        self, assignment_with_recent_launch, db_session, fetch_assignment_roster
+    ):
+        db_session.flush()
+
+        schedule_fetching_assignment_rosters()
+
+        fetch_assignment_roster.delay.assert_called_once_with(
+            assignment_id=assignment_with_recent_launch.id
         )
 
     @pytest.fixture
@@ -39,8 +78,18 @@ class TestScheduleFetchingRosters:
         return factories.LMSCourse()
 
     @pytest.fixture
+    def assignment_with_no_lti_v13_id(self):
+        return factories.LMSCourse()
+
+    @pytest.fixture
     def lms_course_with_no_launch(self):
         return factories.LMSCourse(lti_context_memberships_url="URL")
+
+    @pytest.fixture
+    def assignment_with_no_launch(self):
+        return factories.Assignment(
+            lti_v13_resource_link_id="ID", course=factories.Course()
+        )
 
     @pytest.fixture
     def lms_course_with_recent_launch(self):
@@ -53,7 +102,19 @@ class TestScheduleFetchingRosters:
         return factories.LMSCourse(
             lti_context_memberships_url="URL",
             h_authority_provided_id=course.authority_provided_id,
+            course=course,
         )
+
+    @pytest.fixture
+    def assignment_with_recent_launch(self, lms_course_with_recent_launch):
+        assignment = factories.Assignment(
+            lti_v13_resource_link_id="ID", course=lms_course_with_recent_launch.course
+        )
+        factories.Event(
+            assignment=assignment,
+            timestamp=datetime(2024, 8, 28),
+        )
+        return assignment
 
     @pytest.fixture
     def lms_course_with_launch_and_recent_roster(self):
@@ -74,8 +135,39 @@ class TestScheduleFetchingRosters:
         return lms_course
 
     @pytest.fixture
-    def fetch_roster(self, patch):
-        return patch("lms.tasks.roster.fetch_roster")
+    def assignment_with_launch_and_recent_roster(self, lms_course_with_recent_launch):
+        assignment = factories.Assignment(
+            lti_v13_resource_link_id="ID", course=lms_course_with_recent_launch.course
+        )
+        factories.Event(
+            assignment=assignment,
+            timestamp=datetime(2024, 8, 28),
+        )
+        factories.AssignmentRoster(
+            assignment=assignment,
+            lms_user=factories.LMSUser(),
+            lti_role=factories.LTIRole(),
+            active=True,
+            updated=datetime(2024, 8, 25),
+        )
+
+        return assignment
+
+    @pytest.fixture
+    def fetch_course_roster(self, patch):
+        return patch("lms.tasks.roster.fetch_course_roster")
+
+    @pytest.fixture
+    def fetch_assignment_roster(self, patch):
+        return patch("lms.tasks.roster.fetch_assignment_roster")
+
+    @pytest.fixture
+    def schedule_fetching_assignment_rosters(self, patch):
+        return patch("lms.tasks.roster.schedule_fetching_assignment_rosters")
+
+    @pytest.fixture
+    def schedule_fetching_course_rosters(self, patch):
+        return patch("lms.tasks.roster.schedule_fetching_course_rosters")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6185


Fetch assignment roster as well as course ones.
 

In some LMS (ie Canvas "assignment to" feature) assignment rosters will be different to courses's.

We'll start fetching both at the same frequency to compare the data in the wild.

I have written a version of this train of PRs (migration/model and this one) using just one table "Roster", that have both FK to course  and assignment.

That resulted in a more complicated table (with constraint based on one column being null, checking uniqueness the others) and the code look pretty much the same as in this PR, no duplication was avoided as while using the same table, queries to it were different.


### Testing


- Launch https://hypothesis.instructure.com/courses/319/assignments/3308
- Truncate any local rosters:

```
docker compose exec postgres psql -U postgres -c "truncate course_roster, assignment_roster cascade;"
```

- Schedule the main task, in make shell:

```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```



- The task should run the task and schedule a course and assignment roster fetch:


```
worker (stderr)      | [2024-09-03 11:44:55,908: INFO/MainProcess] Task lms.tasks.roster.schedule_fetching_rosters[74343979-5d64-4287-a282-bed8fdbdb88e] received
worker (stderr)      | [2024-09-03 11:44:56,059: INFO/MainProcess] Task lms.tasks.roster.fetch_course_roster[e8bfb65f-51e6-4135-9fef-f8ecc61c3708] received
worker (stderr)      | [2024-09-03 11:44:56,073: INFO/ForkPoolWorker-16] lms.tasks.roster.schedule_fetching_rosters[74343979-5d64-4287-a282-bed8fdbdb88e] Task lms.tasks.roster.schedule_fetching_rosters[74343979-5d64-4287-a282-bed8fdbdb88e] succeeded in 0.16293631700682454s: None
worker (stderr)      | [2024-09-03 11:44:56,074: INFO/MainProcess] Task lms.tasks.roster.fetch_assignment_roster[dc36e99c-6fa0-44bf-8348-0dea6d4a095a] received
worker (stderr)      | [2024-09-03 11:44:58,254: INFO/ForkPoolWorker-16] lms.tasks.roster.fetch_assignment_roster[dc36e99c-6fa0-44bf-8348-0dea6d4a095a] Task lms.tasks.roster.fetch_assignment_roster[dc36e99c-6fa0-44bf-8348-0dea6d4a095a] succeeded in 2.1793353560060496s: None
worker (stderr)      | [2024-09-03 11:44:59,766: INFO/ForkPoolWorker-1] lms.tasks.roster.fetch_course_roster[e8bfb65f-51e6-4135-9fef-f8ecc61c3708] Task lms.tasks.roster.fetch_course_roster[e8bfb65f-51e6-4135-9fef-f8ecc61c3708] succeeded in 3.7037895879911957s: None
```


- A query like 


```select distinct lms_user_id from course_roster except select distinct lms_user_id from assignment_roster;```

will (if those are the only rosters in your local DB) return the users that are part of the course but not the assignment.




