### PR TITLE
New JSON renderer that handles datetime objects

### DIFF
--- a/lms/app.py
+++ b/lms/app.py
@@ -3,6 +3,7 @@ import pyramid_tm
 from sqlalchemy.exc import IntegrityError
 
 from lms.config import configure
+from lms.renderers import json_iso_utc
 
 
 def configure_jinja2_assets(config):
@@ -34,6 +35,9 @@ def create_app(global_config, **settings):  # noqa: ARG001
 
     config.include("pyramid_jinja2")
     config.include("pyramid_services")
+
+    # Add our own json renderer that handles datetime objects.
+    config.add_renderer("json_iso_utc", json_iso_utc())
 
     # Use pyramid_tm's explicit transaction manager.
     #

--- a/lms/renderers.py
+++ b/lms/renderers.py
@@ -1,0 +1,23 @@
+from datetime import UTC, datetime
+
+from pyramid.renderers import JSON
+
+
+def json_iso_utc():
+    """Return a JSON renderer that formats dates as `isoformat`.
+
+    This renderer assumes datetimes without tz info are in UTC and
+    includes that in the datetime objects so the resulting string
+    includes tz information.
+    """
+
+    renderer = JSON()
+
+    def _datetime_adapter(obj: datetime, _request) -> str:
+        if not obj.tzinfo:
+            obj = obj.replace(tzinfo=UTC)
+        return obj.isoformat()
+
+    renderer.add_adapter(datetime, _datetime_adapter)
+
+    return renderer

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -59,7 +59,7 @@ class AssignmentViews:
     @view_config(
         route_name="api.dashboard.assignments",
         request_method="GET",
-        renderer="json",
+        renderer="json_iso_utc",
         permission=Permissions.DASHBOARD_VIEW,
         schema=ListAssignmentsSchema,
     )
@@ -85,7 +85,7 @@ class AssignmentViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
-                    created=assignment.created.isoformat(),
+                    created=assignment.created,
                 )
                 for assignment in assignments
             ],
@@ -95,7 +95,7 @@ class AssignmentViews:
     @view_config(
         route_name="api.dashboard.assignment",
         request_method="GET",
-        renderer="json",
+        renderer="json_iso_utc",
         permission=Permissions.DASHBOARD_VIEW,
     )
     def assignment(self) -> APIAssignment:
@@ -103,7 +103,7 @@ class AssignmentViews:
         api_assignment = APIAssignment(
             id=assignment.id,
             title=assignment.title,
-            created=assignment.created.isoformat(),
+            created=assignment.created,
             course=APICourse(
                 id=assignment.course.id,
                 title=assignment.course.lms_name,
@@ -128,7 +128,7 @@ class AssignmentViews:
     @view_config(
         route_name="api.dashboard.course.assignments.metrics",
         request_method="GET",
-        renderer="json",
+        renderer="json_iso_utc",
         permission=Permissions.DASHBOARD_VIEW,
         schema=AssignmentsMetricsSchema,
     )
@@ -191,7 +191,7 @@ class AssignmentViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
-                    created=assignment.created.isoformat(),
+                    created=assignment.created,
                     course=api_course,
                     annotation_metrics=metrics,
                 )

--- a/tests/unit/lms/renderers_test.py
+++ b/tests/unit/lms/renderers_test.py
@@ -1,0 +1,28 @@
+from datetime import UTC, datetime
+from unittest.mock import sentinel
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from lms.renderers import json_iso_utc
+
+
+@pytest.mark.parametrize(
+    "time,expected",
+    [
+        # No timezone, UTC is assumed
+        (datetime(2024, 1, 1), "2024-01-01T00:00:00+00:00"),
+        # UTC, UTC is left intact
+        (datetime(2024, 1, 1, tzinfo=UTC), "2024-01-01T00:00:00+00:00"),
+        # Non-UTC, timezone is also left intact
+        (
+            datetime(2024, 1, 1, tzinfo=ZoneInfo("Europe/Madrid")),
+            "2024-01-01T00:00:00+01:00",
+        ),
+    ],
+)
+def test_json_iso_utc(time, expected):
+    assert (
+        json_iso_utc()(sentinel.info)({"time": time}, {})
+        == f"""{{"time": "{expected}"}}"""
+    )

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -39,7 +39,7 @@ class TestAssignmentViews:
         )
         assert response == {
             "assignments": [
-                {"id": a.id, "title": a.title, "created": a.created.isoformat()}
+                {"id": a.id, "title": a.title, "created": a.created}
                 for a in assignments
             ],
             "pagination": sentinel.pagination,
@@ -69,7 +69,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "created": assignment.created.isoformat(),
+            "created": assignment.created,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
         }
 
@@ -96,7 +96,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "created": assignment.created.isoformat(),
+            "created": assignment.created,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "groups": [],
             "auto_grading_config": {
@@ -125,7 +125,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "created": assignment.created.isoformat(),
+            "created": assignment.created,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "groups": [
                 {"h_authority_provided_id": g.authority_provided_id, "name": g.lms_name}
@@ -152,7 +152,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
-            "created": assignment.created.isoformat(),
+            "created": assignment.created,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "sections": [
                 {"h_authority_provided_id": g.authority_provided_id, "name": g.lms_name}
@@ -210,7 +210,7 @@ class TestAssignmentViews:
                 {
                     "id": assignment.id,
                     "title": assignment.title,
-                    "created": assignment.created.isoformat(),
+                    "created": assignment.created,
                     "course": {
                         "id": course.id,
                         "title": course.lms_name,
@@ -224,7 +224,7 @@ class TestAssignmentViews:
                 {
                     "id": assignment_with_no_annos.id,
                     "title": assignment_with_no_annos.title,
-                    "created": assignment_with_no_annos.created.isoformat(),
+                    "created": assignment_with_no_annos.created,
                     "course": {
                         "id": course.id,
                         "title": course.lms_name,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6748

---

Based on the default json serializer from pyramid but it formats datetime objects as isoformat().

It special cases datetimes without datetime information and assumes they are in UTC.

This commit introduces this seralizer as a new one on top of the default `json` as `json_iso_utc` an starts using it on the assignments API.

Short term we'll use this serializer in all dashboard related routes and longer term we'll replace all uses of json by this seralizer and then will make it the default.



### Testing


- Compare the return payload from metrics `courses/metrics`:

```
{
    "courses": [
        {
            "id": 261,
            "title": "LTI 1.3 Testing",
            "course_metrics": {
                "assignments": 1,
                "last_launched": "2024-10-02T14:23:03.566715"
            }
        }
    ]
}
```

no TZ information here, vs any of the assignments endpoints:


```
{
    "assignments": [
        {
            "id": 147,
            "title": "localhost - Autograding",
            "created": "2024-10-02T14:23:03.566715+00:00"
        }
    ],
    "pagination": {
        "next": null
    }
}
```

`created` contains the `+00:00` suffix.




