### PR TITLE
Better error message when not grading sync exists yet for an assignment

### DIFF
--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -1,7 +1,6 @@
 import logging
 
 from marshmallow import Schema, fields, validate
-from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy import select
 
@@ -89,7 +88,8 @@ class DashboardGradingViews:
         if grading_sync := self.auto_grading_service.get_last_sync(assignment):
             return {"status": grading_sync.status}
 
-        raise HTTPNotFound()
+        self.request.response.status_int = 404
+        return {"message": f"No existing grading sync for assignment:{assignment.id}"}
 
     @staticmethod
     def _start_sync_grades(_request) -> None:

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from pyramid.httpexceptions import HTTPNotFound
 
 from lms.views.dashboard.api.grading import DashboardGradingViews
 from tests import factories
@@ -109,11 +108,15 @@ class TestDashboardGradingViews:
             "status": auto_grading_service.get_last_sync.return_value.status
         }
 
-    def test_get_grading_sync_not_found(self, auto_grading_service, views):
+    def test_get_grading_sync_not_found(
+        self, auto_grading_service, views, pyramid_request
+    ):
         auto_grading_service.get_last_sync.return_value = None
 
-        with pytest.raises(HTTPNotFound):
-            views.get_grading_sync()
+        response = views.get_grading_sync()
+
+        pyramid_request.response.status_int = 404
+        assert response["message"].startswith("No existing grading sync")
 
     def test__start_sync_grades(self, sync_grades, views, pyramid_request):
         views._start_sync_grades(pyramid_request)  # noqa: SLF001


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647

The previous error was very confusing as it was the same as for a non-existing endpoint both on the response to the client and the logging in the console.


## Testing

- Remove your local syncs `truncate grading_sync cascade;`
- Try to get the sync for an assignment

```
curl 'http://localhost:8001/api/dashboard/assignments/121/grading/sync' -X GET \
  -H 'Accept: */*' \
  -H "Content-Type: application/json" \
  -H 'Authorization: Bearer TOKEN'
```

```{"message": "No existing grading sync for assignment:121"}%```
