### PR TITLE
Calculate and expose auto grading grade on the students metrics endpoint

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -67,6 +67,8 @@ class APIStudent(TypedDict):
 
     annotation_metrics: NotRequired[AnnotationMetrics]
 
+    auto_grading_grade: NotRequired[float]
+
 
 class APICourses(TypedDict):
     courses: list[APICourse]

--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -1,0 +1,54 @@
+from lms.js_config_types import AnnotationMetrics
+from lms.models import AutoGradingConfig
+
+
+def calculate_grade(
+    auto_grading_config: AutoGradingConfig, annotation_metrics: AnnotationMetrics
+) -> float:
+    """Calculate auto grades based on the config and the number of annotations made.
+
+    The results is a 100 based float rounded to two decimals.
+    """
+    combined_count = annotation_metrics["annotations"] + annotation_metrics["replies"]
+
+    grade: float = 0
+    match (auto_grading_config.grading_type, auto_grading_config.activity_calculation):
+        case ("all_or_nothing", "cumulative"):
+            if combined_count >= auto_grading_config.required_annotations:
+                grade = 100
+            else:
+                grade = 0
+        case ("all_or_nothing", "separate"):
+            assert (
+                auto_grading_config.required_replies is not None
+            ), "'separate' auto grade config with empty replies"
+            if (
+                annotation_metrics["annotations"]
+                >= auto_grading_config.required_annotations
+                and annotation_metrics["replies"]
+                >= auto_grading_config.required_replies
+            ):
+                grade = 100
+            else:
+                grade = 0
+
+        case ("scaled", "cumulative"):
+            grade = combined_count / auto_grading_config.required_annotations * 100
+
+        case ("scaled", "separate"):
+            assert (
+                auto_grading_config.required_replies is not None
+            ), "'separate' auto grade config with empty replies"
+            grade = (
+                combined_count
+                / (
+                    auto_grading_config.required_annotations
+                    + auto_grading_config.required_replies
+                )
+                * 100
+            )
+        case _:
+            raise ValueError("Unknown auto grading configuration")
+
+    grade = min(100, grade)  # Proportional grades are capped at 100%
+    return round(grade, 2)

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -1,0 +1,53 @@
+import pytest
+
+from lms.js_config_types import AnnotationMetrics
+from lms.models import AutoGradingConfig
+from lms.services.auto_grading import calculate_grade
+
+
+@pytest.mark.parametrize(
+    "grading_type,activity_calculation,required_annotations, required_replies,annotations,replies,expected_grade",
+    [
+        ("all_or_nothing", "cumulative", 15, None, 5, 5, 0),
+        ("all_or_nothing", "cumulative", 15, None, 10, 6, 100),
+        ("all_or_nothing", "separate", 10, 5, 10, 4, 0),
+        ("all_or_nothing", "separate", 10, 5, 10, 5, 100),
+        ("scaled", "cumulative", 15, None, 5, 5, 66.67),
+        ("scaled", "cumulative", 15, None, 10, 10, 100),
+        ("scaled", "separate", 10, 5, 8, 2, 66.67),
+        ("scaled", "separate", 10, 5, 5, 1, 40),
+    ],
+)
+def test_calculate_grade(
+    activity_calculation,
+    grading_type,
+    required_annotations,
+    required_replies,
+    annotations,
+    replies,
+    expected_grade,
+):
+    grade = calculate_grade(
+        AutoGradingConfig(
+            activity_calculation=activity_calculation,
+            grading_type=grading_type,
+            required_annotations=required_annotations,
+            required_replies=required_replies,
+        ),
+        AnnotationMetrics(annotations=annotations, replies=replies),
+    )
+
+    assert grade == expected_grade
+
+
+def test_calculate_grade_bad_config():
+    with pytest.raises(ValueError):
+        calculate_grade(
+            AutoGradingConfig(
+                activity_calculation="RANDOM",
+                grading_type="RANDOM",
+                required_annotations=10,
+                required_replies=10,
+            ),
+            AnnotationMetrics(annotations=10, replies=10),
+        )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647

Calculate auto-grades when the assignment is configured to use them and expose them in the metrics endpoint. 

## Testing

- Launch https://hypothesis.instructure.com/courses/319/assignments/7296

- Launch it again with at least one student. https://hypothesis.instructure.com/courses/319/assignments/7296

- Open the assignment dashboard, check the response for the metrics endpoints. It does now contain an `auto_grading_grade` field.

```
{
    "students": [
        {
            "h_userid": "acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is",
            "lms_id": "2a8a99bc095a8438a594cd57c1f4f0341951e360",
            "display_name": "Hypothesis 101 Student",
            "annotation_metrics": {
                "annotations": 0,
                "replies": 0,
                "last_activity": null
            },
            "auto_grading_grade": 0.0
        }
    ]
}

```