### PR TITLE
Expose individual grade status

### DIFF
--- a/lms/models/grading_sync.py
+++ b/lms/models/grading_sync.py
@@ -58,3 +58,14 @@ class GradingSyncGrade(CreatedUpdatedMixin, Base):
 
     success: Mapped[bool | None] = mapped_column()
     """Whether or not this grade has been synced to the LMS"""
+
+    @property
+    def status(self) -> AutoGradingSyncStatus:
+        if self.success is None:
+            return AutoGradingSyncStatus.IN_PROGRESS
+
+        return (
+            AutoGradingSyncStatus.FINISHED
+            if self.success
+            else AutoGradingSyncStatus.FAILED
+        )

--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -1,4 +1,5 @@
 from sqlalchemy import select
+from sqlalchemy.orm import subqueryload
 
 from lms.js_config_types import AnnotationMetrics
 from lms.models import (
@@ -49,7 +50,13 @@ class AutoGradingService:
         return grading_sync
 
     def _search_query(self, assignment, statuses: list[str] | None = None):
-        query = select(GradingSync).where(GradingSync.assignment_id == assignment.id)
+        query = (
+            select(GradingSync)
+            .where(GradingSync.assignment_id == assignment.id)
+            .options(
+                subqueryload(GradingSync.grades).subqueryload(GradingSyncGrade.lms_user)
+            )
+        )
         if statuses:
             query = query.where(GradingSync.status.in_(statuses))
 

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from h_matchers import Any
 
 from lms.views.dashboard.api.grading import DashboardGradingViews
 from tests import factories
@@ -87,15 +88,22 @@ class TestDashboardGradingViews:
             {student_1: 0.5, student_2: 1},
         )
         assert response == {
-            "status": auto_grading_service.create_grade_sync.return_value.status
+            "status": auto_grading_service.create_grade_sync.return_value.status,
+            "grades": [],
         }
         pyramid_request.add_finished_callback.assert_called_once_with(
             views._start_sync_grades  # noqa: SLF001
         )
 
     def test_get_grading_sync(
-        self, auto_grading_service, pyramid_request, views, dashboard_service
+        self,
+        auto_grading_service,
+        pyramid_request,
+        views,
+        dashboard_service,
+        grading_sync,
     ):
+        auto_grading_service.get_last_sync.return_value = grading_sync
         response = views.get_grading_sync()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
@@ -105,7 +113,14 @@ class TestDashboardGradingViews:
             dashboard_service.get_request_assignment.return_value
         )
         assert response == {
-            "status": auto_grading_service.get_last_sync.return_value.status
+            "status": grading_sync.status,
+            "grades": Any.list.containing(
+                [
+                    {"grade": 1.0, "h_userid": "STUDENT_1", "status": "in_progress"},
+                    {"grade": 0.0, "h_userid": "STUDENT_2", "status": "finished"},
+                    {"grade": 0.5, "h_userid": "STUDENT_3", "status": "failed"},
+                ]
+            ),
         }
 
     def test_get_grading_sync_not_found(
@@ -135,6 +150,26 @@ class TestDashboardGradingViews:
     @pytest.fixture
     def lms_user(self):
         return factories.LMSUser(lti_v13_user_id="LTI_V13_USER_ID")
+
+    @pytest.fixture
+    def grading_sync(self, assignment, db_session):
+        student_1 = factories.LMSUser(h_userid="STUDENT_1")
+        student_2 = factories.LMSUser(h_userid="STUDENT_2")
+        student_3 = factories.LMSUser(h_userid="STUDENT_3")
+        grading_sync = factories.GradingSync(assignment=assignment)
+        db_session.flush()
+
+        factories.GradingSyncGrade(
+            lms_user=student_1, grade=1, grading_sync=grading_sync, success=None
+        )
+        factories.GradingSyncGrade(
+            lms_user=student_2, grade=0, grading_sync=grading_sync, success=True
+        )
+        factories.GradingSyncGrade(
+            lms_user=student_3, grade=0.5, grading_sync=grading_sync, success=False
+        )
+
+        return grading_sync
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request, lms_user):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6647


Expose each of the status of a grading sync grades

### Testing

- Go to the dashboard, on an auto-grading assignment with a finished/failed sync, check the return data of `/api/dashboard/assignments/121/grading/sync`


```
{
    "status": "finished",
    "grades": [
        {
            "h_userid": "acct:f6c3ed0edd8a4013bfc8d0c22b9eca@lms.hypothes.is",
            "grade": 0.0,
            "status": "finished"
        },
        {
            "h_userid": "acct:acea453480dde254bdf1c1058758e2@lms.hypothes.is",
            "grade": 0.0,
            "status": "finished"
        }
    ]
}
```




