### PR TITLE
Pin GHA's upload-artifact to 3.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.${{ matrix.python-version }}
       - name: Upload coverage file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverage
           path: .coverage.*


### PR DESCRIPTION
As a temporary workaround for the changes newer versions (>3.2.0) around not uploading hidden files