### PR TITLE
Roster service methods to retrieve data from the DB

### DIFF
--- a/lms/templates/admin/assignment/show.html.jinja2
+++ b/lms/templates/admin/assignment/show.html.jinja2
@@ -19,5 +19,14 @@
       <legend class="label has-text-centered">Course</legend>
       {{ macros.course_preview(request, assignment.course) }}
     </fieldset>
+
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Roster</legend>
+        {% if roster %}
+            {{ macros.roster_table(request, roster) }}
+        {% else %}
+            <legend class="label has-text-centered">No roster information</legend>
+        {% endif %}
+    </fieldset>
 </div>
 {% endblock %}

--- a/lms/templates/admin/course/show.html.jinja2
+++ b/lms/templates/admin/course/show.html.jinja2
@@ -32,7 +32,16 @@
         {% else %}
             <legend class="label has-text-centered">No assignments</legend>
         {% endif %}
-
     </fieldset>
+
+    <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Roster</legend>
+        {% if roster %}
+            {{ macros.roster_table(request, roster) }}
+        {% else %}
+            <legend class="label has-text-centered">No roster information</legend>
+        {% endif %}
+    </fieldset>
+
 </div>
 {% endblock %}

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -108,16 +108,20 @@
             <table class="table is-fullwidth">
                 <thead>
                     <tr>
+                        {% if route %}
                         <th></th>
+                        {% endif %}
                         {% for field in fields %}<th>{{ field.label }}</th>{% endfor %}
                     </tr>
                 </thead>
                 <tbody>
                     {% for object in objects %}
                         <tr>
+                            {% if route %}
                             <td>
                                 <a class="button" href="{{ request.route_url(route, id_=object.id) }}">View</a>
                             </td>
+                            {% endif %}
                             {% for field in fields %}<td>{{ auto_format(object[field.name], html=html) }}</td>{% endfor %}
                         </tr>
                     {% endfor %}
@@ -278,3 +282,12 @@
         {"label": "Context ID", "name": "lms_id"},
     ]) }}
 {% endmacro %}
+{% macro roster_table(request, roster_users) %}
+    {{ object_list_table(request, None, roster_users,
+        fields=[
+        {"label": "Name", "name": "display_name"},
+        {"label": "H Userid", "name": "h_userid"},
+        {"label": "LTI user id", "name": "lti_user_id"},
+    ]) }}
+{% endmacro %}
+

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -6,12 +6,14 @@ from pyramid.view import view_config, view_defaults
 from lms.events import AuditTrailEvent, ModelChange
 from lms.models import Assignment, EventType
 from lms.security import Permissions
+from lms.services import RosterService
 
 
 @view_defaults(request_method="GET", permission=Permissions.ADMIN)
 class AdminAssignmentViews:
     def __init__(self, request) -> None:
         self.request = request
+        self.roster_service: RosterService = request.find_service(RosterService)
         self.assignment_service = request.find_service(name="assignment")
 
     @view_config(
@@ -22,9 +24,8 @@ class AdminAssignmentViews:
     )
     def show(self):
         assignment = self._get_or_404()
