### PR TITLE
Improve grading popover accessibility

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
@@ -1,7 +1,11 @@
-import { CheckIcon, CancelIcon } from '@hypothesis/frontend-shared';
+import {
+  CheckIcon,
+  CancelIcon,
+  useKeyPress,
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
-import { useCallback, useState } from 'preact/hooks';
+import { useCallback, useId, useState } from 'preact/hooks';
 
 import type { AutoGradingConfig } from '../../api-types';
 import GradeStatusChip from './GradeStatusChip';
@@ -64,6 +68,9 @@ export default function GradeIndicator({
   const [popoverVisible, setPopoverVisible] = useState(false);
   const showPopover = useCallback(() => setPopoverVisible(true), []);
   const hidePopover = useCallback(() => setPopoverVisible(false), []);
+  const popoverId = useId();
+
+  useKeyPress(['Escape'], hidePopover);
 
   const isCalculationSeparate = config?.activity_calculation === 'separate';
   const combined = annotations + replies;
@@ -72,23 +79,25 @@ export default function GradeIndicator({
     : 0;
 
   return (
-    <div
-      className="inline-block relative"
-      onMouseOver={showPopover}
-      onMouseOut={hidePopover}
-      // Make element focusable so that the popover can be shown even when
-      // interacting with the keyboard
-      onFocus={showPopover}
-      onBlur={hidePopover}
-      role="button"
-      tabIndex={0}
-      data-testid="container"
-    >
-      <GradeStatusChip grade={grade} />
+    <div className="relative">
+      <button
+        className="focus-visible-ring rounded"
+        onClick={showPopover}
+        onMouseOver={showPopover}
+        onFocus={showPopover}
+        onMouseOut={hidePopover}
+        onBlur={hidePopover}
+        data-testid="popover-toggle"
+        aria-expanded={popoverVisible}
+        aria-describedby={popoverVisible ? popoverId : undefined}
+        aria-controls={popoverVisible ? popoverId : undefined}
+      >
+        <GradeStatusChip grade={grade} />
+      </button>
       <div aria-live="polite" aria-relevant="additions">
         {popoverVisible && (
           <div
-            role="tooltip"
+            id={popoverId}
             className={classnames(
               'rounded shadow-lg bg-white border',
               'w-64 absolute -left-6 top-full mt-0.5',

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -23,11 +23,15 @@ describe('GradeIndicator', () => {
     );
   }
 
+  function getToggleButton(wrapper) {
+    return wrapper.find('[data-testid="popover-toggle"]');
+  }
+
   /**
    * @param {'onMouseOver' | 'onMouseOut' | 'onFocus' | 'onBlur'} callback
    */
   function invokeCallback(wrapper, callback) {
-    act(() => wrapper.find('[data-testid="container"]').prop(callback)());
+    act(() => getToggleButton(wrapper).prop(callback)());
     wrapper.update();
   }
 
@@ -39,7 +43,7 @@ describe('GradeIndicator', () => {
     return wrapper.exists('[data-testid="popover"]');
   }
 
-  ['onMouseOver', 'onFocus'].forEach(callback => {
+  ['onMouseOver', 'onFocus', 'onClick'].forEach(callback => {
     it(`shows popover ${callback}`, () => {
       const wrapper = createComponent();
 
@@ -60,6 +64,23 @@ describe('GradeIndicator', () => {
       invokeCallback(wrapper, callback);
       assert.isFalse(isPopoverVisible(wrapper));
     });
+  });
+
+  it(`hides popover on Escape key press`, () => {
+    const wrapper = createComponent();
+
+    // Start with the popover open
+    openPopover(wrapper);
+    assert.isTrue(isPopoverVisible(wrapper));
+
+    act(() =>
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape' }),
+      ),
+    );
+    wrapper.update();
+
+    assert.isFalse(isPopoverVisible(wrapper));
   });
 
   [
@@ -144,6 +165,21 @@ describe('GradeIndicator', () => {
           annotationCountElement.exists(expectedAnnotationCount.icon),
         );
       });
+    });
+  });
+
+  [true, false].forEach(popoverVisible => {
+    it('sets proper aria attributes', () => {
+      const wrapper = createComponent();
+      if (popoverVisible) {
+        openPopover(wrapper);
+      }
+
+      const toggleButton = getToggleButton(wrapper);
+
+      assert.equal(toggleButton.prop('aria-expanded'), popoverVisible);
+      assert.equal(!!toggleButton.prop('aria-describedby'), popoverVisible);
+      assert.equal(!!toggleButton.prop('aria-controls'), popoverVisible);
     });
   });
 


### PR DESCRIPTION
This PR changes a bit how the grading popover is implemented, so that it is closer to how popovers usually work, rather than tooltips:

The main difference between tooltips and popovers, from a conceptual point of view, is that [tooltips are not expected to be shown in touch devices](https://react-spectrum.adobe.com/react-aria/Tooltip.html#accessibility), therefore they should not contain information which is otherwise not available.

However, there's a bit of overlapping between both patterns, and a few grey areas and opinions. Hence, I tried to make some sensible decisions that can be discussed here.

### TL;DR

The changes here are the result of checking how some popular UI libraries treat popovers:

* Bootstrap: https://getbootstrap.com/docs/5.3/components/popovers
* Headless UI: https://headlessui.com/react/popover
* MUI: https://mui.com/material-ui/react-popover/
* React Aria: https://react-spectrum.adobe.com/react-aria/Popover.html

Based on those, these changes were made:

1. I removed the `role="tooltip"` from the popover element. It was originally used just because it was the closest to popover that was available, but from the libraries above, only bootstrap uses it.
    Additionally, we will eventually implement popovers via the standard [popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API), so we can as well remove the tooltip role already.
2. The popover can now be closed via `Escape` key. Except for bootstrap, all examples above have this behavior.
3. The toggle element is now an actual `button`. All examples above use this approach, and is the only way to make sure the popover can be shown in mobile devices, by tapping on it.
    I did not remove the hover/focus event handlers though, because in our designs it feels like that's how it is expected to work, but we might need to clarify this.
4. The toggle button now includes these aria attributes:
    * `aria-expanded`: It is true if the popover is open.
        Headless UI and React Aria implement it like this.
    * `aria-describedby`: A reference to the popover element, only when it's visible. Otherwise it is not defined.
        MUI and React Aria implement it like this.
    * `aria-controls`: Same as `aria-describedby`.
        Headless UI and React Aria implement it like this.

There's one last thing all the UI libraries have in common, which is the fact that they render popovers on their own container, "detached" from the toggle.

I didn't follow that here because it requires extra logic to manually position it based on the toggle position, but we'll eventually follow this approach when using the [popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).
