### PR TITLE
Remove existing auto grading config when reconfiguring assignments

### DIFF
--- a/lms/views/dashboard/pagination.py
+++ b/lms/views/dashboard/pagination.py
@@ -98,7 +98,6 @@ class PaginationParametersMixin(PyramidRequestSchema):
                 "Invalid value for pagination cursor. Cursor must be a list of at least two values."
             )
         if [type(v) for v in in_data["cursor"]] not in [[str, int], [NoneType, int]]:
-            print([type(v) for v in in_data["cursor"]])
             raise ValidationError(
                 "Invalid value for pagination cursor. Cursor must be a [str | None, int] list."
             )

--- a/tests/unit/lms/views/dashboard/pagination_test.py
+++ b/tests/unit/lms/views/dashboard/pagination_test.py
@@ -47,7 +47,7 @@ class TestGetPage:
 
     def test_it_filters_by_cursor(self, pyramid_request, db_session):
         courses = factories.Course.create_batch(5)
-        query = select(Course)
+        query = select(Course).order_by(Course.id)
         db_session.flush()
         pyramid_request.parsed_params = {
             "cursor": [courses[0].id, courses[0].lms_name],
@@ -61,7 +61,7 @@ class TestGetPage:
     def test_it_filters_by_cursor_allows_nullable(self, pyramid_request, db_session):
         students = factories.User.create_batch(5)
         students[0].display_name = None
-        query = select(User)
+        query = select(User).order_by(User.id)
         db_session.flush()
         pyramid_request.parsed_params = {
             "cursor": [None, students[0].id],


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


This allows to edit assignments to no longer use auto grading.


## Testing

- Edit https://hypothesis.instructure.com/courses/319/assignments/7296, don't use the auto grading option.

- Open the dashboard, no auto grading column.

- Edit https://hypothesis.instructure.com/courses/319/assignments/7296, enable auto grading, open the dashboard. See the grading column now.
