### PR TITLE
Use ORM upsert for LMSUser instead of the native PSQL one

### DIFF
--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -227,12 +227,20 @@ class TestUserService:
 
     @pytest.fixture
     def user(self, lti_user, application_instance):
-        return factories.User(
+        user = factories.User(
             application_instance=application_instance,
             user_id=lti_user.user_id,
             h_userid=lti_user.h_user.userid("authority.example.com"),
             roles="old_roles",
         )
+        factories.LMSUser(
+            tool_consumer_instance_guid=application_instance.tool_consumer_instance_guid,
+            lti_user_id=user.user_id,
+            h_userid=lti_user.h_user.userid("authority.example.com"),
+            email=user.email,
+            display_name=user.display_name,
+        )
+        return user
 
     @pytest.fixture
     def service(self, db_session):


### PR DESCRIPTION
Since we first deployed this we have observed the upsert query taking a longer term than expected.

Trying the ORM version which should be easier to debug.