### PR TITLE
Take a AI instead of registration in the sync_grade method to allow the same signature to work in both LTI versions

### DIFF
--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
-from lms.models import LTIRegistration
+from lms.models import ApplicationInstance, LTIRegistration
 from lms.product.family import Family
 from lms.product.plugin.misc import MiscPlugin
 from lms.services.exceptions import ExternalRequestError, StudentNotInCourse
@@ -94,7 +94,7 @@ class LTI13GradingService(LTIGradingService):
 
     def sync_grade(  # noqa: PLR0913
         self,
-        lti_registration: LTIRegistration,
+        application_instance: ApplicationInstance,
         lis_outcome_service_url: str,
         grade_timestamp: str,
         user_grading_id: str,
@@ -108,7 +108,7 @@ class LTI13GradingService(LTIGradingService):
         """
         payload = self._record_score_payload(score, user_grading_id, grade_timestamp)
 
-        if lti_registration.product_family == Family.CANVAS:
+        if application_instance.lti_registration.product_family == Family.CANVAS:
             # By default Canvas calls to /score create a new submission
             # Disable that behaviour and just submit the new grade.
             # See: https://canvas.instructure.com/doc/api/score.html
@@ -116,7 +116,7 @@ class LTI13GradingService(LTIGradingService):
                 "new_submission": False
             }
         return self._ltia_service.request(
-            lti_registration,
+            application_instance.lti_registration,
             "POST",
             self._service_url(lis_outcome_service_url, "/scores"),
             scopes=self.LTIA_SCOPES,

--- a/lms/tasks/grading.py
+++ b/lms/tasks/grading.py
@@ -1,12 +1,6 @@
 from sqlalchemy import exists, select
 
-from lms.models import (
-    ApplicationInstance,
-    GradingSync,
-    GradingSyncGrade,
-    Grouping,
-    LTIRegistration,
-)
+from lms.models import GradingSync, GradingSyncGrade
 from lms.services import LTIAHTTPService
 from lms.services.lti_grading.factory import LTI13GradingService
 from lms.tasks.celery import app
@@ -30,18 +24,8 @@ def sync_grades():
                 assert (
                     assignment.lis_outcome_service_url
                 ), "Assignment without grading URL"
-                lti_registration = request.db.scalars(
-                    select(LTIRegistration)
-                    .join(ApplicationInstance)
-                    .join(Grouping)
-                    .where(Grouping.id == assignment.course_id)
-                    .order_by(LTIRegistration.updated.desc())
-                ).first()
-                assert lti_registration, "No LTI registraion for LTI1.3 assignment"
-
                 for grade in sync.grades:
                     sync_grade.delay(
-                        lti_registration_id=lti_registration.id,
                         lis_outcome_service_url=assignment.lis_outcome_service_url,
                         grading_sync_grade_id=grade.id,
                     )
@@ -54,14 +38,13 @@ def sync_grades():
     retry_backoff=10,
     autoretry_for=(Exception,),
 )
-def sync_grade(
-    *, lti_registration_id, lis_outcome_service_url: str, grading_sync_grade_id: int
-):
+def sync_grade(*, lis_outcome_service_url: str, grading_sync_grade_id: int):
     """Send one particular grade to the LMS."""
     with app.request_context() as request:
         with request.tm:
             grading_sync_grade = request.db.get(GradingSyncGrade, grading_sync_grade_id)
             grading_sync = grading_sync_grade.grading_sync
+            application_instance = grading_sync.assignment.course.application_instance
 
             grading_service = LTI13GradingService(
                 ltia_service=request.find_service(LTIAHTTPService),
@@ -73,7 +56,7 @@ def sync_grade(
             )
             try:
                 grading_service.sync_grade(
-                    request.db.get(LTIRegistration, lti_registration_id),
+                    application_instance,
                     lis_outcome_service_url,
                     grading_sync.created.isoformat(),
                     grading_sync_grade.lms_user.lti_v13_user_id,

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -150,12 +150,16 @@ class TestLTI13GradingService:
         assert not svc.get_score_maximum(sentinel.resource_link_id)
 
     @pytest.mark.parametrize("is_canvas", [True, False])
-    def test_sync_grade(self, svc, ltia_http_service, lti_registration, is_canvas):
+    def test_sync_grade(
+        self, svc, ltia_http_service, lti_v13_application_instance, is_canvas
+    ):
         if is_canvas:
-            lti_registration.issuer = "https://canvas.instructure.com"
+            lti_v13_application_instance.lti_registration.issuer = (
+                "https://canvas.instructure.com"
+            )
 
         response = svc.sync_grade(
-            lti_registration,
+            lti_v13_application_instance,
             "LIS_OUTCOME_SERVICE_URL",
             datetime(2022, 4, 4).isoformat(),
             sentinel.user_id,
@@ -176,7 +180,7 @@ class TestLTI13GradingService:
             }
 
         ltia_http_service.request.assert_called_once_with(
-            lti_registration,
+            lti_v13_application_instance.lti_registration,
             "POST",
             "LIS_OUTCOME_SERVICE_URL/scores",
             scopes=svc.LTIA_SCOPES,


### PR DESCRIPTION
While LTIRegistration is the object that will drive authentication in
LTI1.3 API taking an application instance instead will allow to use the
same interface in LTI1.3 and LTI1.1 (where LTI registrations don't
exist)


From https://github.com/hypothesis/lms/pull/6720#issuecomment-2383125293


We have two problems:

* We have to manually create an instance to LTI13GradingService in grading/task.py to use the sync_grade method.
* Auto grading doesn't work in LTI1.1

The solution for both is to create a generic (v13 & v11) sync_grade method so we can just use find_service(LTIGradingService) and that will dispatch to the right version of the service.

The LTI1.1 version of sync_grade will need to talk to the LTI API on behalf of any applications instance (not the one from the request). To do that it needs to be able to use OAuth1 with artibarty AI as well. That's what this PR does.

We need to:

- [x]  https://github.com/hypothesis/lms/pull/6720
- [ ]  **This PR** [Take a AI instead of registration in the sync_grade method to allow the same signature to work in both LTI versions.](https://github.com/hypothesis/lms/pull/6724)
- [ ] Also be able to inject the "service url" for grading in LTI

- [ ] Include sync_grade in the LTIGradingService interface.
- [ ] Call the new generic method from task
- [ ] Write the v11 version of sync_grade



## Testing

- Sync grades on a LTI1.3 assignment