### PR TITLE
Only upsert LMSUser on launches

### DIFF
--- a/lms/security.py
+++ b/lms/security.py
@@ -363,7 +363,7 @@ def get_lti_user(request) -> LTIUser | None:
     if lti_user:
         # Make a record of the user for analytics so we can map from the
         # LTI users and the corresponding user in H
-        request.find_service(UserService).upsert_user(lti_user, request.lti_params)
+        request.find_service(UserService).upsert_user(lti_user)
 
         # Attach useful information to sentry in case we get an exception further down the line
         sentry_sdk.set_tag("application_instance_id", lti_user.application_instance_id)

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -35,7 +35,7 @@ class UserService:
         self._db = db
         self._h_authority = h_authority
 
-    def upsert_user(self, lti_user: LTIUser, lti_params: LTIParams) -> User:
+    def upsert_user(self, lti_user: LTIUser) -> User:
         """Store a record of having seen a particular user."""
 
         # Note! - Storing a user in our DB currently has an implication for
@@ -65,13 +65,11 @@ class UserService:
             # We are only storing emails for teachers now.
             user.email = lti_user.email
 
-        self._upsert_lms_user(user, lti_params)
         return user
 
-    def _upsert_lms_user(self, user: User, lti_params: LTIParams) -> LMSUser:
+    def upsert_lms_user(self, user: User, lti_params: LTIParams) -> LMSUser:
         """Upsert LMSUser based on a User object."""
         self._db.flush()  # Make sure User has hit the DB on the current transaction
-
         lms_user = bulk_upsert(
             self._db,
             LMSUser,

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -20,7 +20,7 @@ from lms.events import LTIEvent
 from lms.models import Assignment
 from lms.product.plugin.misc import MiscPlugin
 from lms.security import Permissions
-from lms.services import LTIGradingService, VitalSourceService
+from lms.services import LTIGradingService, UserService, VitalSourceService
 from lms.services.assignment import AssignmentService
 from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
 
@@ -50,6 +50,11 @@ class BasicLaunchViews:
         # This might raise ReausedCondumerKey, preventing the launch
         self.request.find_service(name="application_instance").update_from_lti_params(
             self.request.lti_user.application_instance, self.request.lti_params
+        )
+        # Keep a record of every LMS user in the DB
+        # While request.user gets updated on every request we only need/want to update LMSUser on launches
+        request.find_service(UserService).upsert_lms_user(
+            request.user, request.lti_params
         )
         self.course = self._record_course()
 

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -49,7 +49,7 @@ from webargs import fields
 from lms.events import LTIEvent
 from lms.product.plugin.misc import MiscPlugin
 from lms.security import Permissions
-from lms.services import JWTService
+from lms.services import JWTService, UserService
 from lms.validation import DeepLinkingLTILaunchSchema
 from lms.validation._base import JSONPyramidRequestSchema
 
@@ -67,6 +67,10 @@ def deep_linking_launch(context, request):
     request.find_service(name="application_instance").update_from_lti_params(
         request.lti_user.application_instance, request.lti_params
     )
+    # Keep a record of every LMS user in the DB
+    # While request.user gets updated on every request we only need/want to update LMSUser on launches
+    request.find_service(UserService).upsert_lms_user(request.user, request.lti_params)
+
     course = request.find_service(name="course").get_from_launch(
         request.product.family, request.lti_params
     )

--- a/tests/unit/lms/security_test.py
+++ b/tests/unit/lms/security_test.py
@@ -651,9 +651,7 @@ class TestGetLTIUser:
         result = get_lti_user(pyramid_request)
 
         assert result == lti_user
-        user_service.upsert_user.assert_called_once_with(
-            result, pyramid_request.lti_params
-        )
+        user_service.upsert_user.assert_called_once_with(result)
         sentry_sdk.set_tag.assert_called_once_with(
             "application_instance_id", lti_user.application_instance_id
         )

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -13,8 +13,8 @@ from tests import factories
 
 class TestUserService:
     @pytest.mark.usefixtures("user_is_instructor")
-    def test_upsert_user(self, service, lti_user, db_session, pyramid_request):
-        user = service.upsert_user(lti_user, pyramid_request.lti_params)
+    def test_upsert_user(self, service, lti_user, db_session):
+        user = service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user == Any.instance_of(User).with_attrs(
@@ -31,43 +31,50 @@ class TestUserService:
             }
         )
         assert saved_user == user
-        self.assert_lms_user(db_session, user, pyramid_request.lti_params)
 
     @pytest.mark.usefixtures("user_is_learner")
     def test_upsert_user_doesnt_save_email_for_students(
-        self, service, lti_user, db_session, pyramid_request
+        self, service, lti_user, db_session
     ):
