### PR TITLE
Keep the LMSUserAssignmentMembership table in sync with AssignmentMembership

### DIFF
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -172,6 +172,7 @@ class BasicLaunchViews:
 
         # Store the relationship between the assignment and the user
         self.assignment_service.upsert_assignment_membership(
+            lti_params=self.request.lti_params,
             assignment=assignment,
             user=self.request.user,
             lti_roles=self.request.lti_user.lti_roles,

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -258,6 +258,7 @@ class TestBasicLaunchViews:
         )
 
         assignment_service.upsert_assignment_membership.assert_called_once_with(
+            pyramid_request.lti_params,
             assignment=assignment,
             user=pyramid_request.user,
             lti_roles=lti_user.lti_roles,


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6743
- https://github.com/hypothesis/lms/issues/6575


---

This changes allow us store the LTI1.1 grading ID which is unique per assignment and user.

We do  this in a new table that follows the LMSUser, LMSCourse, LMSCourseMebmership patterns. This will allows to find membership objects without having to worry about duplicated users.


#### Testing


- Apply the migration

```
tox -e dev --run-command 'alembic upgrade head'

dev run-test-pre: PYTHONHASHSEED='602997392'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade aea9bbeee574 -> 712c4c9a4e2e, Create LMSUserAssignmentMembership.
```


- Launch an LTI1.3 assignment as a teacher

https://hypothesis.instructure.com/courses/125/assignments/7777


- Launch an LTI1.1 assignment as a teacher

https://hypothesis.instructure.com/courses/319/assignments/7296


- Repeat the launches as a student for both assignments


- Check the data from the DB, we'll have rows with for both thet studend and teacher, only with the lti_v11_lis_result_sourcedid on the LTI1.1 launch:

```
elect distinct title, lms_user.display_name, lms_user_assignment_membership.lti_v11_lis_result_sourcedid from lms_user_assignment_membership join lms_user on lms_user_id = lms_user.id join assignment on assignment.id = assignment_id order by title;                                                                                                                             title               |      display_name      |               lti_v11_lis_result_sourcedid               
----------------------------------+------------------------+----------------------------------------------------------
 localhost - LTI1.1 -Autograding  | DISPLAY NAME TEACHER   | 
 localhost - LTI1.1 -Autograding  | Hypothesis 101 Student | 416-125-7777-35-ad406308d0411f0538bf4b6c6124e44fefe4d2be
 localhost - LTI1.3 - Autograding | DISPLAY NAME TEACHER   | 
 localhost - LTI1.3 - Autograding | Hypothesis 101 Student | 
(4 rows)
```





