### PR TITLE
Display information about individual student sync status

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -7,6 +7,7 @@ import type {
   AssignmentDetails,
   GradingSync,
   StudentGradingSync,
+  StudentGradingSyncStatus,
   StudentsMetricsResponse,
 } from '../../api-types';
 import { useConfig } from '../../config';
@@ -30,6 +31,7 @@ import SyncGradesButton from './SyncGradesButton';
 
 type StudentsTableRow = {
   lms_id: string;
+  h_userid: string;
   display_name: string | null;
   last_activity: string | null;
   annotations: number;
@@ -174,6 +176,14 @@ export default function AssignmentActivity() {
       !!result.data &&
       ['scheduled', 'in_progress'].includes(result.data.status),
   });
+  const studentSyncStatuses = useMemo(() => {
+    const studentStatusMap: Record<string, StudentGradingSyncStatus> = {};
+    for (const { h_userid, status } of lastSync.data?.grades ?? []) {
+      studentStatusMap[h_userid] = status;
+    }
+
+    return studentStatusMap;
+  }, [lastSync.data?.grades]);
 
   const onSyncScheduled = useCallback(() => {
     // Once the request succeeds, we update the params so that polling the
@@ -385,6 +395,7 @@ export default function AssignmentActivity() {
                     lastGrade={stats.last_grade}
                     annotations={stats.annotations}
                     replies={stats.replies}
+                    status={studentSyncStatuses[stats.h_userid]}
                     config={assignment.data?.auto_grading_config}
                   />
                 </div>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -12,7 +12,7 @@ describe('GradeIndicator', () => {
     required_replies: 1,
   };
 
-  function createComponent({ config = defaultConfig, lastGrade } = {}) {
+  function createComponent({ config = defaultConfig, lastGrade, status } = {}) {
     return mount(
       <GradeIndicator
         grade={80}
@@ -20,6 +20,7 @@ describe('GradeIndicator', () => {
         annotations={5}
         replies={2}
         config={config}
+        status={status}
       />,
     );
   }
@@ -207,18 +208,20 @@ describe('GradeIndicator', () => {
   [
     {
       lastGrade: undefined,
-      shouldShowLabel: true,
+      shouldShowBadge: true,
       shouldShowPrevGrade: false,
     },
-    { lastGrade: 90, shouldShowLabel: true, shouldShowPrevGrade: true },
-    { lastGrade: 80, shouldShowLabel: false, shouldShowPrevGrade: false },
-  ].forEach(({ lastGrade, shouldShowLabel, shouldShowPrevGrade }) => {
-    it('shows the "new" label if last grade is not set or is different than current grade', () => {
+    { lastGrade: 90, shouldShowBadge: true, shouldShowPrevGrade: true },
+    { lastGrade: 80, shouldShowBadge: false, shouldShowPrevGrade: false },
+  ].forEach(({ lastGrade, shouldShowBadge, shouldShowPrevGrade }) => {
+    it('shows the "new" badge if last grade is not set or is different than current grade', () => {
       const wrapper = createComponent({ lastGrade });
-      assert.equal(
-        wrapper.exists('[data-testid="new-label"]'),
-        shouldShowLabel,
-      );
+      const badge = wrapper.find('Badge[type="new"]');
+
+      assert.equal(badge.exists(), shouldShowBadge);
+      if (shouldShowBadge) {
+        assert.equal(badge.text(), 'New');
+      }
     });
 
     it('shows last grade in popover if set and is different than current grade', () => {
@@ -228,6 +231,23 @@ describe('GradeIndicator', () => {
         wrapper.exists('[data-testid="last-grade"]'),
         shouldShowPrevGrade,
       );
+    });
+  });
+
+  [
+    { status: 'failed', expectedBadge: 'error', expectedBadgeText: 'Error' },
+    {
+      status: 'in_progress',
+      expectedBadge: 'syncing',
+      expectedBadgeText: 'Syncing…',
+    },
+  ].forEach(({ status, expectedBadge, expectedBadgeText }) => {
+    it('shows the corresponding badge based on status', () => {
+      const wrapper = createComponent({ status });
+      const badge = wrapper.find(`Badge[type="${expectedBadge}"]`);
+
+      assert.isTrue(badge.exists());
+      assert.equal(badge.text(), expectedBadgeText);
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6755 and closes https://github.com/hypothesis/lms/issues/6723

Display information about individual sync statuses per student, including "error" or "syncing". 

[Grabación de pantalla desde 2024-10-07 13-44-31.webm](https://github.com/user-attachments/assets/2e498f31-ae05-4e0e-a343-27795bd0a77d)

