### PR TITLE
Sync grades back to the LMS for auto grading

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -118,6 +118,9 @@ class DashboardRoutes(TypedDict):
     students: str
     """Paginated endpoint to fetch students"""
 
+    assignment_grades_sync: str
+    """Sync grades for a given assignment"""
+
 
 class User(TypedDict):
     is_staff: bool

--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -130,3 +130,6 @@ class User(TypedDict):
 class DashboardConfig(TypedDict):
     user: User
     routes: DashboardRoutes
+
+    auto_grading_sync_enabled: bool
+    """Whether or nor the opotion to sync grades back to the LMS is enabled."""

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -56,6 +56,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
         JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
         JSONSetting("hypothesis", "auto_grading_enabled", asbool),
+        JSONSetting("hypothesis", "auto_grading_sync_enabled", asbool),
     )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -287,6 +287,10 @@ class JSConfig:
                             "api.dashboard.assignments.grading.sync"
                         ),
                     ),
+                    auto_grading_sync_enabled=self._lti_user
+                    and self._application_instance.settings.get(
+                        "hypothesis", "auto_grading_sync_enabled", False
+                    ),
                 ),
             }
         )

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -283,6 +283,9 @@ class JSConfig:
                             "api.dashboard.assignments"
                         ),
                         students=self._to_frontend_template("api.dashboard.students"),
+                        assignment_grades_sync=self._to_frontend_template(
+                            "api.dashboard.assignments.grading.sync"
+                        ),
                     ),
                 ),
             }

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -284,6 +284,10 @@ def includeme(config):  # noqa: PLR0915
     config.add_route(
         "api.dashboard.assignment", r"/api/dashboard/assignments/{assignment_id}"
     )
+    config.add_route(
+        "api.dashboard.assignments.grading.sync",
+        "/api/dashboard/assignments/{assignment_id}/grading/sync",
+    )
     config.add_route("api.dashboard.assignments", "/api/dashboard/assignments")
     config.add_route(
         "api.dashboard.course.assignments.metrics",

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -1,8 +1,8 @@
 from pyramid.httpexceptions import HTTPNotFound, HTTPUnauthorized
 from sqlalchemy import select
 
+from lms.models import Assignment, Organization
 from lms.models.dashboard_admin import DashboardAdmin
-from lms.models.organization import Organization
 from lms.security import Permissions
 from lms.services.organization import OrganizationService
 
@@ -21,7 +21,7 @@ class DashboardService:
         self._course_service = course_service
         self._organization_service = organization_service
 
-    def get_request_assignment(self, request):
+    def get_request_assignment(self, request) -> Assignment:
         """Get and authorize an assignment for the given request."""
         assigment_id = request.matchdict.get(
             "assignment_id"

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -115,6 +115,7 @@
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                             {{ settings_checkbox("Enable auto-grading", "hypothesis", "auto_grading_enabled", default=False) }}
+                            {{ settings_checkbox("Enable auto-grading grade sync", "hypothesis", "auto_grading_sync_enabled", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -1,0 +1,86 @@
+import logging
+from datetime import datetime
+
+from marshmallow import Schema, fields
+from pyramid.view import view_config
+from sqlalchemy import select
+
+from lms.models import (
+    ApplicationInstance,
+    Grouping,
+    LMSUser,
+    LTIRegistration,
+)
+from lms.security import Permissions
+from lms.services import LTIAHTTPService
+from lms.services.dashboard import DashboardService
+from lms.services.lti_grading.factory import LTI13GradingService
+from lms.validation._base import JSONPyramidRequestSchema
+
+LOG = logging.getLogger(__name__)
+
+
+class _GradeSchema(Schema):
+    h_userid = fields.Str(required=True)
+    grade = fields.Float(required=True)
+
+
+class AutoGradeSyncSchema(JSONPyramidRequestSchema):
+    grades = fields.List(fields.Nested(_GradeSchema), required=True)
+
+
+class DashboardGradingViews:
+    def __init__(self, request) -> None:
+        self.request = request
+        self.db = request.db
+        self.dashboard_service: DashboardService = request.find_service(
+            name="dashboard"
+        )
+
+    @view_config(
+        route_name="api.dashboard.assignments.grading.sync",
+        request_method="POST",
+        renderer="json",
+        permission=Permissions.GRADE_ASSIGNMENT,
+        schema=AutoGradeSyncSchema,
+    )
+    def auto_grading_sync(self):
+        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assert assignment.lis_outcome_service_url, "Assignment without grading URL"
+        lti_registration = self.db.scalars(
+            select(LTIRegistration)
+            .join(ApplicationInstance)
+            .join(Grouping)
+            .where(Grouping.id == assignment.course_id)
+            .order_by(LTIRegistration.updated.desc())
+        ).first()
+        assert lti_registration, "No LTI registraion for LTI1.3 assignment"
+
+        sync_h_user_ids = [g["h_userid"] for g in self.request.parsed_params["grades"]]
+
+        sync_lms_users = self.db.execute(
+            select(LMSUser.h_userid, LMSUser.lti_v13_user_id).where(
+                LMSUser.h_userid.in_(sync_h_user_ids)
+            )
+        ).all()
+        # Organize the data in a dict h_userid -> lti_user_id for easier access
+        sync_lms_users_by_h_userid = {r[0]: r[1] for r in sync_lms_users}
+
+        grading_service = LTI13GradingService(
+            ltia_service=self.request.find_service(LTIAHTTPService),
+            line_item_url=None,
+            line_item_container_url=None,
+            product_family=None,  # type: ignore
+            misc_plugin=None,  # type: ignore
+            lti_registration=None,  # type: ignore
+        )
+        # Use the same timestamp for all grades of the same sync
+        grade_sync_time_stamp = datetime.now()
+        for grade in self.request.parsed_params["grades"]:
+            grading_service.sync_grade(
+                lti_registration,
+                assignment.lis_outcome_service_url,
+                grade_sync_time_stamp,
+                sync_lms_users_by_h_userid[grade["h_userid"]],
+                grade["grade"],
+            )

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -735,6 +735,7 @@ class TestEnableDashboardMode:
                 "courses": "/api/dashboard/courses",
                 "assignments": "/api/dashboard/assignments",
                 "students": "/api/dashboard/students",
+                "assignment_grades_sync": "/api/dashboard/assignments/:assignment_id/grading/sync",
             },
         }
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -713,7 +713,18 @@ class TestEnableErrorDialogMode:
 
 
 class TestEnableDashboardMode:
-    def test_it(self, js_config, lti_user, bearer_token_schema):
+    @pytest.mark.parametrize("auto_grading_sync_setting", [True, False])
+    def test_it(
+        self,
+        js_config,
+        lti_user,
+        bearer_token_schema,
+        auto_grading_sync_setting,
+        application_instance,
+    ):
+        application_instance.settings.set(
+            "hypothesis", "auto_grading_sync_enabled", auto_grading_sync_setting
+        )
         js_config.enable_dashboard_mode(token_lifetime_seconds=100)
         config = js_config.asdict()
 
@@ -737,6 +748,7 @@ class TestEnableDashboardMode:
                 "students": "/api/dashboard/students",
                 "assignment_grades_sync": "/api/dashboard/assignments/:assignment_id/grading/sync",
             },
+            "auto_grading_sync_enabled": auto_grading_sync_setting,
         }
 
     def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
@@ -748,6 +760,8 @@ class TestEnableDashboardMode:
             "is_staff": True,
             "display_name": "staff@example.com",
         }