-        return {
-            "assignment": assignment,
-        }
+        roster = self.roster_service.get_assignment_roster(assignment)
+        return {"assignment": assignment, "roster": roster}
 
     @view_config(
         route_name="admin.assignment.dashboard",

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -8,7 +8,7 @@ from webargs import fields
 from lms.events import AuditTrailEvent, ModelChange
 from lms.models import Course, EventType
 from lms.security import Permissions
-from lms.services import InvalidPublicId, OrganizationService
+from lms.services import InvalidPublicId, OrganizationService, RosterService
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
 from lms.views.admin._schemas import EmptyStringInt
@@ -33,6 +33,7 @@ class AdminCourseViews:
         self.organization_service: OrganizationService = request.find_service(
             OrganizationService
         )
+        self.roster_service: RosterService = request.find_service(RosterService)
 
     @view_config(
         route_name="admin.courses",
@@ -52,8 +53,9 @@ class AdminCourseViews:
     def show(self):
         course_id = self.request.matchdict["id_"]
         course = self._get_course_or_404(course_id)
+        roster = self.roster_service.get_course_roster(course.lms_course)
 
-        return {"course": course}
+        return {"course": course, "roster": roster}
 
     @view_config(
         route_name="admin.courses.dashboard",

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -11,6 +11,64 @@ from tests import factories
 
 
 class TestRosterService:
+    @pytest.mark.parametrize("with_role_scope", [True, False])
+    @pytest.mark.parametrize("with_role_type", [True, False])
+    def test_get_course_roster(
+        self, svc, lms_course, db_session, with_role_scope, with_role_type
+    ):
+        lms_user = factories.LMSUser()
+        inactive_lms_user = factories.LMSUser()
+        lti_role = factories.LTIRole()
+
+        factories.CourseRoster(
+            lms_user=lms_user,
+            lms_course=lms_course,
+            lti_role=lti_role,
+            active=True,
+        )
+        factories.CourseRoster(
+            lms_user=inactive_lms_user,
+            lms_course=lms_course,
+            lti_role=lti_role,
+            active=False,
+        )
+        db_session.flush()
+
+        assert svc.get_course_roster(
+            lms_course,
+            role_scope=lti_role.scope if with_role_scope else None,
+            role_type=lti_role.type if with_role_type else None,
+        ) == [lms_user]
+
+    @pytest.mark.parametrize("with_role_scope", [True, False])
+    @pytest.mark.parametrize("with_role_type", [True, False])
+    def test_get_assignment_roster(
+        self, svc, assignment, db_session, with_role_type, with_role_scope
+    ):
+        lms_user = factories.LMSUser()
+        inactive_lms_user = factories.LMSUser()
+        lti_role = factories.LTIRole()
+
+        factories.AssignmentRoster(
+            lms_user=lms_user,
+            assignment=assignment,
+            lti_role=lti_role,
+            active=True,
+        )
+        factories.AssignmentRoster(
+            lms_user=inactive_lms_user,
+            assignment=assignment,
+            lti_role=lti_role,
+            active=False,
+        )
+        db_session.flush()
+
+        assert svc.get_assignment_roster(
+            assignment,
+            role_scope=lti_role.scope if with_role_scope else None,
+            role_type=lti_role.type if with_role_type else None,
+        ) == [lms_user]
+
     def test_fetch_course_roster(
         self,
         svc,

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -9,16 +9,21 @@ from lms.views.admin.assignment import AdminAssignmentViews
 from tests import factories
 
 
+@pytest.mark.usefixtures("roster_service")
 class TestAdminAssignmentViews:
-    def test_show(self, pyramid_request, assignment_service, views):
+    def test_show(self, pyramid_request, assignment_service, views, roster_service):
         pyramid_request.matchdict["id_"] = sentinel.id
 
         response = views.show()
 
         assignment_service.get_by_id.assert_called_once_with(id_=sentinel.id)
+        roster_service.get_assignment_roster.assert_called_once_with(
+            assignment_service.get_by_id.return_value
+        )
 
         assert response == {
             "assignment": assignment_service.get_by_id.return_value,
+            "roster": roster_service.get_assignment_roster.return_value,
         }
 
     def test_show_not_found(self, pyramid_request, assignment_service, views):

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -10,17 +10,21 @@ from lms.views.admin.course import AdminCourseViews
 from tests import factories
 
 
-@pytest.mark.usefixtures("course_service", "organization_service")
+@pytest.mark.usefixtures("course_service", "organization_service", "roster_service")
 class TestAdminCourseViews:
-    def test_show(self, pyramid_request, course_service, views):
+    def test_show(self, pyramid_request, course_service, views, roster_service):
         pyramid_request.matchdict["id_"] = sentinel.id_
 
         response = views.show()
 
         course_service.get_by_id.assert_called_once_with(id_=sentinel.id_)
+        roster_service.get_course_roster.assert_called_once_with(
+            course_service.get_by_id.return_value.lms_course
+        )
 
         assert response == {
             "course": course_service.get_by_id.return_value,
+            "roster": roster_service.get_course_roster.return_value,
         }
 
     def test_show_not_found(self, pyramid_request, course_service, views):


### PR DESCRIPTION
We are going to need to start using the roster information for the auto grading feature.

To try to keep this PR size manageable we only introduce two simple methods here that just query the data.

As a bonus, mostly because it's pretty straightforward and because it simplifies testing, we also expose this information in the admin pages.


## Testing 

- Go to the admin pages, find the canvas LTI1.3 course
- Check the roster data at the course and assignment levels. 

