### PR TITLE
Make sure usePolledAPIFetch does not continue polling in case of error

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
@@ -42,7 +42,8 @@ export default function SyncGradesButton({
     params: lastSyncParams,
     // Keep polling as long as sync is in progress
     shouldRefresh: result =>
-      !result.data || ['scheduled', 'in_progress'].includes(result.data.status),
+      !!result.data &&
+      ['scheduled', 'in_progress'].includes(result.data.status),
   });
 
   const buttonContent = useMemo(() => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
@@ -77,7 +77,7 @@ describe('SyncGradesButton', () => {
   [
     {
       fetchResult: { data: null },
-      expectedResult: true,
+      expectedResult: false,
     },
     {
       fetchResult: {


### PR DESCRIPTION
This PR fixes a bug I introduced in a last-minute change in https://github.com/hypothesis/lms/pull/6700.

Basically, I made it refresh requests that have failed when using `usePolledAPIFetch`, so it never transitions to an error state, but also never consideres it should no longer refresh, causing the polling to continue forever.