### PR TITLE
Display last time grades were synced

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -147,8 +147,13 @@ export type YouTubeVideoInfo = {
  * Dashboard-related API types
  */
 
+/**
+ * Represents dates exposed by the backend as string, in ISO 8601 format
+ */
+export type ISODateTime = string;
+
 export type AnnotationMetrics = {
-  last_activity: string | null;
+  last_activity: ISODateTime | null;
   annotations: number;
   replies: number;
 };
@@ -163,7 +168,7 @@ export type Course = {
 
 export type CourseMetrics = {
   assignments: number;
-  last_launched: string | null;
+  last_launched: ISODateTime | null;
 };
 
 export type CourseWithMetrics = Course & {
@@ -181,7 +186,7 @@ export type Assignment = {
   id: number;
   title: string;
   /** Date in which the assignment was created, in ISO format */
-  created: string;
+  created: ISODateTime;
 };
 
 export type Student = {
@@ -196,7 +201,7 @@ export type AutoGradingGrade = {
   /** Grade that was last synced, if any */
   last_grade: number | null;
   /** When did the last grade sync happen, if any */
-  last_grade_date: number | null;
+  last_grade_date: ISODateTime | null;
 };
 
 export type StudentWithMetrics = Student & {
@@ -302,9 +307,37 @@ export type StudentsResponse = {
   pagination: Pagination;
 };
 
+export type StudentGradingSyncStatus = 'in_progress' | 'finished' | 'failed';
+
+export type StudentGradingSync = {
+  h_userid: string;
+  status: StudentGradingSyncStatus;
+};
+
+export type GradingSyncStatus = 'scheduled' | StudentGradingSyncStatus;
+
 /**
  * Response for `/api/dashboard/assignments/{assignment_id}/grading/sync`
+ * That endpoint returns a 404 when an assignment has never been synced.
  */
 export type GradingSync = {
-  status: 'scheduled' | 'in_progress' | 'finished' | 'failed';
+  /**
+   * Global sync status.
+   * If at least one student grade is syncing, this will be `in_progress`.
+   * If at least one student grade failed, this will be `failed`.
+   * If all student grades finished successfully, this will be `finished`.
+   */
+  status: GradingSyncStatus;
+
+  /**
+   * The date and time when syncing grades finished.
+   * It is null as long as status is `scheduled` or `in_progress`.
+   */
+  finish_date: ISODateTime | null;
+
+  /**
+   * Grading status for every individual student that was scheduled as part of
+   * this sync.
+   */
+  grades: StudentGradingSync[];
 };

--- a/lms/static/scripts/frontend_apps/components/RelativeTime.tsx
+++ b/lms/static/scripts/frontend_apps/components/RelativeTime.tsx
@@ -1,0 +1,38 @@
+import {
+  decayingInterval,
+  formatRelativeDate,
+  formatDateTime,
+} from '@hypothesis/frontend-shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+export type RelativeTimeProps = {
+  /** The reference date-time, in ISO format */
+  dateTime: string;
+};
+
+/**
+ * Displays a date as a time relative to `now`, making sure it is updated at
+ * appropriate intervals
+ */
+export default function RelativeTime({ dateTime }: RelativeTimeProps) {
+  const [now, setNow] = useState(() => new Date());
+  const absoluteDate = useMemo(
+    () => formatDateTime(dateTime, { includeWeekday: true }),
+    [dateTime],
+  );
+  const relativeDate = useMemo(
+    () => formatRelativeDate(new Date(dateTime), now),
+    [dateTime, now],
+  );
+
+  // Refresh relative timestamp, at a frequency appropriate for the age.
+  useEffect(() => {
+    return decayingInterval(dateTime, () => setNow(new Date()));
+  }, [dateTime]);
+
+  return (
+    <time dateTime={dateTime} title={absoluteDate}>
+      {relativeDate}
+    </time>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
@@ -51,7 +51,7 @@ export default function DashboardBreadcrumbs({
 
   return (
     <div
-      className="flex flex-row gap-0.5 w-full font-semibold"
+      className="flex flex-row gap-0.5 grow font-semibold"
       data-testid="breadcrumbs-container"
     >
       {linksWithHome.map(({ title, href }, index) => {

--- a/lms/static/scripts/frontend_apps/components/test/RelativeTime-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/RelativeTime-test.js
@@ -1,0 +1,74 @@
+import { checkAccessibility } from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+import { act } from 'preact/test-utils';
+
+import RelativeTime, { $imports } from '../RelativeTime';
+
+describe('RelativeTime', () => {
+  let clock;
+  let fakeFormatDateTime;
+  let fakeFormatRelativeDate;
+  let fakeDecayingInterval;
+  const dateTime = '2015-05-10T20:18:56.613388+00:00';
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+
+    fakeFormatDateTime = sinon.stub().returns('absolute date');
+    fakeFormatRelativeDate = sinon.stub().returns('relative date');
+    fakeDecayingInterval = sinon.stub();
+
+    $imports.$mock({
+      '@hypothesis/frontend-shared': {
+        formatDateTime: fakeFormatDateTime,
+        formatRelativeDate: fakeFormatRelativeDate,
+        decayingInterval: fakeDecayingInterval,
+      },
+    });
+  });
+
+  afterEach(() => {
+    clock.restore();
+    $imports.$restore();
+  });
+
+  function createComponent() {
+    return mount(<RelativeTime dateTime={dateTime} />);
+  }
+
+  it('sets initial time values', () => {
+    const wrapper = createComponent();
+    const time = wrapper.find('time');
+
+    assert.equal(time.prop('title'), 'absolute date');
+    assert.equal(time.prop('dateTime'), dateTime);
+    assert.equal(wrapper.text(), 'relative date');
+  });
+
+  it('is updated after time passes', () => {
+    fakeDecayingInterval.callsFake((date, callback) => {
+      const id = setTimeout(callback, 10);
+      return () => clearTimeout(id);
+    });
+    const wrapper = createComponent();
+    fakeFormatRelativeDate.returns('60 jiffies');
+
+    act(() => {
+      clock.tick(1000);
+    });
+    wrapper.update();
+
+    assert.equal(wrapper.text(), '60 jiffies');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => {
+        // Fake timers break axe-core.
+        clock.restore();
+        return createComponent();
+      },
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -217,7 +217,7 @@ export function useAPIFetch<T = unknown>(
 
 export type PolledAPIFetchOptions<T> = {
   /** Path for API call */
-  path: string;
+  path: string | null;
   /** Query params for API call */
   params?: QueryParams;
   /** Determines if, based on the result, the API should be called again */

--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -1,10 +1,12 @@
 import logging
+from datetime import UTC
 
 from marshmallow import Schema, fields, validate
 from pyramid.view import view_config
 from sqlalchemy import select
 
 from lms.models import GradingSync, LMSUser
+from lms.models.grading_sync import AutoGradingSyncStatus
 from lms.security import Permissions
 from lms.services import AutoGradingService
 from lms.services.dashboard import DashboardService
@@ -102,6 +104,10 @@ class DashboardGradingViews:
     def _serialize_grading_sync(grading_sync: GradingSync) -> dict:
         return {
             "status": grading_sync.status,
+            "finish_date": grading_sync.updated.replace(tzinfo=UTC).isoformat()
+            if grading_sync.status
+            in {AutoGradingSyncStatus.FINISHED, AutoGradingSyncStatus.FAILED}
+            else None,
             "grades": [
                 {
                     "h_userid": grade.lms_user.h_userid,


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6712 and https://github.com/hypothesis/lms/pull/6742

For auto-grading assignments, display the relative date in which last sync occurred.

![image](https://github.com/user-attachments/assets/79f1891f-7f80-4e9e-b5b3-14cf45f45c58)

Additionally, this PR refactors the `SyncGradesButton` so that the result of fetching current sync status is passed to it from the parent component. That way we can use that for the component displaying the last sync date, and eventually, in the students metrics table, to display individual syncing and error statuses.

This has the side effect that a few code blocks and tests have been moved from `SyncGradesButton/-test` to `AssignmentActivity/-test`.

### Considerations

There was some discussion around what date should be displayed as "last synced". At some point we considered exposing the date of the last non-in-progress sync so that we can display that while a sync is in progress, but modeling that turned out to be a bit cumbersome.

Instead, we have decided to go simple for now, expose the date that the last sync was finished (as long as it's not in progress), and display a placeholder when a sync is in progress. Something in these lines:

https://github.com/user-attachments/assets/5bc57976-7c7a-4257-8cbf-609ad30931b6

This may eventually change though, but I decided to push that decision forward for now.

You can see the overall discussion in slack: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1727684801551909

### Todo

- [x] Use clock icon. Current one is a placeholder.
- [x] Display relative times with the formatted date as `title` attribute.
- [x] Add tests