### PR TITLE
Include sync_grade in the generic LTIGrading interface

### DIFF
--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -1,27 +1,48 @@
 from lms.services.lti_grading._v11 import LTI11GradingService
 from lms.services.lti_grading._v13 import LTI13GradingService
+from lms.services.lti_grading.interface import LTIGradingService
 from lms.services.ltia_http import LTIAHTTPService
 
 
-def service_factory(_context, request):
-    application_instance = request.lti_user.application_instance
+def service_factory(_context, request, application_instance=None) -> LTIGradingService:
+    """Create a new LTIGradingService.
 
-    if application_instance.lti_version == "1.3.0":
+    When called via pyramid services (ie request.find_service) the LTI version is selected
+    depending on the current request's application_instance.
+
+    For other uses cases (e.g. from a Celery task) the passed application_instance will be used instead.
+    """
+
+    if not application_instance:
+        application_instance = request.lti_user.application_instance
+
+    lti_version = application_instance.lti_version
+    lis_outcome_service_url = _get_lis_outcome_service_url(request)
+
+    if lti_version == "1.3.0":
         return LTI13GradingService(
-            # Pick the value from the right dictionary depending on the context we are running
-            # either an API call from the frontend (parsed_params) or inside an LTI launch (lti_params).
-            line_item_url=request.parsed_params.get("lis_outcome_service_url")
-            or request.lti_params.get("lis_outcome_service_url"),
+            line_item_url=lis_outcome_service_url,
             line_item_container_url=request.lti_params.get("lineitems"),
             ltia_service=request.find_service(LTIAHTTPService),
             product_family=request.product.family,
             misc_plugin=request.product.plugin.misc,
-            lti_registration=request.lti_user.application_instance.lti_registration,
+            lti_registration=application_instance.lti_registration,
         )
 
     return LTI11GradingService(
-        line_item_url=request.parsed_params.get("lis_outcome_service_url"),
+        line_item_url=lis_outcome_service_url,
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
         application_instance=request.lti_user.application_instance,
     )
+
+
+def _get_lis_outcome_service_url(request) -> str | None:
+    # Pick the value from the right dictionary depending on the context we are running
+    # either an API call from the frontend (parsed_params) or inside an LTI launch (lti_params).
+    if hasattr(request, "parsed_params") and (
+        lis_outcome_service_url := request.parsed_params.get("lis_outcome_service_url")
+    ):
+        return lis_outcome_service_url
+
+    return request.lti_params.get("lis_outcome_service_url")

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from lms.models import ApplicationInstance, LMSUser
+
 
 @dataclass
 class GradingResult:
@@ -82,6 +84,22 @@ class LTIGradingService:  # pragma: no cover
         :param comment: Comment to associate with the grade as feedback for the student
 
         :raise TypeError: if the given pre_record_hook returns a non-dict
+        """
+        raise NotImplementedError()
+
+    def sync_grade(  # noqa: PLR0913
+        self,
+        application_instance: ApplicationInstance,
+        lis_outcome_service_url: str,
+        grade_timestamp: str,
+        lms_user: LMSUser,
+        score: float,
+    ):
+        """
+        Send a grade to the LMS.
+
+        This is very similar to `record_result` but not scoped to the request context,
+        taking all the necessary information as parameters.
         """
         raise NotImplementedError()
 

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -9,6 +9,7 @@ from pytest import param
 from lms.product.family import Family
 from lms.services.exceptions import ExternalRequestError, StudentNotInCourse
 from lms.services.lti_grading._v13 import LTI13GradingService
+from tests import factories
 
 
 class TestLTI13GradingService:
@@ -153,6 +154,7 @@ class TestLTI13GradingService:
     def test_sync_grade(
         self, svc, ltia_http_service, lti_v13_application_instance, is_canvas
     ):
+        lms_user = factories.LMSUser(lti_v13_user_id=sentinel.user_id)
         if is_canvas:
             lti_v13_application_instance.lti_registration.issuer = (
                 "https://canvas.instructure.com"
@@ -162,7 +164,7 @@ class TestLTI13GradingService:
             lti_v13_application_instance,
             "LIS_OUTCOME_SERVICE_URL",
             datetime(2022, 4, 4).isoformat(),
-            sentinel.user_id,
+            lms_user,
             sentinel.grade,
         )
 

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -2,7 +2,11 @@ from unittest.mock import Mock, sentinel
 
 import pytest
 
-from lms.services.lti_grading.factory import service_factory
+from lms.services.lti_grading.factory import (
+    LTI11GradingService,
+    LTI13GradingService,
+    service_factory,
+)
 
 
 class TestFactory:
@@ -55,6 +59,24 @@ class TestFactory:
             pyramid_request.lti_user.application_instance.lti_registration,
         )
         assert svc == LTI13GradingService.return_value
+
+    @pytest.mark.usefixtures("ltia_http_service", "misc_plugin")
+    def test_with_explicit_lti_v13_application_instance(
+        self, pyramid_request, lti_v13_application_instance
+    ):
+        svc = service_factory(
+            sentinel.context, pyramid_request, lti_v13_application_instance
+        )
+
+        assert isinstance(svc, LTI13GradingService)
+
+    @pytest.mark.usefixtures("http_service", "oauth1_service")
+    def test_with_explicit_lti_v11_application_instance(
+        self, pyramid_request, application_instance
+    ):
+        svc = service_factory(sentinel.context, pyramid_request, application_instance)
+
+        assert isinstance(svc, LTI11GradingService)
 
     @pytest.fixture
     def pyramid_request(self, pyramid_request):


### PR DESCRIPTION
For:
- https://github.com/hypothesis/lms/issues/6743


This allows us to use the generic service in the grading task instead of
manually instantiating the LTI1.3 version.

We still can't use `find_service` to create the service as the celery
task placeholder request is not scoped to any application instance.

Added a new parameter to the factory to explicitly pass an application
instance to base the LTI version decision on.

This commit doesn't implement sync_grade on LTI1.1 yet.

From https://github.com/hypothesis/lms/pull/6720#issuecomment-2383125293

```
We have two problems:

* We have to manually create an instance to LTI13GradingService in grading/task.py to use the sync_grade method.
* Auto grading doesn't work in LTI1.1

The solution for both is to create a generic (v13 & v11) sync_grade method so we can just use find_service(LTIGradingService) and that will dispatch to the right version of the service.

The LTI1.1 version of sync_grade will need to talk to the LTI API on behalf of any applications instance (not the one from the request). To do that it needs to be able to use OAuth1 with artibarty AI as well. That's what this PR does.
```

#### Done
- https://github.com/hypothesis/lms/pull/6720
- https://github.com/hypothesis/lms/pull/6724

#### This PR:

- Include sync_grade in the LTIGradingService interface.
- Call the new generic method from task

#### TODO

- Write the v11 version of sync_grade
- Call the new generic method from task
- Also be able to inject the "service url" for grading in LTI

### Testing

- Sync grades on an assignment with auto-grading https://hypothesis.instructure.com/courses/319/assignments/7296

