### PR TITLE
Keep record of the grading service URL for each assignment

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -168,6 +168,11 @@ class AssignmentService:
             "https://purl.imsglobal.org/spec/lti/claim/resource_link", {}
         ).get("id")
 
+        # Keep record of the grading service URL relevant for this assignment if available
+        assignment.lis_outcome_service_url = request.lti_params.get(
+            "lis_outcome_service_url"
+        )
+
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,7 @@ def lti_v11_params():
         "lis_person_name_family": "TEST_FAMILY_NAME",
         "lis_person_name_full": "TEST_FULL_NAME",
         "lis_person_contact_email_primary": "EMAIL",
+        "lis_outcome_service_url": "GRADING URL",
         "lti_message_type": "basic-lti-launch-request",
         "context_id": "DUMMY-CONTEXT-ID",
         "context_title": "A context title",

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -128,10 +128,7 @@ class TestAssignmentService:
         )
         assert assignment.is_gradable == misc_plugin.is_assignment_gradable.return_value
         assert assignment.course_id == course.id
-        assert (
-            assignment.lti_v13_resource_link_id
-            == pyramid_request.lti_params.v13.get("")
-        )
+        assert assignment.lis_outcome_service_url == "GRADING URL"
 
     def test_get_assignment_for_launch_set_v13_context_id(
         self, lti_v13_pyramid_request, svc, course


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647



To sync grades outside the context of a launch we have to fetch the URL on the launches to be able to use it later.

It would be possible to fetch this URL from the rostering information but for this we'll get on each launch as it would become handy for our regular grading operations (ie the grading bar).


## Testing

- Launch a LTI1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/7296
- Launch a LTI1.1 assignment https://hypothesis.instructure.com/courses/125/assignments/873
- Check the data in the sql

```docker compose exec postgres psql -U postgres -c "select title, lis_outcome_service_url from assignment where lis_outcome_service_url is not null;"```


```
                  title                   |                        lis_outcome_service_url                         
------------------------------------------+------------------------------------------------------------------------
 localhost - Autograding                  | https://hypothesis.instructure.com/api/lti/courses/319/line_items/2456
 localhost (make devdata) HTML Assignment | https://hypothesis.instructure.com/api/lti/v1/tools/416/grade_passback
```