### PR TITLE
Use the LTI1.1 assignment ID after a failure to fetch a roster

### DIFF
--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -145,7 +145,7 @@ def fetch_course_roster(*, lms_course_id) -> None:
 def fetch_assignment_roster(*, assignment_id) -> None:
     """Fetch the roster for one course."""
     with app.request_context() as request:
-        roster_service = request.find_service(RosterService)
+        roster_service: RosterService = request.find_service(RosterService)
         with request.tm:
             assignment = request.db.get(Assignment, assignment_id)
             roster_service.fetch_assignment_roster(assignment)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ disable = [
     # Mostly false positives, better served by mypy
     "not-callable",
     "no-member",
+    "unsupported-membership-test",
 
 ]
 


### PR DESCRIPTION
We have seen some issues in production where the assignment roster fetch fails with a cryptic error from Canvas.

We have not been able to reproduce this situation locally.

As we have two IDs for the same assignment lets try the LTI1.1 one.

We have tested the other following scenarios:

- LTI1.3 assignment. Use the LTI1.3 id works.

- Upgrade from LTI1.1 LTI1.3 assignment. Using the LTI1.1 ID fails while the 1.3 one works.



## Testing 

I don't know how to reproduce this bug (and I don't know either if this will fix it). We can however test if the pieces here are wired together to catch errors by a message on the response

- Let's simulate the opposite scenario, we'll send the LTI1.1 ID which will fail, catch that particular error message, and try again with the right ID


Apply this diff:

```diff
diff --git a/lms/services/roster.py b/lms/services/roster.pyindex 0afd3b7c2..3e0d774b2 100644--- a/lms/services/roster.py+++ b/lms/services/roster.py@@ -116,14 +116,14 @@ class RosterService:             roster = self._lti_names_roles_service.get_context_memberships(
                 lti_registration,                 lms_course.lti_context_memberships_url,
-                resource_link_id=assignment.lti_v13_resource_link_id,
+                resource_link_id=assignment.resource_link_id,
             )
         except ExternalRequestError as err:
             if (                 err.response_body
                 and (                     # Error message from Canvas
-                    "Requested ResourceLink bound to unexpected external tool"
+                    "Invalid"
                     in err.response_body
                 )
                 # In cases for which we have different assignment IDs
@@ -135,7 +135,7 @@ class RosterService:
                 roster = self._lti_names_roles_service.get_context_memberships(
                     lti_registration,
                     lms_course.lti_context_memberships_url,
-                    resource_link_id=assignment.resource_link_id,
+                    resource_link_id=assignment.lti_v13_resource_link_id,
                 )
             else:
                 raise
```



- In make shell, sync rosters


```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```

- As expected we'll try a second time to fetch the assignment roster.

```
worker (stderr)      | [2024-09-04 14:19:56,350: INFO/MainProcess] Task lms.tasks.roster.fetch_assignment_roster[7f7eb7a6-a919-4c29-ac5c-1f990e765dec] received
worker (stderr)      | [2024-09-04 14:20:00,031: INFO/ForkPoolWorker-16] lms.tasks.roster.fetch_assignment_roster[aad7d2bc-5d33-4ce1-954b-dd574ae0b86f] Try to fetch roster with the LTI1.1 identifier
worker (stderr)      | [2024-09-04 14:20:00,419: INFO/ForkPoolWorker-16] lms.tasks.roster.fetch_assignment_roster[aad7d2bc-5d33-4ce1-954b-dd574ae0b86f] Task lms.tasks.roster.fetch_assignment_roster[aad7d2bc-5d33-4ce1-954b-dd574ae0b86f] succeeded in 4.0682554739760235s: None
```