### PR TITLE
Display information about individual student sync status

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -29,6 +29,7 @@ import SyncGradesButton from './SyncGradesButton';
 
 type StudentsTableRow = {
   lms_id: string;
+  h_userid: string;
   display_name: string | null;
   last_activity: string | null;
   annotations: number;
@@ -355,6 +356,11 @@ export default function AssignmentActivity() {
                     lastGrade={stats.last_grade}
                     annotations={stats.annotations}
                     replies={stats.replies}
+                    status={
+                      lastSync.data?.student_syncs.find(
+                        s => s.h_userid === stats.h_userid,
+                      )?.status
+                    }
                     config={assignment.data?.auto_grading_config}
                   />
                 </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -216,7 +216,7 @@ describe('GradeIndicator', () => {
     it('shows the "new" label if last grade is not set or is different than current grade', () => {
       const wrapper = createComponent({ lastGrade });
       assert.equal(
-        wrapper.exists('[data-testid="new-label"]'),
+        wrapper.exists('[data-testid="badge-new"]'),
         shouldShowLabel,
       );
     });


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6751 and is part of https://github.com/hypothesis/lms/issues/6723

Display information about individual sync statuses per student, including the error or loading states. 