### PR TITLE
Ignore assignment not found error while fetching rosters

### DIFF
--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -119,12 +119,12 @@ class RosterService:
                 resource_link_id=assignment.lti_v13_resource_link_id,
             )
         except ExternalRequestError as err:
-            if (
-                err.response_body
-                and (
-                    "Requested ResourceLink bound to unexpected external tool"  # Canvas, unknown reason
-                    in err.response_body
-                )
+            if err.response_body and (
+                # Canvas, unknown reason
+                "Requested ResourceLink bound to unexpected external tool"
+                in err.response_body
+                # Canvas, assignment deleted in the LMS
+                or "Requested ResourceLink was not found" in err.response_body
             ):
                 LOG.error("Fetching assignment roster failed: %s", err.response_body)
                 # We ignore this type of error, just stop here.

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -127,15 +127,18 @@ class TestLTINameRolesServices:
         assert roster[3].lms_user.lti_user_id == "USER_ID_INACTIVE"
         assert not roster[3].active
 
+    @pytest.mark.parametrize(
+        "known_error",
+        [
+            "Requested ResourceLink bound to unexpected external tool",
+            "Requested ResourceLink was not found",
+        ],
+    )
     def test_fetch_assignment_roster_retries_with_lti_v11_id(
-        self, svc, lti_names_roles_service, assignment
+        self, svc, lti_names_roles_service, assignment, known_error
     ):
         lti_names_roles_service.get_context_memberships.side_effect = (
-            ExternalRequestError(
-                response=Mock(
-                    text="Requested ResourceLink bound to unexpected external tool"
-                )
-            )
+            ExternalRequestError(response=Mock(text=known_error))
         )
 
         # Method finishes without re-raising the exception


### PR DESCRIPTION
This occurs when the assignment we try to fetch the roster for has been deleted from the LMS


These are just causing noise on the monitoring now.