### PR TITLE
Rename grades prop to student_syncs when getting sync status

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -336,8 +336,8 @@ export type GradingSync = {
   finish_date: ISODateTime | null;
 
   /**
-   * Grading status for every individual student that was scheduled as part of
+   * Sync status for every individual student that was scheduled as part of
    * this sync.
    */
-  grades: StudentGradingSync[];
+  student_syncs: StudentGradingSync[];
 };

--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -108,7 +108,7 @@ class DashboardGradingViews:
             if grading_sync.status
             in {AutoGradingSyncStatus.FINISHED, AutoGradingSyncStatus.FAILED}
             else None,
-            "grades": [
+            "student_syncs": [
                 {
                     "h_userid": grade.lms_user.h_userid,
                     "grade": grade.grade,

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -92,7 +92,7 @@ class TestDashboardGradingViews:
         assert response == {
             "status": auto_grading_service.create_grade_sync.return_value.status,
             "finish_date": None,
-            "grades": [],
+            "student_syncs": [],
         }
         pyramid_request.add_finished_callback.assert_called_once_with(
             views._start_sync_grades  # noqa: SLF001
@@ -121,7 +121,7 @@ class TestDashboardGradingViews:
             if grading_sync.status
             in {AutoGradingSyncStatus.FINISHED, AutoGradingSyncStatus.FAILED}
             else None,
-            "grades": Any.list.containing(
+            "student_syncs": Any.list.containing(
                 [
                     {"grade": 1.0, "h_userid": "STUDENT_1", "status": "in_progress"},
                     {"grade": 0.0, "h_userid": "STUDENT_2", "status": "finished"},


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6721

As discussed in https://github.com/hypothesis/lms/pull/6721#discussion_r1784817271, renaming the `grades` prop returned by the `GET /grades/sync` endpoint to `student_syncs`.

I reckon this more accurately describes what this property represents, as the most important aspect is that every entry in the array is the individual status for every student to sync.