### PR TITLE
Add a feature flag for the sync grade side of auto grading

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -130,3 +130,6 @@ class User(TypedDict):
 class DashboardConfig(TypedDict):
     user: User
     routes: DashboardRoutes
+
+    sync_enabled: bool
+    """Whether or nor the opotion to sync the grades back to the LMS is enabled."""

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -56,6 +56,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
         JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
         JSONSetting("hypothesis", "auto_grading_enabled", asbool),
+        JSONSetting("hypothesis", "auto_grading_sync_enabled", asbool),
     )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -287,6 +287,10 @@ class JSConfig:
                             "api.dashboard.assignments.grading.sync"
                         ),
                     ),
+                    sync_enabled=self._lti_user
+                    and self._application_instance.settings.get(
+                        "hypothesis", "auto_grading_sync_enabled", False
+                    ),
                 ),
             }
         )

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -115,6 +115,7 @@
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                             {{ settings_checkbox("Enable auto-grading", "hypothesis", "auto_grading_enabled", default=False) }}
+                            {{ settings_checkbox("Enable auto-grading grade sync", "hypothesis", "auto_grading_sync_enabled", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -713,7 +713,18 @@ class TestEnableErrorDialogMode:
 
 
 class TestEnableDashboardMode:
-    def test_it(self, js_config, lti_user, bearer_token_schema):
+    @pytest.mark.parametrize("auto_grading_sync_setting", [True, False])
+    def test_it(
+        self,
+        js_config,
+        lti_user,
+        bearer_token_schema,
+        auto_grading_sync_setting,
+        application_instance,
+    ):
+        application_instance.settings.set(
+            "hypothesis", "auto_grading_sync_enabled", auto_grading_sync_setting
+        )
         js_config.enable_dashboard_mode(token_lifetime_seconds=100)
         config = js_config.asdict()
 
@@ -737,6 +748,7 @@ class TestEnableDashboardMode:
                 "students": "/api/dashboard/students",
                 "assignment_grades_sync": "/api/dashboard/assignments/:assignment_id/grading/sync",
             },
+            "sync_enabled": auto_grading_sync_setting,
         }
 
     def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
@@ -748,6 +760,8 @@ class TestEnableDashboardMode:
             "is_staff": True,
             "display_name": "staff@example.com",
         }
+        # Grade syncing always disabled for staff
+        assert not config["dashboard"]["sync_enabled"]
 
     @pytest.fixture
     def pyramid_request_staff_member(self, pyramid_config, pyramid_request):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


This will allow us to expose the configuring and calculating side of auto grading while we work on the syncing part.