### PR TITLE
Return grades sync finish_date as datetime

### DIFF
--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import UTC
 
 from marshmallow import Schema, fields, validate
 from pyramid.view import view_config
@@ -104,7 +103,7 @@ class DashboardGradingViews:
     def _serialize_grading_sync(grading_sync: GradingSync) -> dict:
         return {
             "status": grading_sync.status,
-            "finish_date": grading_sync.updated.replace(tzinfo=UTC).isoformat()
+            "finish_date": grading_sync.updated
             if grading_sync.status
             in {AutoGradingSyncStatus.FINISHED, AutoGradingSyncStatus.FAILED}
             else None,

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -1,4 +1,3 @@
-from datetime import UTC
 from unittest.mock import Mock
 
 import pytest
@@ -117,7 +116,7 @@ class TestDashboardGradingViews:
         )
         assert response == {
             "status": grading_sync.status,
-            "finish_date": grading_sync.updated.replace(tzinfo=UTC).isoformat()
+            "finish_date": grading_sync.updated
             if grading_sync.status
             in {AutoGradingSyncStatus.FINISHED, AutoGradingSyncStatus.FAILED}
             else None,


### PR DESCRIPTION
Since after https://github.com/hypothesis/lms/pull/6753, the view for `GET /grades/sync` endpoint is now using the `json_iso_utc` renderer from https://github.com/hypothesis/lms/pull/6750, this PR changes the `finish_date` so that it is returned as datetime instead of string, letting the renderer serialize it.

### Testing steps

If you open an auto-grading assignment in the dashboard, there should be no visual differences.