### PR TITLE
Add missing constraints on GradingSync and GradingSyncGrade

### DIFF
--- a/lms/migrations/versions/aea9bbeee574_constrains_for_grading_sync_tables.py
+++ b/lms/migrations/versions/aea9bbeee574_constrains_for_grading_sync_tables.py
@@ -1,0 +1,35 @@
+"""Constrains for grading sync tables."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "aea9bbeee574"
+down_revision = "f68aacfc62c7"
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix__grading_sync_assignment_status_unique",
+        "grading_sync",
+        ["assignment_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('scheduled', 'in_progress')"),
+    )
+    op.create_unique_constraint(
+        op.f("uq__grading_sync_grade__grading_sync_id"),
+        "grading_sync_grade",
+        ["grading_sync_id", "lms_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("uq__grading_sync_grade__grading_sync_id"),
+        "grading_sync_grade",
+        type_="unique",
+    )
+    op.drop_index(
+        "ix__grading_sync_assignment_status_unique",
+        table_name="grading_sync",
+        postgresql_where=sa.text("status IN ('scheduled', 'in_progress')"),
+    )

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -51,12 +51,23 @@ class TestAutoGradingService:
         student_2 = factories.LMSUser()
         instructor = factories.LMSUser()
 
-        sync = factories.GradingSync(assignment=assignment, created_by=instructor)
-        older_sync = factories.GradingSync(assignment=assignment, created_by=instructor)
+        sync_1 = factories.GradingSync(
+            assignment=assignment, created_by=instructor, status="finished"
+        )
+        sync_2 = factories.GradingSync(
+            assignment=assignment, created_by=instructor, status="finished"
+        )
+        sync_3 = factories.GradingSync(
+            assignment=assignment, created_by=instructor, status="finished"
+        )
+
+        older_sync = factories.GradingSync(
+            assignment=assignment, created_by=instructor, status="finished"
+        )
 
         # Not successful
         factories.GradingSyncGrade(
-            grading_sync=sync,
+            grading_sync=sync_1,
             lms_user=student_1,
             success=False,
             updated=datetime(2025, 1, 1),
@@ -64,14 +75,14 @@ class TestAutoGradingService:
         )
         # Old
         factories.GradingSyncGrade(
-            grading_sync=sync,
+            grading_sync=sync_2,
             lms_user=student_1,
             success=True,
             updated=datetime(2023, 1, 1),
             grade=2,
         )
         factories.GradingSyncGrade(
-            grading_sync=sync,
+            grading_sync=sync_3,
             lms_user=student_1,
             success=True,
             updated=datetime(2024, 1, 1),


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647

---


- Allow just one pending sync per assignment
- Allow just one grade per student/sync

## Testing

- Remove all existing data

```truncate grading_sync cascade;```

- Insert one scheduled grading sync (IDs will need adjusting on local different environments) 


```insert into grading_sync (assignment_id, created_by_id, status) values (84, 1251, 'scheduled');```



- Try the same thing again, you'll hit the constraint:


```
ERROR:  duplicate key value violates unique constraint "ix__grading_sync_assignment_status_unique"
DETAIL:  Key (assignment_id)=(84) already exists.
```

- Same error if we try with an `in_progress`

`insert into grading_sync (assignment_id, created_by_id, status) values (84, 1251, 'in_progress');`



- But it's fine to insert a failed or finished one;

```
postgres=# insert into grading_sync (assignment_id, created_by_id, status) values (84, 1251, 'finished');
INSERT 0 1
postgres=# insert into grading_sync (assignment_id, created_by_id, status) values (84, 1251, 'failed');
INSERT 0 1
```