### PR TITLE
Reduce size taken by grade chips in activity tables

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 import { useLocation, useParams, useSearch } from 'wouter-preact';
 
@@ -199,7 +200,17 @@ export default function AssignmentActivity() {
                 )
               );
             case 'auto_grading_grade':
-              return <GradeStatusChip grade={stats.auto_grading_grade ?? 0} />;
+              return (
+                <div
+                  className={classnames(
+                    // Add a bit of vertical negative margin to avoid the chip
+                    // component to make rows too tall
+                    '-my-0.5',
+                  )}
+                >
+                  <GradeStatusChip grade={stats.auto_grading_grade ?? 0} />
+                </div>
+              );
             default:
               return '';
           }

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -384,8 +384,9 @@ describe('AssignmentActivity', () => {
             .find('OrderableActivityTable')
             .props()
             .renderItem({ auto_grading_grade }, 'auto_grading_grade');
+          const gradeChip = mount(item).find('GradeStatusChip');
 
-          assert.equal(mount(item).prop('grade'), auto_grading_grade ?? 0);
+          assert.equal(gradeChip.prop('grade'), auto_grading_grade ?? 0);
         });
       },
     );


### PR DESCRIPTION
In https://github.com/hypothesis/lms/pull/6666 we added a grae column to the students activity table, which renders a grade chip component that makes rows slightly taller than they were before due to the implicit padding in table cells.

This PR adds a bit of negative margin around the grade chip to compensate for that and make rows have the same height they had before.

This is the height of a row without grade column:

![image](https://github.com/user-attachments/assets/9f169ff7-9a92-4176-b7fe-a12b129801af)

This is the height when the grade chip is included, before applying the changes from this PR:

![image](https://github.com/user-attachments/assets/d99f3c49-c9d4-449f-a10a-3b610a007361)

And this is how it looks with the changes from this PR:

![image](https://github.com/user-attachments/assets/f5d5421a-19a6-4855-8638-a42d34ed58b8)

I added the smallest possible margin, which is enough so that a single line of text in any of the other cells is taller.

Bigger margins would not make a difference here, unless the rest of the cells were empty. 

I considered implementing something in frontend-shared, that allows customizing the cells padding, but I think this should do for now and we can improve on that if we find more use cases where the padding needs to be adjusted on a per-cell basis.