### PR TITLE
Take an explicit application instance on the OAuth1 client

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -82,7 +82,7 @@ def includeme(config):
         "lms.services.group_info.GroupInfoService", name="group_info"
     )
     config.register_service_factory("lms.services.lti_h.LTIHService", name="lti_h")
-    config.register_service_factory("lms.services.oauth1.OAuth1Service", name="oauth1")
+    config.register_service_factory("lms.services.oauth1.factory", name="oauth1")
     config.register_service_factory(
         "lms.services.course.course_service_factory", name="course"
     )

--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -2,6 +2,7 @@ from xml.parsers.expat import ExpatError
 
 import xmltodict
 
+from lms.models import ApplicationInstance
 from lms.services.exceptions import ExternalRequestError, StudentNotInCourse
 from lms.services.http import HTTPService
 from lms.services.lti_grading.interface import GradingResult, LTIGradingService
@@ -11,11 +12,16 @@ from lms.services.oauth1 import OAuth1Service
 class LTI11GradingService(LTIGradingService):
     #  See: LTI1.1 Outcomes https://www.imsglobal.org/specs/ltiomv1p0/specification
     def __init__(
-        self, line_item_url, http_service: HTTPService, oauth1_service: OAuth1Service
+        self,
+        line_item_url,
+        http_service: HTTPService,
+        oauth1_service: OAuth1Service,
+        application_instance: ApplicationInstance,
     ):
         super().__init__(line_item_url, None)
         self.http_service = http_service
         self.oauth1_service = oauth1_service
+        self.application_instance = application_instance
 
     def read_result(self, grading_id) -> GradingResult:
         result = GradingResult(score=None, comment=None)
@@ -73,7 +79,7 @@ class LTI11GradingService(LTIGradingService):
                 url=self.line_item_url,
                 data=xml_body,
                 headers={"Content-Type": "application/xml"},
-                auth=self.oauth1_service.get_client(),
+                auth=self.oauth1_service.get_client(self.application_instance),
             )
         except ExternalRequestError as err:
             err.message = "Error calling LTI Outcomes service"

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -23,4 +23,5 @@ def service_factory(_context, request):
         line_item_url=request.parsed_params.get("lis_outcome_service_url"),
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
+        application_instance=request.lti_user.application_instance,
     )

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -239,8 +239,6 @@ class DeepLinkingFieldsViews:
         if title := assignment_configuration.get("title"):
             content_item["title"] = title
 
-        oauth1_service = self.request.find_service(name="oauth1")
-
         payload = {
             "content_items": json.dumps(
                 {
@@ -256,8 +254,11 @@ class DeepLinkingFieldsViews:
             # An opaque value which should be returned by the TP in its response.
             payload["data"] = data
 
-        return oauth1_service.sign(
-            self.request.parsed_params["content_item_return_url"], "post", payload
+        return self.request.find_service(name="oauth1").sign(
+            self.request.lti_user.application_instance,
+            self.request.parsed_params["content_item_return_url"],
+            "post",
+            payload,
         )
 
     @staticmethod

--- a/tests/unit/lms/services/__init___test.py
+++ b/tests/unit/lms/services/__init___test.py
@@ -8,7 +8,6 @@ from lms.services.group_info import GroupInfoService
 from lms.services.h_api import HAPI
 from lms.services.launch_verifier import LaunchVerifier
 from lms.services.lti_h import LTIHService
-from lms.services.oauth1 import OAuth1Service
 
 
 class TestIncludeme:
@@ -20,7 +19,6 @@ class TestIncludeme:
             ("grading_info", GradingInfoService),
             ("group_info", GroupInfoService),
             ("lti_h", LTIHService),
-            ("oauth1", OAuth1Service),
         ),
     )
     def test_it_has_the_expected_service_by_name(

--- a/tests/unit/lms/services/lti_grading/_v11_test.py
+++ b/tests/unit/lms/services/lti_grading/_v11_test.py
@@ -187,8 +187,10 @@ class TestLTI11GradingService:
         return getattr(svc, request.param)
 
     @pytest.fixture
-    def svc(self, oauth1_service, http_service):
-        return LTI11GradingService(sentinel.service_url, http_service, oauth1_service)
+    def svc(self, oauth1_service, http_service, application_instance):
+        return LTI11GradingService(
+            sentinel.service_url, http_service, oauth1_service, application_instance
+        )
 
 
 class GradingResponse(dict):

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -14,7 +14,10 @@ class TestFactory:
         svc = service_factory(sentinel.context, pyramid_request)
 
         LTI11GradingService.assert_called_once_with(
-            sentinel.grading_url, http_service, oauth1_service
+            sentinel.grading_url,
+            http_service,
+            oauth1_service,
+            pyramid_request.lti_user.application_instance,
         )
         assert svc == LTI11GradingService.return_value
 

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -209,6 +209,7 @@ class TestDeepLinkingFieldsView:
         title,
         opaque_data_lti11,
         oauth1_service,
+        application_instance,
     ):
         misc_plugin.get_deeplinking_launch_url.return_value = "LAUNCH_URL"
         pyramid_request.parsed_params["opaque_data_lti11"] = opaque_data_lti11
@@ -252,7 +253,7 @@ class TestDeepLinkingFieldsView:
             expected_fields["data"] = opaque_data_lti11
 
         oauth1_service.sign.assert_called_once_with(
-            sentinel.return_url, "post", expected_fields
+            application_instance, sentinel.return_url, "post", expected_fields
         )
         assert fields == oauth1_service.sign.return_value
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


We need to merge the interfaces of v11 and v13 again for both to support the auto grading features.

The main difference is supporting sending grades for any applications instance, not the AI of a the current logged in user.


The first step here is to take an arbitrary AI on the oauth1 service. 


## Testing

#### Deep linking

- [Re deeplink this assignment](https://hypothesis.instructure.com/courses/125/assignments/7412/edit?name=Assignment%20creation%20-%20test%20&due_at=&points_possible=0)


#### Grading 


- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3350/View
- We'll hit the grading API to fetch the score max:


```
Score maximum for F7373A6B-A469-426E-8F99-138CEF897E95-2545_6782: None
```

and also to read the current grade.

- Hit the API again to record a new grade 


