### PR TITLE
Extract PaginatedMultiSelect to its own module

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
@@ -1,0 +1,153 @@
+import { Button, MultiSelect, RefreshIcon } from '@hypothesis/frontend-shared';
+import type { ComponentChildren } from 'preact';
+import type { MutableRef } from 'preact/hooks';
+import { useRef } from 'preact/hooks';
+
+import type { PaginatedFetchResult } from '../../utils/api';
+
+type FiltersEntity = 'courses' | 'assignments' | 'students';
+
+/**
+ * Placeholder to indicate a loading is in progress in one of the dropdowns
+ */
+function LoadingOption({ entity }: { entity: FiltersEntity }) {
+  return (
+    <div className="py-2 px-4 mb-1 text-grey-4 italic">
+      Loading more {entity}...
+    </div>
+  );
+}
+
+type LoadingErrorProps = {
+  entity: FiltersEntity;
+  retry: () => void;
+};
+
+/**
+ * Indicates an error occurred while loading filters, and presents a button to
+ * retry.
+ */
+function LoadingError({ entity, retry }: LoadingErrorProps) {
+  return (
+    <div
+      className="flex gap-2 items-center py-2 pl-4 pr-2.5 mb-1"
+      // Make this element "focusable" so that clicking on it does not cause
+      // the listbox containing it to be closed
+      tabIndex={-1}
+    >
+      <span className="italic text-red-error">Error loading {entity}</span>
+      <Button
+        icon={RefreshIcon}
+        onClick={retry}
+        size="sm"
+        data-testid="retry-button"
+      >
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Checks if provided element's scroll is at the bottom.
+ *
+ * @param offset - Return true if the difference between the element's current
+ *                 and maximum scroll position is below this value.
+ *                 Defaults to 20.
+ */
+function elementScrollIsAtBottom(element: HTMLElement, offset = 20): boolean {
+  const distanceToTop = element.scrollTop + element.clientHeight;
+  const triggerPoint = element.scrollHeight - offset;
+  return distanceToTop >= triggerPoint;
+}
+
+export type PaginatedMultiSelectProps<TResult, TSelect> = {
+  result: PaginatedFetchResult<NonNullable<TResult>[]>;
+  activeItem?: TResult;
+  renderOption: (
+    item: NonNullable<TResult>,
+    ref?: MutableRef<HTMLElement | null>,
+  ) => ComponentChildren;
+  entity: FiltersEntity;
+  buttonContent?: ComponentChildren;
+  value: TSelect[];
+  onChange: (newValue: TSelect[]) => void;
+};
+
+/**
+ * A MultiSelect whose data is fetched from a paginated API.
+ * It includes loading and error indicators, and transparently loads more data
+ * while scrolling.
+ */
+export default function PaginatedMultiSelect<TResult, TSelect>({
+  result,
+  activeItem,
+  entity,
+  renderOption,
+  buttonContent,
+  value,
+  onChange,
+}: PaginatedMultiSelectProps<TResult, TSelect>) {
+  const lastOptionRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <MultiSelect
+      disabled={result.isLoadingFirstPage}
+      value={value}
+      onChange={onChange}
+      aria-label={`Select ${entity}`}
+      containerClasses="!w-auto min-w-[180px]"
+      buttonContent={buttonContent}
+      data-testid={`${entity}-select`}
+      onListboxScroll={e => {
+        if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {
+          result.loadNextPage();
+        }
+      }}
+    >
+      <MultiSelect.Option
+        value={undefined}
+        elementRef={
+          !activeItem && (!result.data || result.data.length === 0)
+            ? lastOptionRef
+            : undefined
+        }
+      >
+        All {entity}
+      </MultiSelect.Option>
+      {activeItem ? (
+        renderOption(activeItem, lastOptionRef)
+      ) : (
+        <>
+          {result.data?.map((item, index, list) =>
+            renderOption(
+              item,
+              list.length - 1 === index ? lastOptionRef : undefined,
+            ),
+          )}
+          {result.isLoading && <LoadingOption entity={entity} />}
+          {result.error && (
+            <LoadingError
+              entity={entity}
+              retry={() => {
+                // Focus last option before retrying, to avoid the listbox to
+                // be closed:
+                // - Starting the fetch retry will cause the result to no
+                //   longer be in the error state, hence the Retry button will
+                //   be umounted.
+                // - If the retry button had focus when unmounted, the focus
+                //   would revert to the document body.
+                // - Since the body is outside the select dropdown, this would
+                //   cause the select dropdown to auto-close.
+                // - To avoid this we focus a different element just before
+                //   initiating the retry.
+                lastOptionRef.current?.focus();
+                result.retry();
+              }}
+            />
+          )}
+        </>
+      )}
+    </MultiSelect>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
@@ -1,0 +1,167 @@
+import { MultiSelect } from '@hypothesis/frontend-shared';
+import { mount } from 'enzyme';
+
+import PaginatedMultiSelect from '../PaginatedMultiSelect';
+
+describe('PaginatedMultiSelect', () => {
+  let wrappers;
+
+  beforeEach(() => {
+    wrappers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(w => w.unmount());
+  });
+
+  function createComponent(props) {
+    const wrapper = mount(
+      <PaginatedMultiSelect
+        entity="courses"
+        value={[]}
+        onChange={sinon.stub()}
+        renderOption={o => (
+          <MultiSelect.Option value={o}>{o}</MultiSelect.Option>
+        )}
+        {...props}
+      />,
+    );
+    wrappers.push(wrapper);
+
+    return wrapper;
+  }
+
+  function getSelect(wrapper, id = 'courses') {
+    return wrapper.find(`MultiSelect[data-testid="${id}-select"]`);
+  }
+
+  it('renders options based on result data', () => {
+    const resultData = ['foo', 'bar', 'baz'];
+    const expectedOptions = ['All courses', ...resultData];
+    const wrapper = createComponent({
+      result: {
+        data: resultData,
+      },
+    });
+    const select = getSelect(wrapper);
+    const options = select.find(MultiSelect.Option);
+
+    assert.equal(options.length, expectedOptions.length);
+    options.forEach((option, index) => {
+      assert.equal(option.text(), expectedOptions[index]);
+    });
+  });
+
+  [true, false].forEach(isLoading => {
+    it('shows page loading indicators when loading', () => {
+      const wrapper = createComponent({
+        result: { isLoading },
+      });
+
+      assert.equal(wrapper.exists('LoadingOption'), isLoading);
+    });
+  });
+
+  context('when scrolling listboxes down', () => {
+    function getScrollableSelect() {
+      const fakeLoadNextPage = sinon.stub();
+      const wrapper = createComponent({
+        result: {
+          loadNextPage: fakeLoadNextPage,
+          data: ['foo', 'bar', 'baz'],
+        },
+      });
+      const select = getSelect(wrapper);
+
+      return { select, fakeLoadNextPage };
+    }
+
+    function scrollTo(select, scrollHeight) {
+      select.props().onListboxScroll({
+        target: {
+          scrollTop: 100,
+          clientHeight: 50,
+          scrollHeight,
+        },
+      });
+    }
+
+    it('loads next page when scroll is at the bottom', () => {
+      const { select, fakeLoadNextPage } = getScrollableSelect();
+
+      scrollTo(select, 160);
+      assert.called(fakeLoadNextPage);
+    });
+
+    it('does nothing when scroll is not at the bottom', () => {
+      const { select, fakeLoadNextPage } = getScrollableSelect();
+
+      scrollTo(select, 250);
+      assert.notCalled(fakeLoadNextPage);
+    });
+  });
+
+  it('displays only active item if provided', () => {
+    const wrapper = createComponent({
+      activeItem: 'This is displayed',
+      // Result is ignored
+      result: {
+        data: ['foo', 'bar', 'baz'],
+      },
+    });
+    const select = getSelect(wrapper);
+    const options = select.find(MultiSelect.Option);
+
+    assert.equal(options.length, 2);
+    assert.equal(options.at(0).text(), 'All courses');
+    assert.equal(options.at(1).text(), 'This is displayed');
+  });
+
+  describe('error handling', () => {
+    let fakeRetry;
+
+    beforeEach(() => {
+      fakeRetry = sinon.stub();
+    });
+
+    function createComponentWithError() {
+      return createComponent({
+        result: {
+          isLoading: false,
+          error: new Error('An error occurred'),
+          retry: fakeRetry,
+        },
+      });
+    }
+
+    function clickRetry(wrapper) {
+      wrapper.find('button[data-testid="retry-button"]').simulate('click');
+    }
+
+    it('shows error message when loading filters fails', () => {
+      const wrapper = createComponentWithError();
+      assert.isTrue(wrapper.exists('LoadingError'));
+    });
+
+    it('retries loading when retry button is clicked', () => {
+      const wrapper = createComponentWithError();
+
+      clickRetry(wrapper);
+      assert.called(fakeRetry);
+    });
+
+    it('focuses last option when retry button is clicked', () => {
+      const wrapper = createComponentWithError();
+
+      const lastOption = wrapper
+        .find(`[data-testid="courses-select"]`)
+        .find('[role="option"]')
+        .last()
+        .getDOMNode();
+      const focusOption = sinon.stub(lastOption, 'focus');
+
+      clickRetry(wrapper);
+      assert.called(focusOption);
+    });
+  });
+});


### PR DESCRIPTION
The `PaginatedMultiSelect` component was internal to the `DashboardActivityFilters`, but it was complex enough to define its own module and independent test.

Additionally, even though I'm not fully convinced yet, but we may need to display a `PaginatedMultiSelect` out of the activity filters group.

### Testing

Sanity-check that the dashboard filters are properly displayed and work as expected in every section.