### PR TITLE
Expose the last synced grade and its date on the user metrics endpoint

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -56,6 +56,17 @@ class APICourse(TypedDict):
     course_metrics: NotRequired[CourseMetrics]
 
 
+class AutoGradingGrade(TypedDict):
+    current_grade: float
+    """Current auto-grading grade calculated based on the config and current number of annotations."""
+
+    last_grade: float | None
+    """Last grade that was succefully sync to the LMS."""
+
+    last_grade_date: str | None
+    """Time when `last_grade` was synced to the LMS."""
+
+
 class APIStudent(TypedDict):
     h_userid: str
     """ID of the student in H."""
@@ -66,8 +77,7 @@ class APIStudent(TypedDict):
     display_name: str | None
 
     annotation_metrics: NotRequired[AnnotationMetrics]
-
-    auto_grading_grade: NotRequired[float]
+    auto_grading_grade: NotRequired[AutoGradingGrade]
 
 
 class APICourses(TypedDict):

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -190,9 +190,18 @@ export type Student = {
   display_name: string | null;
 };
 
+export type AutoGradingGrade = {
+  /** Grade calculated with current annotations/replies */
+  current_grade: number;
+  /** Grade that was last synced, if any */
+  last_grade: number | null;
+  /** When did the last grade sync happen, if any */
+  last_grade_date: number | null;
+};
+
 export type StudentWithMetrics = Student & {
   annotation_metrics: AnnotationMetrics;
-  auto_grading_grade?: number;
+  auto_grading_grade?: AutoGradingGrade;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -30,7 +30,7 @@ type StudentsTableRow = {
   last_activity: string | null;
   annotations: number;
   replies: number;
-  auto_grading_grade?: number;
+  current_grade?: number;
 };
 
 /**
@@ -110,17 +110,16 @@ export default function AssignmentActivity() {
     }
 
     // TODO Filter out students whose grades didn't change
-    return students.data.students.map(
-      ({ h_userid, auto_grading_grade = 0 }) => ({
-        h_userid,
-        grade: auto_grading_grade,
-      }),
-    );
+    return students.data.students.map(({ h_userid, auto_grading_grade }) => ({
+      h_userid,
+      grade: auto_grading_grade?.current_grade ?? 0,
+    }));
   }, [isAutoGradingAssignment, students.data]);
   const rows: StudentsTableRow[] = useMemo(
     () =>
       (students.data?.students ?? []).map(
-        ({ annotation_metrics, ...rest }) => ({
+        ({ annotation_metrics, auto_grading_grade, ...rest }) => ({
+          current_grade: auto_grading_grade?.current_grade,
           ...rest,
           ...annotation_metrics,
         }),
@@ -154,7 +153,7 @@ export default function AssignmentActivity() {
 
     if (isAutoGradingAssignment) {
       firstColumns.push({
-        field: 'auto_grading_grade',
+        field: 'current_grade',
         label: 'Grade',
       });
     }
@@ -263,7 +262,7 @@ export default function AssignmentActivity() {
                   </span>
                 )
               );
-            case 'auto_grading_grade':
+            case 'current_grade':
               return (
                 <div
                   className={classnames(
@@ -273,7 +272,7 @@ export default function AssignmentActivity() {
                   )}
                 >
                   <GradeIndicator
-                    grade={stats.auto_grading_grade ?? 0}
+                    grade={stats.current_grade ?? 0}
                     annotations={stats.annotations}
                     replies={stats.replies}
                     config={assignment.data?.auto_grading_config}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -373,7 +373,7 @@ describe('AssignmentActivity', () => {
             label: 'Student',
           },
           {
-            field: 'auto_grading_grade',
+            field: 'current_grade',
             label: 'Grade',
           },
           {
@@ -407,8 +407,8 @@ describe('AssignmentActivity', () => {
       });
     });
 
-    [{ auto_grading_grade: undefined }, { auto_grading_grade: 25 }].forEach(
-      ({ auto_grading_grade }) => {
+    [{ current_grade: undefined }, { current_grade: 25 }].forEach(
+      ({ current_grade }) => {
         it('shows the grade for every student', () => {
           setUpFakeUseAPIFetch({
             ...activeAssignment,
@@ -419,10 +419,10 @@ describe('AssignmentActivity', () => {
           const item = wrapper
             .find('OrderableActivityTable')
             .props()
-            .renderItem({ auto_grading_grade }, 'auto_grading_grade');
+            .renderItem({ current_grade }, 'current_grade');
           const gradeIndicator = mount(item).find('GradeIndicator');
 
-          assert.equal(gradeIndicator.prop('grade'), auto_grading_grade ?? 0);
+          assert.equal(gradeIndicator.prop('grade'), current_grade ?? 0);
         });
       },
     );
@@ -471,12 +471,16 @@ describe('AssignmentActivity', () => {
             {
               display_name: 'a',
               h_userid: 'foo',
-              auto_grading_grade: 0.5,
+              auto_grading_grade: {
+                current_grade: 0.5,
+              },
             },
             {
               display_name: 'b',
               h_userid: 'bar',
-              auto_grading_grade: 0.87,
+              auto_grading_grade: {
+                current_grade: 0.87,
+              },
             },
             {
               display_name: 'c',


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


**Do not merge** This PR requires changes in the frontend to accept the new response shape from the metrics endpont.


This should enable the following in the FE/UI:

- Displaying a `new` badge or similar for grade which calculated grade
  is different that the last synced value.

- Only creating a GradeSyncGrade for grades that have changed from the
  last updated grade.


## Testing

- Check the response from the metrics endpoint:


```
curl 'http://localhost:8001/api/dashboard/students/metrics?assignment_id=121' \
  -H 'Accept: */*' \
  -H 'Authorization: Bearer ' \
  -H 'Cache-Control: no-cache' 
```

```
{"students": [{"h_userid": "acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is", "lms_id": "2a8a99bc095a8438a594cd57c1f4f0341951e360", "display_name": "Hypothesis 101 Student", "annotation_metrics": {"annotations": 0, "replies": 0, "last_activity": null}, "auto_grading_grade": {"current_grade": 0.0, "last_grade": null, "last_grade_date": null}}, {"h_userid": "acct:acea453480dde254bdf1c1058758e2@lms.hypothes.is", "lms_id": "42418adf1d4e99493adf6577d1ffcce2f89e3236", "display_name": "Leopold.Bloom (he/him)", "annotation_metrics": {"annotations": 0, "replies": 0, "last_activity": null}, "auto_grading_grade": {"current_grade": 0.0, "last_grade": 0.999, "last_grade_date": "2024-09-25T08:55:32.956830"}}]}
```


- Truncate all local existing grading sync grades.

```truncate grading_sync_grade;```

- Repeat the same curl, last grade info is now missing:


```
"auto_grading_grade": {"current_grade": 0.0, "last_grade": null, "last_grade_date": null}}
```

