### PR TITLE
Fix grading popover being rundered underneath the grading chip

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
@@ -100,7 +100,7 @@ export default function GradeIndicator({
             id={popoverId}
             className={classnames(
               'rounded shadow-lg bg-white border',
-              'w-64 absolute -left-6 top-full mt-0.5',
+              'w-64 absolute z-1 -left-6 top-full mt-0.5',
             )}
             data-testid="popover"
           >


### PR DESCRIPTION
Add a higher z-index to grading popover to make sure it renders over the grading chips:

Before:

https://github.com/user-attachments/assets/01f8c97c-e3f6-4ee6-a030-c343b6046681

After:

https://github.com/user-attachments/assets/571c9886-a4d0-4acb-92bd-b12b862c7a23