### PR TITLE
Fix grade calculation for scaled+separate auto-grading assignments

### DIFF
--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -93,8 +93,17 @@ class AutoGradingService:
                 assert (
                     auto_grading_config.required_replies is not None
                 ), "'separate' auto grade config with empty replies"
+                # Let's make sure we do not count annotations or replies above the requirement, otherwise, a person
+                # with 6 replies and 0 annotations on an assignment which requires 3 of each would get a 100% grade,
+                # instead of 50%
+                normalized_combined_count = min(
+                    annotation_metrics["annotations"],
+                    auto_grading_config.required_annotations,
+                ) + min(
+                    annotation_metrics["replies"], auto_grading_config.required_replies
+                )
                 grade = (
-                    combined_count
+                    normalized_combined_count
                     / (
                         auto_grading_config.required_annotations
                         + auto_grading_config.required_replies

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -57,6 +57,9 @@ class TestAutoGradingService:
             ("scaled", "cumulative", 15, None, 10, 10, 100),
             ("scaled", "separate", 10, 5, 8, 2, 66.67),
             ("scaled", "separate", 10, 5, 5, 1, 40),
+            # In scaled+separate cases, extra annos/replies should be ignored
+            ("scaled", "separate", 3, 2, 0, 3, 40),
+            ("scaled", "separate", 5, 5, 12, 2, 70),
         ],
     )
     def test_calculate_grade(


### PR DESCRIPTION
I noticed the auto-grading grade could be incorrectly calculated when an assignment is configured with scaled and separate calculation, and a user provides more annotations and/or replies than required.

Those would end up being taken into consideration for the total, making a user with, let's say 6 annotations and 0 replies, get a 100% when 3 annotations and 3 replies are required, instead of 50%.

![image](https://github.com/user-attachments/assets/be4f961e-edc3-417d-a2dc-663d6fe6af01)

This PR changes the logic to make sure "extra" annotations/replies are not counted when calculating the grade.

