### PR TITLE
Display a more human-friendly text in disabled segments filter

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -3,6 +3,7 @@ import {
   LinkButton,
   MultiSelect,
 } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import type { MutableRef } from 'preact/hooks';
 import { useMemo } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
@@ -131,13 +132,15 @@ function StudentOption({
 function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
   const segmentsName = segments.type === 'groups' ? 'groups' : 'sections';
   const segmentNameSingular = segments.type === 'groups' ? 'group' : 'section';
-  const allSegmentsText =
-    segments.type === 'none' ? 'N/A' : `All ${segmentsName}`;
+  const isNoneType = segments.type === 'none';
+  const allSegmentsText = isNoneType
+    ? 'No sections/groups'
+    : `All ${segmentsName}`;
 
   return (
     <MultiSelect
       aria-label={`Select ${segmentsName}`}
-      containerClasses="!w-auto min-w-[180px]"
+      containerClasses={classnames('!w-auto', { 'min-w-44': !isNoneType })}
       value={segments.selectedIds}
       onChange={newSegmentIds => segments.onChange(newSegmentIds)}
       disabled={segments.entries.length === 0}

--- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
@@ -96,7 +96,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
       value={value}
       onChange={onChange}
       aria-label={`Select ${entity}`}
-      containerClasses="!w-auto min-w-[180px]"
+      containerClasses="!w-auto min-w-44"
       buttonContent={buttonContent}
       data-testid={`${entity}-select`}
       onListboxScroll={e => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -581,7 +581,7 @@ describe('DashboardActivityFilters', () => {
       // "None" type
       {
         segmentsConfig: { type: 'none' },
-        expectedButtonContent: 'N/A',
+        expectedButtonContent: 'No sections/groups',
       },
       // 1 known selected item
       {


### PR DESCRIPTION
This PR improves https://github.com/hypothesis/lms/pull/6704, by adding a more human-friendly text in segments filter when it is displayed disabled because the assignment doesn't have groups or sections.

The provisional text was `N/A`, but this PR changes it to `No sections/groups`.

Additionally, we make sure that dropdown takes as little space as possible when it is displayed disabled.

![image](https://github.com/user-attachments/assets/d92bc146-a0dc-4e6b-abef-4a9a70b8d3d5)