### PR TITLE
Fix course copy, fetch files form the current course, not the old one

### DIFF
--- a/lms/product/canvas/_plugin/course_copy.py
+++ b/lms/product/canvas/_plugin/course_copy.py
@@ -22,7 +22,7 @@ class CanvasCourseCopyPlugin:
     def is_file_in_course(self, course_id, file_id):
         return self._files_helper.is_file_in_course(course_id, file_id, self.file_type)
 
-    def find_matching_file_in_course(self, course_id, file_ids):
+    def find_matching_file_in_course(self, current_course_id, file_ids) -> str | None:
         """
         Return the ID of a file in course_id that matches one of the files in file_ids.
 
@@ -33,7 +33,7 @@ class CanvasCourseCopyPlugin:
         Return None if no matching file is found.
         """
         # Find the files in the current course. We call this for the side effect of storing the files in the DB
-        _ = self._api.list_files(course_id)
+        _ = self._api.list_files(current_course_id)
 
         for file_id in file_ids:
             file = self._file_service.get(file_id, type_=self.file_type)
@@ -41,7 +41,7 @@ class CanvasCourseCopyPlugin:
             if not file:
                 continue
 
-            if new_file := self._file_service.find_copied_file(course_id, file):
+            if new_file := self._file_service.find_copied_file(current_course_id, file):
                 return new_file.lms_id
 
         return None

--- a/lms/services/canvas.py
+++ b/lms/services/canvas.py
@@ -12,14 +12,14 @@ class CanvasService:
         self._course_copy_plugin = course_copy_plugin
 
     def public_url_for_file(
-        self, assignment, file_id, course_id, check_in_course=False
+        self, assignment, file_id, current_course_id, check_in_course=False
     ):
         """
         Return a public URL for file_id.
 
         :param assignment: the current assignment
         :param file_id: the Canvas API ID of the file
-        :param course_id: the Canvas API ID of the course that the file is in
+        :param current_course_id: the Canvas API ID of the current course
         :param check_in_course: whether to check that file_id is in course_id
 
         :raise FileNotFoundInCourse: if check_in_course was True and the
@@ -30,11 +30,10 @@ class CanvasService:
         """
         # If there's a previously stored mapping for file_id use that instead.
         effective_file_id = assignment.get_canvas_mapped_file_id(file_id)
-
         try:
             if check_in_course:
                 if not self._course_copy_plugin.is_file_in_course(
-                    course_id, effective_file_id
+                    current_course_id, effective_file_id
                 ):
                     raise FileNotFoundInCourse(
                         "canvas_file_not_found_in_course", file_id
@@ -52,7 +51,7 @@ class CanvasService:
             # We'll try to find another copy of the same file that the current
             # user *can* see in the current course and use that instead.
             found_file_id = self._course_copy_plugin.find_matching_file_in_course(
-                course_id,
+                current_course_id,
                 # Use a set to avoid searching for the same ID twice if file_id
                 # and effective_file_id are the same.
                 {file_id, effective_file_id},

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -50,7 +50,7 @@ class FilesAPIViews:
         public_url = self.canvas.public_url_for_file(
             assignment,
             document_url_match["file_id"],
-            document_url_match["course_id"],
+            assignment.course.extra["canvas"]["custom_canvas_course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
 

--- a/tests/unit/lms/services/canvas_test.py
+++ b/tests/unit/lms/services/canvas_test.py
@@ -151,7 +151,7 @@ class TestPublicURLForFile:
         return partial(
             canvas_service.public_url_for_file,
             assignment,
-            course_id=sentinel.course_id,
+            current_course_id=sentinel.course_id,
         )
 
 

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -39,7 +39,7 @@ class TestFilesAPIViews:
         canvas_service.public_url_for_file.assert_called_once_with(
             assignment,
             "FILE_ID",
-            "COURSE_ID",
+            assignment.course.extra["canvas"]["custom_canvas_course_id"],
             check_in_course=pyramid_request.lti_user.is_instructor,
         )
         helpers.via_url.assert_called_once_with(


### PR DESCRIPTION
The course copy process should fetch file from the LMS for the current
course and rely on the data on the DB for the old course.

This is because often the instructor teaching the new course won't have
access to the old course.

Change the parameter passed to the course copy functions to be based on
the current assignment's course instead of coming from the `canvas://`
style URL.

---


### How is course copy for canvas file supposed to work?

- At some point an instructor configures a file assignment in the original course.
- We store all the files in that course in the DB, including the one selected for the assignment
- The course gets copied in the LMS
- A new instructor launches the new course
- We realize the assignment is configured with a file ID that's not in the new course
- **We fetch all the files in the new course**.
- We match, based on the info we have now on the DB, the old file to the new file (for example based on name).
- We store a map of new file to old file to avoid repeating this process.

We were however not fetching the files in the new course but in the old one.


### How is this not completely broken

There a few scenarios that make this work even while doing the wrong thing:

- Often the same instructor has access to both courses and we might have recorded the new courses files in the DB while configuring an assignment on that course.

- For old assignments, we don't configure them (we don't deep link them) using the url in the `canvas://` style but we use a `file_id` 

https://github.com/hypothesis/lms/blob/0e123e9a35bc4fbf93919810bfa81f94fb0c2b42/lms/product/canvas/_plugin/misc.py#L120-L124

but we constructor the `canvas://` URL using the **current** course (because we don't know the old one)

So for this type of assignment, picking the course ID from the URL was already doing the right thing.


### Testing

- Truncate your assignments table


`docker compose exec postgres psql -U postgres -c "truncate assignment cascade;"`


this is what we store the mapping info from old file id to new file id.


