### PR TITLE
Return current auto-grading grades as a value from 0 to 1

### DIFF
--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -80,7 +80,7 @@ class AutoGradingService:
     ) -> float:
         """Calculate auto grades based on the config and the number of annotations made.
 
-        The results is a 100 based float rounded to two decimals.
+        The results is a float from 0 to 1, rounded to two decimals.
         """
         combined_count = (
             annotation_metrics["annotations"] + annotation_metrics["replies"]
@@ -93,7 +93,7 @@ class AutoGradingService:
         ):
             case ("all_or_nothing", "cumulative"):
                 if combined_count >= auto_grading_config.required_annotations:
-                    grade = 100
+                    grade = 1
                 else:
                     grade = 0
             case ("all_or_nothing", "separate"):
@@ -106,12 +106,12 @@ class AutoGradingService:
                     and annotation_metrics["replies"]
                     >= auto_grading_config.required_replies
                 ):
-                    grade = 100
+                    grade = 1
                 else:
                     grade = 0
 
             case ("scaled", "cumulative"):
-                grade = combined_count / auto_grading_config.required_annotations * 100
+                grade = combined_count / auto_grading_config.required_annotations
 
             case ("scaled", "separate"):
                 assert (
@@ -126,18 +126,14 @@ class AutoGradingService:
                 ) + min(
                     annotation_metrics["replies"], auto_grading_config.required_replies
                 )
