### PR TITLE
Batch calls to H groups API when we request data for a large number of groups

### DIFF
--- a/lms/services/organization_usage_report.py
+++ b/lms/services/organization_usage_report.py
@@ -149,6 +149,11 @@ class OrganizationUsageReportService:
         if not groups_from_org:
             raise ValueError(f"No courses found for {organization.public_id}")
 
+        LOG.info(
+            "Generating report for %s based on %d candidate groups.",
+            organization.public_id,
+            len(groups_from_org),
+        )
         # Of those groups, get the ones that do have annotations in the time period
         groups_with_annos = [
             group.authority_provided_id


### PR DESCRIPTION
Some context of this being very slow:

https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1727696994601579


---


We use this API call to fetch the groups of a given organization that have annotations.

The number of groups that belong to one organizations is potential very big so will make N request to the API based on starting batch size of 1000.

We start with a very big number to be able to tweak and balance the number of requests vs the performance of individual calls.


### Test

- Sanity check the batching with a diff like:

```
diff --git a/lms/services/h_api.py b/lms/services/h_api.py
index c76210234..c9891827f 100644
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -143,7 +143,7 @@ class HAPI:
         groups: Sequence[str],
         annotations_created_after: datetime,
         annotations_created_before: datetime,
-        batch_size: int = 1000,
+        batch_size: int = 10,
     ) -> Iterator[HAPIGroup]:
         """
         Fetch groups that have annotations created between two dates.
```

- And head to the admin pages of one organization locally, eg: http://localhost:8001/admin/orgs/1/usage

pick a some dates with local activity and generate the report.


You'll see something like:

```
 INFO  [lms.services.organization_usage_report:152][MainThread] Generating report for us.lms.org.kXFNz2fJQBaQ3l5ZKF3nJA based on 21 candidate groups.
```

Note that this admin pages entry point is the less common one, this usually runs on a celery task, but this is easier to test.