### PR TITLE
Add conditional grade column to assignment activity table

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -192,6 +192,7 @@ export type Student = {
 
 export type StudentWithMetrics = Student & {
   annotation_metrics: AnnotationMetrics;
+  auto_grading_grade?: number;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -2,6 +2,7 @@ import type { DataTableProps, Order } from '@hypothesis/frontend-shared';
 import { DataTable } from '@hypothesis/frontend-shared';
 import { useOrderedRows } from '@hypothesis/frontend-shared';
 import type { OrderDirection } from '@hypothesis/frontend-shared/lib/types';
+import classnames from 'classnames';
 import { useMemo, useState } from 'preact/hooks';
 import { useLocation } from 'wouter-preact';
 
@@ -46,7 +47,13 @@ export default function OrderableActivityTable<T>({
       columns.map(({ field, label }, index) => ({
         field,
         label,
-        classes: index === 0 ? 'lg:w-[60%] md:w-[45%]' : undefined,
+        classes: classnames({
+          // For assignments with auto-grading, a fifth column is displayed.
+          // In that case, we need to reserve less space for the first column,
+          // otherwise the rest overflow.
+          'lg:w-[60%] md:w-[45%]': index === 0 && columns.length < 5,
+          'lg:w-[45%] md:w-[30%]': index === 0 && columns.length >= 5,
+        }),
       })),
     [columns],
   );


### PR DESCRIPTION
Display a new "Grade" column in the assignment activity table, for assignments where auto-grading has been enabled.

![image](https://github.com/user-attachments/assets/f79f48d3-6725-418b-9c32-f25232420368)

### Testing steps

1. Go to https://hypothesis.instructure.com/courses/319/assignments/7296, and log-in as the "Hypothesis 101 Teacher" teacher.
2. Edit the assignment and enable auto-grading (default values are fine).
3. Open the dashboard for that assignment. The table should show a new "Grade" column.
    > Note the values of that column may not be displayed yet, as that depends on https://github.com/hypothesis/lms/pull/6664
4. Open the dashboard for any other assignment where auto-grading was not enabled. It should not show the "Grade" column.