### PR TITLE
Explicitly commit schema deletion on init_db.delete

### DIFF
--- a/lms/scripts/init_db.py
+++ b/lms/scripts/init_db.py
@@ -55,6 +55,7 @@ def delete(engine: Engine) -> None:
         # For example, this will delete tables created by migrations in other branches, not only the ones SQLAlchemy know about in the current code base.
         connection.execute(text("DROP SCHEMA PUBLIC CASCADE;"))
         connection.execute(text("CREATE SCHEMA PUBLIC;"))
+        connection.execute(text("COMMIT;"))
 
     try:
         from lms.db import post_delete  # noqa: PLC0415


### PR DESCRIPTION
engine.connect() used in delete() and SQLA's create_all in create() might execute in separate transactions.

Explicitly commit the schema deletion in the first step so it's visible to the rest of the init_db script.

Follow up to https://github.com/hypothesis/lms/pull/6578