### PR TITLE
Display synced students count in auto-grading assignments

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
@@ -83,14 +83,31 @@ describe('SyncGradesButton', () => {
     });
   });
 
-  ['scheduled', 'in_progress'].forEach(status => {
+  [
+    {
+      status: 'scheduled',
+      studentSyncs: [],
+      expectedCount: '0/0',
+    },
+    {
+      status: 'in_progress',
+      studentSyncs: [
+        { status: 'in_progress' },
+        { status: 'in_progress' },
+        { status: 'finished' },
+        { status: 'in_progress' },
+        { status: 'failed' },
+      ],
+      expectedCount: '2/5',
+    },
+  ].forEach(({ status, studentSyncs, expectedCount }) => {
     it('shows syncing text when grades are being synced', () => {
       const wrapper = createComponent(studentsToSync, {
         isLoading: false,
-        data: { status },
+        data: { status, student_syncs: studentSyncs },
       });
 
-      assert.equal(buttonText(wrapper), 'Syncing grades');
+      assert.equal(buttonText(wrapper), `Syncing grades${expectedCount}`);
       assert.isTrue(isButtonDisabled(wrapper));
     });
   });
@@ -98,7 +115,7 @@ describe('SyncGradesButton', () => {
   it('shows syncing errors and allows to retry', () => {
     const wrapper = createComponent(studentsToSync, {
       isLoading: false,
-      data: { status: 'failed' },
+      data: { status: 'failed', student_syncs: [] },
     });
 
     assert.equal(buttonText(wrapper), 'Error syncing. Click to retry');
@@ -125,7 +142,7 @@ describe('SyncGradesButton', () => {
     it('shows the amount of students to be synced when current status is "finished"', () => {
       const wrapper = createComponent(students, {
         isLoading: false,
-        data: { status: 'finished' },
+        data: { status: 'finished', student_syncs: [] },
       });
 
       assert.equal(buttonText(wrapper), `Sync ${expectedAmount} grades`);
@@ -146,7 +163,7 @@ describe('SyncGradesButton', () => {
   it('shows grades synced when no students need to be synced', () => {
     const wrapper = createComponent([], {
       isLoading: false,
-      data: { status: 'finished' },
+      data: { status: 'finished', student_syncs: [] },
     });
 
     assert.equal(buttonText(wrapper), 'Grades synced');
@@ -156,7 +173,7 @@ describe('SyncGradesButton', () => {
   it('submits grades when the button is clicked, then calls onSyncScheduled', async () => {
     const wrapper = createComponent(studentsToSync, {
       isLoading: false,
-      data: { status: 'finished' },
+      data: { status: 'finished', student_syncs: [] },
       mutate: sinon.stub(),
     });
     await act(() => wrapper.find('Button').props().onClick());
@@ -180,7 +197,7 @@ describe('SyncGradesButton', () => {
     const mutate = sinon.stub();
     const wrapper = createComponent(studentsToSync, {
       isLoading: false,
-      data: { status: 'finished' },
+      data: { status: 'finished', student_syncs: [] },
       mutate,
     });
     await act(() => wrapper.find('Button').props().onClick());


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6749 and is part of [#6723](https://github.com/hypothesis/lms/issues/6723)

Add a countdown of students being synced while an auto-grading sync is in progress, instead of a spinner.

[Grabación de pantalla desde 2024-10-04 11-01-55.webm](https://github.com/user-attachments/assets/8336d97d-1eda-4008-b6be-e00c9ca93e29)

### TODO

- [x] Ensure the countdown total value is properly initialized if a sync is in progress when the component renders for the first time.
- [x] Make it look like in the designs.
- [x] Add tests