### PR TITLE
Don't create GradeSync with no GradeSyncGrades

### DIFF
--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -53,6 +53,12 @@ class DashboardGradingViews:
         sync_lms_users = self.db.scalars(
             select(LMSUser).where(LMSUser.h_userid.in_(sync_h_user_ids))
         ).all()
+        if not sync_lms_users:
+            self.request.response.status_int = 400
+            return {
+                "message": "No users for this grade sync. Can't find any of the provided users"
+            }
+
         sync_lms_users_by_h_userid: dict[str, LMSUser] = {
             lms_user.h_userid: lms_user for lms_user in sync_lms_users
         }

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -11,6 +11,30 @@ from tests import factories
     "dashboard_service", "ltia_http_service", "auto_grading_service"
 )
 class TestDashboardGradingViews:
+    def test_create_grading_sync_with_no_lms_users(
+        self,
+        pyramid_request,
+        views,
+        auto_grading_service,
+        dashboard_service,
+        assignment,
+    ):
+        dashboard_service.get_request_assignment.return_value = assignment
+        auto_grading_service.get_in_progress_sync.return_value = None
+        pyramid_request.parsed_params["grades"] = [
+            {"h_userid": "NON EXISTING", "grade": 0.5},
+        ]
+
+        views.create_grading_sync()
+
+        dashboard_service.get_request_assignment.assert_called_once_with(
+            pyramid_request
+        )
+        auto_grading_service.get_in_progress_sync.assert_called_once_with(
+            dashboard_service.get_request_assignment.return_value
+        )
+        pyramid_request.response.status_int = 400
+
     def test_create_grading_sync_with_existing_sync(
         self,
         pyramid_request,


### PR DESCRIPTION
This is mostly a possibility while testing locally. GradeSync with not GradeSyncGrades will currently stay "in_progress" forever as no GradeSync will ever finish.

We could make changes so this type of sync is marked as finished immediately but we are better off not creating them in the first place.

## Testing

- Try to create a new GradeSync with a non-existing HUserId:

```
curl 'http://localhost:8001/api/dashboard/assignments/121/grading/sync' -X POST \
  -H 'Accept: */*' \
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer ' \
  --data '{"grades": [{"h_userid": "NOPE", "grade": 0.7}]}'
```

You'll now get an error:


```{"message": "No users for this grade sync. Can't find any of the provided users."}%```