-                grade = (
-                    normalized_combined_count
-                    / (
-                        auto_grading_config.required_annotations
-                        + auto_grading_config.required_replies
-                    )
-                    * 100
+                grade = normalized_combined_count / (
+                    auto_grading_config.required_annotations
+                    + auto_grading_config.required_replies
                 )
             case _:
                 raise ValueError("Unknown auto grading configuration")
 
-        grade = min(100, grade)  # Proportional grades are capped at 100%
+        grade = min(1, grade)  # Proportional grades are capped at 1
         return round(grade, 2)
 
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 
 export type GradeStatusChipProps = {
   /**
-   * A grade, from 0 to 100, that will be used to render the corresponding
+   * A grade, from 0 to 1, that will be used to render the corresponding
    * color combination.
    */
   grade: number;
@@ -10,35 +10,35 @@ export type GradeStatusChipProps = {
 
 /**
  * A badge where the corresponding color combination is calculated from a grade
- * from 0 to 100, following the next table:
+ * from 0 to 1, following the next table:
  *
- *  100   - bright green
- *  80-99 - light green
- *  50-79 - yellow
- *  1-49  - light red
- *  0     - bright red
- *  other - grey
+ *  1        - bright green
+ *  0.8-0.99 - light green
+ *  0.5-0.79 - yellow
+ *  0.1-0.49 - light red
+ *  0        - bright red
+ *  other    - grey
  */
 export default function GradeStatusChip({ grade }: GradeStatusChipProps) {
-  const gradeIsInvalid = grade < 0 || grade > 100;
+  const gradeIsInvalid = grade < 0 || grade > 1;
 
   return (
     <div
       className={classnames(
         'rounded inline-block font-bold px-2 py-0.5 cursor-default',
         {
-          'bg-grade-success text-white': grade === 100,
+          'bg-grade-success text-white': grade === 1,
           'bg-grade-success-light text-grade-success':
-            grade >= 80 && grade < 100,
+            grade >= 0.8 && grade < 1,
           'bg-grade-warning-light text-grade-warning':
-            grade >= 50 && grade < 80,
-          'bg-grade-error-light text-grade-error': grade >= 1 && grade < 50,
+            grade >= 0.5 && grade < 0.8,
+          'bg-grade-error-light text-grade-error': grade > 0 && grade < 0.5,
           'bg-grade-error text-white': grade === 0,
           'bg-grey-3 text-grey-7': gradeIsInvalid,
         },
       )}
     >
-      {grade}
+      {grade * 100}
       {!gradeIsInvalid && '%'}
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
@@ -106,13 +106,7 @@ export default function SyncGradesButton({
       path: syncURL,
       method: 'POST',
       data: {
-        grades: (studentsToSync ?? []).map(({ grade, h_userid }) => ({
-          h_userid,
-          // FIXME This will be fixed separately, but the BE is currently
-          //  returning grades from 0 to 100, but expects them to be sent back
-          //  from 0 to 1.
-          grade: grade / 100,
-        })),
+        grades: studentsToSync,
       },
     }).catch(() => setSchedulingSyncFailed(true));
 

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeStatusChip-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeStatusChip-test.js
@@ -8,17 +8,17 @@ describe('GradeStatusChip', () => {
     return mount(<GradeStatusChip grade={grade} />);
   }
 
-  [0, 20, 48, 77, 92, 100].forEach(grade => {
+  [0, 0.2, 0.48, 0.77, 0.92, 1].forEach(grade => {
     it('renders valid grades as percentage', () => {
       const wrapper = renderComponent(grade);
-      assert.equal(wrapper.text(), `${grade}%`);
+      assert.equal(wrapper.text(), `${grade * 100}%`);
     });
   });
 
-  [-20, 150].forEach(grade => {
+  [-2, 2].forEach(grade => {
     it('renders invalid grades verbatim', () => {
       const wrapper = renderComponent(grade);
-      assert.equal(wrapper.text(), `${grade}`);
+      assert.equal(wrapper.text(), `${grade * 100}`);
     });
   });
 
@@ -27,19 +27,19 @@ describe('GradeStatusChip', () => {
     checkAccessibility([
       {
         name: '100',
-        content: () => renderComponent(100),
+        content: () => renderComponent(1),
       },
       {
         name: '80',
-        content: () => renderComponent(80),
+        content: () => renderComponent(0.8),
       },
       {
         name: '68',
-        content: () => renderComponent(68),
+        content: () => renderComponent(0.68),
       },
       {
         name: '38',
-        content: () => renderComponent(38),
+        content: () => renderComponent(0.38),
       },
       {
         name: '0',
@@ -47,11 +47,11 @@ describe('GradeStatusChip', () => {
       },
       {
         name: '-20',
-        content: () => renderComponent(-20),
+        content: () => renderComponent(-0.2),
       },
       {
         name: '150',
-        content: () => renderComponent(150),
+        content: () => renderComponent(1.5),
       },
     ]),
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
@@ -16,8 +16,8 @@ describe('SyncGradesButton', () => {
   let shouldRefreshCallback;
 
   const studentsToSync = [
-    { h_userid: '123', grade: 50 },
-    { h_userid: '456', grade: 20 },
+    { h_userid: '123', grade: 0.5 },
+    { h_userid: '456', grade: 0.2 },
   ];
 
   beforeEach(() => {

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -123,7 +123,6 @@ class UserViews:
         """Fetch the stats for one particular assignment."""
         assignment = self.dashboard_service.get_request_assignment(self.request)
 
-        request_h_userids = self.request.parsed_params.get("h_userids")
         request_segment_authority_provided_ids = self.request.parsed_params.get(
             "segment_authority_provided_ids"
         )

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -84,16 +84,16 @@ class TestAutoGradingService:
         "grading_type,activity_calculation,required_annotations, required_replies,annotations,replies,expected_grade",
         [
             ("all_or_nothing", "cumulative", 15, None, 5, 5, 0),
-            ("all_or_nothing", "cumulative", 15, None, 10, 6, 100),
+            ("all_or_nothing", "cumulative", 15, None, 10, 6, 1),
             ("all_or_nothing", "separate", 10, 5, 10, 4, 0),
-            ("all_or_nothing", "separate", 10, 5, 10, 5, 100),
-            ("scaled", "cumulative", 15, None, 5, 5, 66.67),
-            ("scaled", "cumulative", 15, None, 10, 10, 100),
-            ("scaled", "separate", 10, 5, 8, 2, 66.67),
-            ("scaled", "separate", 10, 5, 5, 1, 40),
+            ("all_or_nothing", "separate", 10, 5, 10, 5, 1),
+            ("scaled", "cumulative", 15, None, 5, 5, 0.67),
+            ("scaled", "cumulative", 15, None, 10, 10, 1),
+            ("scaled", "separate", 10, 5, 8, 2, 0.67),
+            ("scaled", "separate", 10, 5, 5, 1, 0.4),
             # In scaled+separate cases, extra annos/replies should be ignored
-            ("scaled", "separate", 3, 2, 0, 3, 40),
-            ("scaled", "separate", 5, 5, 12, 2, 70),
+            ("scaled", "separate", 3, 2, 0, 3, 0.4),
+            ("scaled", "separate", 5, 5, 12, 2, 0.7),
         ],
     )
     def test_calculate_grade(


### PR DESCRIPTION
This PR updates how grades are calculated and exposed by the BE, so that it's always a value from 0 to 1 instead of a value from 0 to 100, making it consistent to how grades are handled in other contexts.

Additionally, the FE is adjusted to ensure it also handles values from 0 to 1, and only when representing the grade in the UI it is converted to a value from 0 to 100.

The behavior and how values are shown in the UI should not have changed compared to `main`. 