### PR TITLE
Add feature flag for dashboard segments filter

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -140,4 +140,7 @@ class DashboardConfig(TypedDict):
     routes: DashboardRoutes
 
     auto_grading_sync_enabled: bool
-    """Whether or nor the opotion to sync grades back to the LMS is enabled."""
+    """Whether or nor the option to sync grades back to the LMS is enabled."""
+
+    assignment_segments_filter_enabled: bool
+    """Whether the segments filter dropdown should be displayed in the assignment view or not"""

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -57,6 +57,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
         JSONSetting("hypothesis", "auto_grading_enabled", asbool),
         JSONSetting("hypothesis", "auto_grading_sync_enabled", asbool),
+        JSONSetting("dashboard", "assignment_segments_filter_enabled", asbool),
     )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -291,6 +291,10 @@ class JSConfig:
                     and self._application_instance.settings.get(
                         "hypothesis", "auto_grading_sync_enabled", False
                     ),
+                    assignment_segments_filter_enabled=not self._lti_user
+                    or self._application_instance.settings.get(
+                        "dashboard", "assignment_segments_filter_enabled", False
+                    ),
                 ),
             }
         )

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -34,7 +34,7 @@ type StudentsTableRow = {
  */
 export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
-  const { routes } = dashboard;
+  const { routes, assignment_segments_filter_enabled } = dashboard;
   const { assignmentId, organizationPublicId } = useParams<{
     assignmentId: string;
     organizationPublicId?: string;
@@ -51,9 +51,12 @@ export default function AssignmentActivity() {
   const autoGradingEnabled = !!assignment.data?.auto_grading_config;
   const segments = useMemo((): DashboardActivityFiltersProps['segments'] => {
     const { data } = assignment;
-    // For now, we want to display the segments filter only for auto-grading
-    // assignments, but this will eventually change
-    if (!data || !autoGradingEnabled) {
+    if (
+      !data ||
+      // Display the segments filter only for auto-grading assignments, or
+      // assignments where the feature was explicitly enabled
+      (!assignment_segments_filter_enabled && !autoGradingEnabled)
+    ) {
       return undefined;
     }
 
@@ -76,7 +79,13 @@ export default function AssignmentActivity() {
       selectedIds: segmentIds,
       onChange: segmentIds => updateFilters({ segmentIds }),
     };
-  }, [assignment, autoGradingEnabled, segmentIds, updateFilters]);
+  }, [
+    assignment,
+    assignment_segments_filter_enabled,
+    autoGradingEnabled,
+    segmentIds,
+    updateFilters,
+  ]);
 
   const students = useAPIFetch<StudentsMetricsResponse>(
     routes.students_metrics,

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -77,6 +77,7 @@ describe('AssignmentActivity', () => {
           assignment: '/api/assignments/:assignment_id',
           students_metrics: '/api/students/metrics',
         },
+        assignment_segments_filter_enabled: false,
       },
     };
 
@@ -485,6 +486,28 @@ describe('AssignmentActivity', () => {
 
       assert.isDefined(filters.prop('onClearSelection'));
     });
+  });
+
+  context('when assignment_segments_filter_enabled is true', () => {
+    beforeEach(() => {
+      fakeConfig.dashboard.assignment_segments_filter_enabled = true;
+    });
+
+    [{ sections: [{}, {}] }, { groups: [{}, {}, {}] }].forEach(
+      assignmentExtra => {
+        it('shows segments filter dropdown', () => {
+          setUpFakeUseAPIFetch({
+            ...activeAssignment,
+            ...assignmentExtra,
+          });
+
+          const wrapper = createComponent();
+          const filters = wrapper.find('DashboardActivityFilters');
+
+          assert.isDefined(filters.prop('segments'));
+        });
+      },
+    );
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -279,6 +279,17 @@ export type DashboardUser = {
 export type DashboardConfig = {
   routes: DashboardRoutes;
   user: DashboardUser;
+
+  /** Whether syncing grades is enabled for auto-grading assignments or not */
+  auto_grading_sync_enabled: boolean;
+
+  /**
+   * Whether the segments filter should be displayed for non-auto-grading
+   * assignments or not.
+   * For auto-grading assignments we'll ignore this and always display the
+   * segments filter.
+   */
+  assignment_segments_filter_enabled: boolean;
 };
 
 /**

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -118,6 +118,10 @@
                             {{ settings_checkbox("Enable auto-grading grade sync", "hypothesis", "auto_grading_sync_enabled", default=False) }}
                         </fieldset>
                         <fieldset class="box">
+                            <legend class="label has-text-centered">Dashboard settings</legend>
+                            {{ settings_checkbox("Enable segments filter in assignment view", "dashboard", "assignment_segments_filter_enabled", default=False) }}
+                        </fieldset>
+                        <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>
                             {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
                             {# Note the mismatch betwween canvas nomenclature and ours #}

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -713,17 +713,26 @@ class TestEnableErrorDialogMode:
 
 
 class TestEnableDashboardMode:
-    @pytest.mark.parametrize("auto_grading_sync_setting", [True, False])
+    @pytest.mark.parametrize(
+        "auto_grading_sync_setting,assignment_segments_filter_setting",
+        [(True, True), (False, True), (True, False), (False, False)],
+    )
     def test_it(
         self,
         js_config,
         lti_user,
         bearer_token_schema,
         auto_grading_sync_setting,
+        assignment_segments_filter_setting,
         application_instance,
     ):
         application_instance.settings.set(
             "hypothesis", "auto_grading_sync_enabled", auto_grading_sync_setting
+        )
+        application_instance.settings.set(
+            "dashboard",
+            "assignment_segments_filter_enabled",
+            assignment_segments_filter_setting,
         )
         js_config.enable_dashboard_mode(token_lifetime_seconds=100)
         config = js_config.asdict()
@@ -749,6 +758,7 @@ class TestEnableDashboardMode:
                 "assignment_grades_sync": "/api/dashboard/assignments/:assignment_id/grading/sync",
             },
             "auto_grading_sync_enabled": auto_grading_sync_setting,
+            "assignment_segments_filter_enabled": assignment_segments_filter_setting,
         }
 
     def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
@@ -762,6 +772,8 @@ class TestEnableDashboardMode:
         }
         # Grade syncing always disabled for staff
         assert not config["dashboard"]["auto_grading_sync_enabled"]
+        # Segments filter is always enabled for staff
+        assert config["dashboard"]["assignment_segments_filter_enabled"]
 
     @pytest.fixture
     def pyramid_request_staff_member(self, pyramid_config, pyramid_request):


### PR DESCRIPTION
This PR adds a feature flag to control when to show the segments filter in the dashboard assignment view.

The feature flag will be taken into consideration only for non-staff users. For staff users, the BE will always expose this option as enabled.

Additionally, for auto-grading assignments, the FE does not take this option into consideration, and instead, it always shows the filter, as it is important in that case, and the first use case for which we introduced the segments filter.

![image](https://github.com/user-attachments/assets/ee23c6c9-7bca-446c-98c4-dcd82210242d)

### Testing steps

1. Check out this branch
2. For staff:
    1. Go to the courses section in the LMS admin http://localhost:8001/admin/courses
    2. Click search, open any course from the result, and click on "Open instructor dashboard"
    3. Once there, if you select any assignment, you should see the segments filter, with a total of 4 dropdowns.
3. For auto-grading assignments:
    1. Go to https://hypothesis.instructure.com/courses/319/assignments/7296
    2. Click on the user icon in the sidebar, then in "Open dashboard".
    3. You should see the segments filter, with a total of 4 dropdowns.
4. For assignments where the feature is explicitly enabled:
    1. Go to https://hypothesis.instructure.com/courses/125/assignments/873 and log in as `eng+canvasteacher@hypothes.is`
    2. Click on the user icon in the sidebar, then in "Open dashboard".
    3. You should only see three filter dropdowns.
    4. On a new tab, go to http://localhost:8001/admin/instances/8/settings, and check the "Enable segments filter in assignment view" option.
    5. Go back to the dashboard and reload the page. You should see the segments dropdown now, with a total of 4.