### PR TITLE
Start a new celery worker that just listens to the email-digest queue

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -31,6 +31,14 @@ stderr_events_enabled=true
 stopsignal=KILL
 stopasgroup=true
 
+[program:worker-email-digests]
+command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO -Q email_digests -n celery-email_digests-@%%h
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal=KILL
+stopasgroup=true
+
+
 [program:assets]
 command=node_modules/.bin/gulp watch
 stdout_events_enabled=true

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -18,6 +18,13 @@ stderr_events_enabled=true
 stdout_logfile=NONE
 stderr_logfile=NONE
 
+[program:worker-email-digests]
+command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO -Q email_digests -n celery-email_digests-@%%h
+stdout_events_enabled=true
+stderr_events_enabled=true
+stdout_logfile=NONE
+stderr_logfile=NONE
+
 [eventlistener:logger]
 command=bin/logger
 buffer_size=1024


### PR DESCRIPTION
Email digest creates many tasks early in the morning which prevents other tasks from being executed.

We plan to move email digest tasks to its own queue, first we'll start listening to jobs in the queue and in a follow up PR we'll configure email digest task to use this queue to facilitate that transition.


See: https://github.com/hypothesis/lms/pull/6790


## Testing

- Start the server locally with `make dev`

The celery startup message will show twice, once for the previous  "celery" queue:

```
worker               |  -------------- celery@lenovo v5.3.6 (emerald-rush)                                                                                                                    
worker               | --- ***** -----                                                                                                                                                        
worker               | -- ******* ---- Linux-6.8.0-45-generic-x86_64-with-glibc2.35 2024-10-18 11:52:11                                                                                       
worker               | - *** --- * ---                                                                                                                                                        
worker               | - ** ---------- [config]                                                                                                                                               
worker               | - ** ---------- .> app:         lms:0x7e77c8f68880                                                                                                                     
worker               | - ** ---------- .> transport:   amqp://guest:**@localhost:5674//                                                                                                       
worker               | - ** ---------- .> results:     disabled://                                                                                                                            
worker               | - *** --- * --- .> concurrency: 16 (prefork)                                                                                                                           
worker               | -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)                                                                                        
worker               | --- ***** -----                                                                                                                                                        
worker               |  -------------- [queues]                    
worker               |                 .> celery           exchange=celery(direct) key=celery          
```
 

An  the new one for the new queue:


```
rker-email-digest  |  -------------- celery-email-digest-@lenovo v5.3.6 (emerald-rush)                                                                                                      worker-email-digest  | --- ***** -----                                                                                                                                                        
worker-email-digest  | -- ******* ---- Linux-6.8.0-45-generic-x86_64-with-glibc2.35 2024-10-18 11:52:11                                                                                       
worker-email-digest  | - *** --- * ---                                                                                                                                                        
worker-email-digest  | - ** ---------- [config]                                                                                                                                               
worker-email-digest  | - ** ---------- .> app:         lms:0x7c59b1268970                                                                                                                     
worker-email-digest  | - ** ---------- .> transport:   amqp://guest:**@localhost:5674//                                                                                                       
worker-email-digest  | - ** ---------- .> results:     disabled://                                                                                                                            worker-email-digest  | - *** --- * --- .> concurrency: 16 (prefork)                                                                                                                           
worker-email-digest  | -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)                                                                                        worker-email-digest  | --- ***** -----                                                                                                                                                        worker-email-digest  |  -------------- [queues]                                                                                                                                               
worker-email-digest  |                 .> email-digest     exchange=email-digest(direct) key=email-digest    
```



