### PR TITLE
Fix query for getting an assignment's last grades

### DIFF
--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -63,7 +63,7 @@ class AutoGradingService:
             select(GradingSyncGrade)
             .distinct(LMSUser.h_userid)
             .join(GradingSync)
-            .join(LMSUser)
+            .join(LMSUser, GradingSyncGrade.lms_user_id == LMSUser.id)
             .where(
                 GradingSync.assignment_id == assignment.id,
                 GradingSyncGrade.success == success,


### PR DESCRIPTION
Explicitly set the join condition with LMSUser. SQLAlhcemy was assuming

`GradingSync.created_by = LMSUser`

Instead of the desired:

`GradingSyncGrade.lms_user = LMSuser`

Changing the order of the join statement in the query would also fix the problem but it's an easy detail to miss, adding the join condition explicitly instead.