-        service.upsert_user(lti_user, pyramid_request.lti_params)
+        service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
-        self.assert_lms_user(db_session, saved_user, pyramid_request.lti_params)
 
     @pytest.mark.usefixtures("user")
-    def test_upsert_user_with_an_existing_user(
-        self, service, lti_user, db_session, pyramid_request
-    ):
-        user = service.upsert_user(lti_user, pyramid_request.lti_params)
+    def test_upsert_user_with_an_existing_user(self, service, lti_user, db_session):
+        user = service.upsert_user(lti_user)
 
         saved_user = db_session.get(User, user.id)
         assert saved_user.id == user.id
         assert saved_user.roles == lti_user.roles
         assert user == saved_user
-        self.assert_lms_user(db_session, saved_user, pyramid_request.lti_params)
 
     @pytest.mark.usefixtures("user")
     def test_upsert_user_doesnt_save_email_for_existing_students(
-        self, service, lti_user, db_session, pyramid_request
+        self, service, lti_user, db_session
     ):
         lti_user.roles = "Student"
 
-        service.upsert_user(lti_user, pyramid_request.lti_params)
+        service.upsert_user(lti_user)
 
         saved_user = db_session.query(User).order_by(User.id.desc()).first()
         assert saved_user.roles == lti_user.roles
         assert not saved_user.email
-        self.assert_lms_user(db_session, saved_user, pyramid_request.lti_params)
+
+    def test_upsert_lms_user(self, service, lti_user, pyramid_request, db_session):
+        user = service.upsert_user(lti_user)
+        lms_user = service.upsert_lms_user(user, pyramid_request.lti_params)
+
+        lms_user = db_session.scalars(
+            select(LMSUser).where(LMSUser.h_userid == user.h_userid)
+        ).one()
+
+        assert lms_user.display_name == user.display_name
+        assert lms_user.email == user.email
+        assert lms_user.updated == user.updated
+        assert lms_user.lti_v13_user_id == pyramid_request.lti_params.v13.get("sub")
 
     def test_get(self, user, service):
         db_user = service.get(user.application_instance, user.user_id)
@@ -175,18 +182,6 @@ class TestUserService:
         )
 
         assert db_session.scalars(query).all() == [student_in_assigment]
-
-    def assert_lms_user(self, db_session, user, lti_params):
-        """Assert the corresponding LMSUser to user exists in the DB with the same attributes."""
-
-        lms_user = db_session.scalars(
-            select(LMSUser).where(LMSUser.h_userid == user.h_userid)
-        ).one()
-
-        assert lms_user.display_name == user.display_name
-        assert lms_user.email == user.email
-        assert lms_user.updated == user.updated
-        assert lms_user.lti_v13_user_id == lti_params.v13.get("sub")
 
     @pytest.fixture
     def course(self, application_instance, db_session):

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -20,6 +20,7 @@ from tests import factories
     "lti_role_service",
     "grouping_service",
     "misc_plugin",
+    "user_service",
 )
 class TestBasicLaunchViews:
     def test___init___(

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -18,6 +18,7 @@ from lms.views.lti.deep_linking import (
 from tests import factories
 
 
+@pytest.mark.usefixtures("user_service")
 class TestDeepLinkingFieldsRequestSchema:
     @pytest.mark.parametrize(
         "payload",
@@ -81,6 +82,7 @@ class TestDeepLinkingLaunch:
         application_instance_service,
         course_service,
         misc_plugin,
+        user_service,
     ):
         deep_linking_launch(context, pyramid_request)
 
@@ -89,6 +91,9 @@ class TestDeepLinkingLaunch:
         )
         course_service.get_from_launch.assert_called_once_with(
             pyramid_request.product.family, pyramid_request.lti_params
+        )
+        user_service.upsert_lms_user.assert_called_once_with(
+            pyramid_request.user, pyramid_request.lti_params
         )
         lti_h_service.sync.assert_called_once_with(
             [course_service.get_from_launch.return_value], pyramid_request.params


### PR DESCRIPTION
We currently have access to User via request.user and that upserts `User` in practically every request.

That is itself is a questionable design but for `LMSUser` we definitely only want to update it from the data from the LMS, not data we have forwarded back to use in API calls.

Only upsert_lms_user in the two direct launches from the LMS, the "basic" launch and deep linking launches.


###  Testing

- [Launch a LTI1.1 assignment](https://hypothesis.instructure.com/courses/125/assignments/873), nothing should change
- [Launch a LTI1.3 assignment](https://hypothesis.instructure.com/courses/319/assignments/7296), the new ID will be stored in the DB.

- Check the ID in the table:


```
 select display_name, lti_V13_user_id from lms_user;
          display_name          |           lti_v13_user_id            
--------------------------------+--------------------------------------
 Hypothesis 101 Teacher Teacher | 3f25366d-ab34-4307-be21-3ea444559e82
(5 rows)
```



