### PR TITLE
Use UTC timezones to sync auto-grading grades

### DIFF
--- a/lms/tasks/grading.py
+++ b/lms/tasks/grading.py
@@ -1,3 +1,5 @@
+from datetime import UTC
+
 from sqlalchemy import exists, select
 
 from lms.models import GradingSync, GradingSyncGrade
@@ -58,7 +60,9 @@ def sync_grade(*, lis_outcome_service_url: str, grading_sync_grade_id: int):
                 grading_service.sync_grade(
                     application_instance,
                     lis_outcome_service_url,
-                    grading_sync.created.isoformat(),
+                    # DB dates are not TZ aware but are always in UTC
+                    # Make them TZ aware so the LTI API calls have an explicit timezone
+                    grading_sync.created.replace(tzinfo=UTC).isoformat(),
                     grading_sync_grade.lms_user.lti_v13_user_id,
                     grading_sync_grade.grade,
                 )

--- a/tests/unit/lms/tasks/grading_test.py
+++ b/tests/unit/lms/tasks/grading_test.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import UTC
 from unittest.mock import call
 
 import pytest
@@ -46,7 +47,7 @@ class TestGradingTasks:
         grading_service.sync_grade.assert_called_once_with(
             lti_v13_application_instance,
             "URL",
-            grading_sync.created.isoformat(),
+            grading_sync.created.replace(tzinfo=UTC).isoformat(),
             grading_sync.grades[0].lms_user.lti_v13_user_id,
             grading_sync.grades[0].grade,
         )


### PR DESCRIPTION
Otherwise we let the LMS guess the timezone itself.

We already use UTC timezones when submitting grades in the grading bar.