### PR TITLE
Disable submission auto-creation while submitting grades to Canvas

### DIFF
--- a/lms/models/lti_registration.py
+++ b/lms/models/lti_registration.py
@@ -38,3 +38,13 @@ class LTIRegistration(CreatedUpdatedMixin, Base):
     application_instances = sa.orm.relationship(
         "ApplicationInstance", back_populates="lti_registration"
     )
+
+    @property
+    def product_family(self) -> str:
+        """To which LMS (Canvas, D2L, BB..) does this registration belong."""
+        from lms.product.family import Family  # noqa: PLC0415
+
+        if self.issuer.endswith(".instructure.com"):
+            return Family.CANVAS
+
+        return Family.UNKNOWN

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -1,10 +1,13 @@
-from typing import NotRequired, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from pyramid.request import Request
 
 from lms.js_config_types import AutoGradingConfig
-from lms.models import Assignment, LTIParams, LTIRegistration
+from lms.models import Assignment, LTIParams
 from lms.services.html_service import strip_html_tags
+
+if TYPE_CHECKING:
+    from lms.models import LTIRegistration
 
 
 class AssignmentConfig(TypedDict):
@@ -58,7 +61,7 @@ class MiscPlugin:
         """Check if the assignment of the current launch is gradable."""
         return bool(lti_params.get("lis_outcome_service_url"))
 
-    def get_ltia_aud_claim(self, lti_registration: LTIRegistration) -> str:
+    def get_ltia_aud_claim(self, lti_registration: "LTIRegistration") -> str:
         """Get the value of the `aud` claim used in LTI advantage requests."""
         return lti_registration.token_url
 

--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -107,6 +107,14 @@ class LTI13GradingService(LTIGradingService):
         taking all the necessary information as parameters.
         """
         payload = self._record_score_payload(score, user_grading_id, grade_timestamp)
+
+        if lti_registration.product_family == Family.CANVAS:
+            # By default Canvas calls to /score create a new submission
+            # Disable that behaviour and just submit the new grade.
+            # See: https://canvas.instructure.com/doc/api/score.html
+            payload["https://canvas.instructure.com/lti/submission"] = {
+                "new_submission": False
+            }
         return self._ltia_service.request(
             lti_registration,
             "POST",

--- a/tests/unit/lms/models/lti_registration_test.py
+++ b/tests/unit/lms/models/lti_registration_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from lms.product.family import Family
+from tests import factories
+
+
+class TestLTIRegistration:
+    @pytest.mark.parametrize(
+        "issuer,family",
+        [
+            ("SOMEURL", Family.UNKNOWN),
+            ("https://canvas.instructure.com", Family.CANVAS),
+        ],
+    )
+    def test_product_family(self, issuer, family):
+        assert factories.LTIRegistration(issuer=issuer).product_family == family

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -149,7 +149,11 @@ class TestLTI13GradingService:
 
         assert not svc.get_score_maximum(sentinel.resource_link_id)
 
-    def test_sync_grade(self, svc, ltia_http_service, lti_registration):
+    @pytest.mark.parametrize("is_canvas", [True, False])
+    def test_sync_grade(self, svc, ltia_http_service, lti_registration, is_canvas):
+        if is_canvas:
+            lti_registration.issuer = "https://canvas.instructure.com"
+
         response = svc.sync_grade(
             lti_registration,
             "LIS_OUTCOME_SERVICE_URL",
@@ -166,6 +170,11 @@ class TestLTI13GradingService:
             "activityProgress": "Completed",
             "gradingProgress": "FullyGraded",
         }
+        if is_canvas:
+            payload["https://canvas.instructure.com/lti/submission"] = {
+                "new_submission": False
+            }
+
         ltia_http_service.request.assert_called_once_with(
             lti_registration,
             "POST",


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647

See:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1727176677869349


## Testing

- Send a grade for `Hypothesis 101 Student` (`acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is`), which has many submissions

Check no new submission are created but the grade is updated in:

https://hypothesis.instructure.com/courses/319/gradebook/speed_grader?assignment_id=7296&student_id=35



- Send a grade for `jeremydean+student3@hypothes.is`, (`f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is`)  who doesn't have any submission.

No submissions are created but the grade does appear in speedgrader, see:

https://hypothesis.instructure.com/courses/319/gradebook/speed_grader?assignment_id=7296&student_id=85
