### PR TITLE
Only update assignment attributes in update_assignment

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -81,6 +81,16 @@ class AssignmentService:
         assignment.is_gradable = self._misc_plugin.is_assignment_gradable(
             request.lti_params
         )
+        # Set the value for the v13 id for this assignment.
+        assignment.lti_v13_resource_link_id = request.lti_params.v13.get(
+            "https://purl.imsglobal.org/spec/lti/claim/resource_link", {}
+        ).get("id")
+
+        # Keep record of the grading service URL relevant for this assignment if available
+        assignment.lis_outcome_service_url = request.lti_params.get(
+            "lis_outcome_service_url"
+        )
+
         assignment.course_id = course.id
         self._update_auto_grading_config(assignment, auto_grading_config)
 
@@ -163,16 +173,6 @@ class AssignmentService:
                     "deep_linking_uuid"
                 )
             )
-
-        # Set the value for the v13 id for this assignment.
-        assignment.lti_v13_resource_link_id = request.lti_params.v13.get(
-            "https://purl.imsglobal.org/spec/lti/claim/resource_link", {}
-        ).get("id")
-
-        # Keep record of the grading service URL relevant for this assignment if available
-        assignment.lis_outcome_service_url = request.lti_params.get(
-            "lis_outcome_service_url"
-        )
 
         # Always update the assignment configuration
         # It often will be the same one while launching the assignment again but

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -147,14 +147,6 @@ def pyramid_request(db_session, application_instance, lti_v11_params):
 
 
 @pytest.fixture
-def lti_v13_pyramid_request(pyramid_request, lti_v13_params, lti_v11_params):
-    pyramid_request.lti_jwt = "JWT"
-    pyramid_request.lti_params = LTIParams(v11=lti_v11_params, v13=lti_v13_params)
-
-    return pyramid_request
-
-
-@pytest.fixture
 def product(pyramid_request):
     return pyramid_request.product
 


### PR DESCRIPTION
update_assignment takes care of the case where speedgrader sends us bogus data and ignores it.

Without this change we were updating lti_v13_resource_link_id and lis_outcome_url on speedgrader launches to incorrect values.



# Testing 

In `main` launch:

- https://hypothesis.instructure.com/courses/319/assignments/3336


`docker compose exec postgres psql -U postgres -c "select lti_v13_resource_link_id,lis_outcome_service_url from assignment where title = 'localhost (make devdata) Groups assignment';"`


```
lti_v13_resource_link_id       |                        lis_outcome_service_url                         
--------------------------------------+------------------------------------------------------------------------
 4a12eea4-8f9b-4b5a-9916-abea14fde8bd | https://hypothesis.instructure.com/api/lti/courses/319/line_items/1035
(1 row)
```


The two columns are correctly in the DB


- Launch in speedgrader 

https://hypothesis.instructure.com/courses/319/gradebook/speed_grader?assignment_id=3336&student_id=35


Repeat the query, the ID is different (?!) and the URL is gone:


```
         lti_v13_resource_link_id         | lis_outcome_service_url 
------------------------------------------+-------------------------
 6ed5aff92b5257ab607ec9c629844ea8586fde68 | 
(1 row)
```

- Switch to this branch, repeat the steps (first regular launch, then speed grader).

The data stays the same in the DB.