+        # Grade syncing always disabled for staff
+        assert not config["dashboard"]["auto_grading_sync_enabled"]
 
     @pytest.fixture
     def pyramid_request_staff_member(self, pyramid_config, pyramid_request):

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from lms.views.dashboard.api.grading import DashboardGradingViews
+from tests import factories
+
+
+@pytest.mark.usefixtures("dashboard_service", "ltia_http_service")
+class TestDashboardGradingViews:
+    @freeze_time("2022-06-21 12:00:00")
+    def test_auto_grading_sync(
+        self,
+        lti_v13_application_instance,
+        pyramid_request,
+        views,
+        DashboardGradingView,
+        ltia_http_service,
+        dashboard_service,
+        assignment,
+    ):
+        dashboard_service.get_request_assignment.return_value = assignment
+
+        views.auto_grading_sync()
+
+        dashboard_service.get_request_assignment.assert_called_once_with(
+            pyramid_request
+        )
+        DashboardGradingView.assert_called_once_with(
+            ltia_service=ltia_http_service,
+            line_item_url=None,
+            line_item_container_url=None,
+            product_family=None,
+            misc_plugin=None,
+            lti_registration=None,
+        )
+        DashboardGradingView.return_value.sync_grade.assert_called_once_with(
+            lti_v13_application_instance.lti_registration,
+            "LIS_OUTCOME_SERVICE_URL",
+            datetime(2022, 6, 21, 12, 0, 0),
+            "LTI_V13_USER_ID",
+            1,
+        )
+
+    @pytest.fixture
+    def assignment(self, lti_v13_application_instance, db_session):
+        course = factories.Course(application_instance=lti_v13_application_instance)
+        assignment = factories.Assignment(
+            lis_outcome_service_url="LIS_OUTCOME_SERVICE_URL", course=course
+        )
+        db_session.flush()
+        return assignment
+
+    @pytest.fixture
+    def lms_user(self):
+        return factories.LMSUser(lti_v13_user_id="LTI_V13_USER_ID")
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request, lms_user):
+        pyramid_request.parsed_params = {
+            "grades": [{"h_userid": lms_user.h_userid, "grade": 1}]
+        }
+        return pyramid_request
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return DashboardGradingViews(pyramid_request)
+
+    @pytest.fixture
+    def DashboardGradingView(self, patch):
+        return patch("lms.views.dashboard.api.grading.LTI13GradingService")


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


Basic API endpoint to support the first version of the "Sync grades" button.


### Testing

- Based on this assignment https://hypothesis.instructure.com/courses/319/assignments/7296

use a request like:

```
curl 'http://localhost:8001/api/dashboard/assignments/121/grading/sync' -X POST \
  -H 'Accept: */*' \
  -H "Content-Type: application/json" \
  -H 'Authorization: XXXXXXX' \
  --data '{"grades": [{"h_userid": "acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is", "grade": 0.7}]}'
```

with a token from an instructor (it won't work for staff members).



- Check the grade over: https://hypothesis.instructure.com/courses/319/assignments/7296