### PR TITLE
Explicitly request a large number of results from BB grading API

### DIFF
--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -51,7 +51,7 @@ class JSConfig:
     def _application_instance(self) -> ApplicationInstance:
         return self._lti_user.application_instance
 
-    def add_document_url(  # pylint: disable=too-complex,too-many-branches,useless-suppression  # noqa: PLR0912
+    def add_document_url(  # pylint: disable=too-complex,too-many-branches,useless-suppression  # noqa: C901, PLR0912
         self, document_url
     ) -> None:
         """

--- a/lms/security.py
+++ b/lms/security.py
@@ -93,9 +93,9 @@ class SecurityPolicy:
 
     @staticmethod
     @lru_cache(maxsize=1)
-    def get_policy(request: Request):  # noqa: PLR0911
+    def get_policy(request: Request):  # noqa: C901, PLR0911
         """Pick the right policy based the request's path."""
-        # pylint:disable=too-many-return-statements,too-complex
+        # pylint:disable=too-many-return-statements
 
         path = request.path
 

--- a/lms/services/application_instance.py
+++ b/lms/services/application_instance.py
@@ -196,8 +196,7 @@ class ApplicationInstanceService:
             .all()
         )
 
-    # pylint: disable=too-complex
-    def _ai_search_query(  # noqa: PLR0913
+    def _ai_search_query(  # noqa: C901, PLR0913
         self,
         *,
         id_=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ disable = [
     "protected-access",
     "singleton-comparison",
     "unnecessary-lambda-assignment",
+    "too-complex",
 
     # Not supported by ruff
     "too-many-ancestors",
@@ -193,7 +194,6 @@ ignore = [
     "PLC1901",
     "E721",
     "C414",
-    "C901",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -72,8 +72,14 @@ disable = [
 
     # Ported to ruff
     "unused-argument",
+    "broad-exception-caught",
+    "too-many-arguments",
+    "import-outside-toplevel",
+    "too-many-statements",
     "protected-access",
+    "singleton-comparison",
     "unnecessary-lambda-assignment",
+    "too-complex",
 ]
 
 # Just disable PyLint's name style checking for the tests, because we

--- a/tests/unit/lms/services/canvas_studio_test.py
+++ b/tests/unit/lms/services/canvas_studio_test.py
@@ -341,7 +341,7 @@ class TestCanvasStudioService:
         svc.get.side_effect = self.get_request_handler(is_admin=True)
         return svc
 
-    def get_request_handler(self, collections=None, is_admin=False):  # noqa: PLR0915 pylint:disable=too-complex
+    def get_request_handler(self, collections=None, is_admin=False):  # noqa: C901, PLR0915
         """
         Create a handler for `GET` requests to the Canvas Studio API.
 
@@ -373,7 +373,7 @@ class TestCanvasStudioService:
                 make_collection(10, None, "course_wide", "2024-03-01"),
             ]
 
-        def handler(url, allow_redirects=True):  # noqa: PLR0912, PLR0915
+        def handler(url, allow_redirects=True):  # noqa: C901, PLR0912, PLR0915
             api_prefix = "/api/public/v1/"
 
             parsed_url = urlparse(url)


### PR DESCRIPTION
Due to a bug in Blackboard (see: https://github.com/hypothesis/lms/pull/5839)
we fetch results for all students and just pick the right one.

We didn't implement pagination together with that change so we are
missing students that are part of the course but are present in other
pages.

For now will just request a large number of results and alert when we
still hit the pagination limit.


Also see: https://hypothes-is.slack.com/archives/C2C2U40LW/p1726613664446289

### Testing

- Login as `blackboardteacher` in https://aunltd-test.blackboard.com/
- Launch the [LTI 1.3 assignment test assignment](https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2085_1&displayName=localhost+PDF+-+LTI1.3&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2085_1%26course_id%3D_19_1)

- Pick "Blackboard student" from the dropdown, the score will get updated and the comment will be now in the text area.


- Make a diff like:

```diff
diff --git a/lms/services/lti_grading/_v13.py b/lms/services/lti_grading/_v13.py
index f89737b44..53a21a800 100644
--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -48,7 +48,7 @@ class LTI13GradingService(LTIGradingService):
             # Using the user filter in the request removes the comment field in the response's body.
             del params["user_id"]
             # We add an explicit limit parameter to fetch all results
-            params["limit"] = 1000
+            params["limit"] = 1
 
         try:
             response = self._ltia_service.request(
```

to force the pagination to kick in.


- Read the score of a student again, you'll see this in the logs:

```2024-09-18 14:59:41,756 ERROR [lms.services.lti_grading._v13:74][MainThread] Blackboard grading reading result, container with paginated results```