### PR TITLE
Store the LTI1.3 user_id in LMSUser

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -363,7 +363,7 @@ def get_lti_user(request) -> LTIUser | None:
     if lti_user:
         # Make a record of the user for analytics so we can map from the
         # LTI users and the corresponding user in H
-        request.find_service(UserService).upsert_user(lti_user)
+        request.find_service(UserService).upsert_user(lti_user, request.lti_params)
 
         # Attach useful information to sentry in case we get an exception further down the line
         sentry_sdk.set_tag("application_instance_id", lti_user.application_instance_id)

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -182,6 +182,7 @@ class RosterService:
         values = []
         for member in roster:
             lti_user_id = member.get("lti11_legacy_user_id") or member["user_id"]
+            lti_v13_user_id = member["user_id"]
             name = display_name(
                 given_name=member.get("name", ""),
                 family_name=member.get("family_name", ""),
@@ -198,6 +199,7 @@ class RosterService:
                 {
                     "tool_consumer_instance_guid": tool_consumer_instance_guid,
                     "lti_user_id": lti_user_id,
+                    "lti_v13_user_id": lti_v13_user_id,
                     "h_userid": h_userid,
                     "display_name": name,
                 }
@@ -208,7 +210,11 @@ class RosterService:
             LMSUser,
             values=values,
             index_elements=["h_userid"],
-            update_columns=["updated"],
+            update_columns=[
+                "updated",
+                # lti_v13_user_id is not going to change but we want to backfill it for existing users.
+                "lti_v13_user_id",
+            ],
         )
 
     def _get_roster_roles(self, roster) -> list[LTIRole]:

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -651,7 +651,9 @@ class TestGetLTIUser:
         result = get_lti_user(pyramid_request)
 
         assert result == lti_user
-        user_service.upsert_user.assert_called_once_with(result)
+        user_service.upsert_user.assert_called_once_with(
+            result, pyramid_request.lti_params
+        )
         sentry_sdk.set_tag.assert_called_once_with(
             "application_instance_id", lti_user.application_instance_id
         )


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


In LTI1.1 launches we only get the LTI1.1 user_id. Conversely in "pure" LTI1.3 launches we only get the LTI1.3 ID.

However in updated LTI1.3 launches we get both versions, the LTI1.1 and LTI1.3 one. We have prefered the LTI1.1 for backwards compatibility, to keep the same identity in H.

While we do use now the LTI1.3 grading API we only do that in the context of a launch where we have all the parameters available to chose.

We need now to the LTI1.3 version in the DB to talk to the the grading API outside of the context of launch for the autograding feature.


###  Testing

- [Launch a LTI1.1 assignment](https://hypothesis.instructure.com/courses/125/assignments/873), nothing should changes
- [Launch a LTI1.3 assignment](https://hypothesis.instructure.com/courses/319/assignments/7296), the new ID will be stored in the DB.
- Fetch the roster for an assignment, all the students in the course will get the ID.

```
from lms.tasks.roster import fetch_assignment_roster
fetch_assignment_roster.delay(assignment_id=121) # ID of an LTI1.3 assignment
```

```
 select display_name, lti_V13_user_id from lms_user;
          display_name          |           lti_v13_user_id            
--------------------------------+--------------------------------------
 Hypothesis 101 Student Student | 2b04173b-1f12-42ea-aa87-5dd0b6ef2473
 Hypothesis 101 Teacher Teacher | 3f25366d-ab34-4307-be21-3ea444559e82
 Leopoldd                       | 6798f121-8bb0-418c-ad9b-b61e400798f6
 eng+coursecopystudent          | 4a3d7f19-7eec-4231-813a-3542e8e8f476
 Test Student Student           | 2cd335e6-1061-40f5-a118-1c857cf7c7ab
(5 rows)
```

