### PR TITLE
Use new colors for grade status chip

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
@@ -24,16 +24,12 @@ export default function GradeStatusChip({ grade }: GradeStatusChipProps) {
 
   return (
     <div
-      className={classnames('rounded font-bold inline-block px-2 py-0.5', {
-        // We would usually use our standard `green-success` and `red-error`
-        // colors here, but they don't have enough contrast when used with
-        // white text and a small font.
-        // Instead, we use slightly darker shades of green and red.
-        'bg-[#008558] text-white': grade === 100,
-        'bg-[#D7373A] text-white': grade === 0,
-        'bg-green-200 text-green-900': grade >= 80 && grade < 100,
-        'bg-amber-100 text-amber-900': grade >= 50 && grade < 80,
-        'bg-red-200 text-red-900': grade >= 1 && grade < 50,
+      className={classnames('rounded inline-block font-bold px-2 py-0.5', {
+        'bg-grade-success text-white': grade === 100,
+        'bg-grade-success-light text-grade-success': grade >= 80 && grade < 100,
+        'bg-grade-warning-light text-grade-warning': grade >= 50 && grade < 80,
+        'bg-grade-error-light text-grade-error': grade >= 1 && grade < 50,
+        'bg-grade-error text-white': grade === 0,
         'bg-grey-3 text-grey-7': gradeIsInvalid,
       })}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ import tailwindConfig from '@hypothesis/frontend-shared/lib/tailwind.preset.js';
 const successGreen =
   tailwindConfig.theme?.extend?.colors?.green?.success ?? '#00a36d';
 
-export default {
+export default /** @type {Partial<import('tailwindcss').Config>} */ ({
   presets: [tailwindConfig],
   content: [
     './lms/static/scripts/frontend_apps/**/*.{js,ts,tsx}',
@@ -16,6 +16,16 @@ export default {
     extend: {
       animation: {
         gradeSubmitSuccess: 'gradeSubmitSuccess 2s ease-out forwards',
+      },
+      colors: {
+        grade: {
+          success: '#005c3d',
+          'success-light': '#dfebe7',
+          error: '#891b1d',
+          'error-light': '#f0e2e3',
+          warning: '#774903',
+          'warning-light': '#fef7ec',
+        },
       },
       fontFamily: {
         sans: [
@@ -37,4 +47,4 @@ export default {
       },
     },
   },
-};
+});


### PR DESCRIPTION
The original colors used for grade chips had some accessibility issues, specifically in the contrast between the background and foreground colors of the bright green and bright red ones.

After [discussing possible approaches](https://hypothes-is.slack.com/archives/C07NXBDNW/p1725618338814759), a [new design](https://www.figma.com/design/ctCnzwkAyYArSNBYEshiCm/Hypothesis---LMS-Assignment-Grading?node-id=1615-174&node-type=frame&t=zNHFJWW0O82sart2-0) has been provided with new colors that pass accessibility checks. This PR updates te component to use those colors.

Additionally, it defines the colors in tailwind configuration.

Before:

![image](https://github.com/user-attachments/assets/3200f820-dc88-453e-9835-d2e511b15c96)

After:

![image](https://github.com/user-attachments/assets/23482915-1aca-40fc-a5c6-bf6fe15979b2)
