### PR TITLE
Support for LTI1.1 on participation grading

### DIFF
--- a/lms/services/lti_grading/_v13.py
+++ b/lms/services/lti_grading/_v13.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
-from lms.models import ApplicationInstance, LMSUser, LTIRegistration
+from lms.models import ApplicationInstance, Assignment, LMSUser, LTIRegistration
 from lms.product.family import Family
 from lms.product.plugin.misc import MiscPlugin
 from lms.services.exceptions import ExternalRequestError, StudentNotInCourse
@@ -95,7 +95,7 @@ class LTI13GradingService(LTIGradingService):
     def sync_grade(  # noqa: PLR0913
         self,
         application_instance: ApplicationInstance,
-        lis_outcome_service_url: str,
+        assignment: Assignment,
         grade_timestamp: str,
         lms_user: LMSUser,
         score: float,
@@ -123,7 +123,7 @@ class LTI13GradingService(LTIGradingService):
         return self._ltia_service.request(
             application_instance.lti_registration,
             "POST",
-            self._service_url(lis_outcome_service_url, "/scores"),
+            self._service_url(assignment.lis_outcome_service_url, "/scores"),
             scopes=self.LTIA_SCOPES,
             json=payload,
             headers={"Content-Type": "application/vnd.ims.lis.v1.score+json"},

--- a/lms/services/lti_grading/factory.py
+++ b/lms/services/lti_grading/factory.py
@@ -30,10 +30,11 @@ def service_factory(_context, request, application_instance=None) -> LTIGradingS
         )
 
     return LTI11GradingService(
+        db=request.db,
         line_item_url=lis_outcome_service_url,
         http_service=request.find_service(name="http"),
         oauth1_service=request.find_service(name="oauth1"),
-        application_instance=request.lti_user.application_instance,
+        application_instance=application_instance,
     )
 
 

--- a/lms/services/lti_grading/interface.py
+++ b/lms/services/lti_grading/interface.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from lms.models import ApplicationInstance, LMSUser
+from lms.models import ApplicationInstance, Assignment, LMSUser
 
 
 @dataclass
@@ -90,7 +90,7 @@ class LTIGradingService:  # pragma: no cover
     def sync_grade(  # noqa: PLR0913
         self,
         application_instance: ApplicationInstance,
-        lis_outcome_service_url: str,
+        assignment: Assignment,
         grade_timestamp: str,
         lms_user: LMSUser,
         score: float,

--- a/tests/unit/lms/services/lti_grading/_v13_test.py
+++ b/tests/unit/lms/services/lti_grading/_v13_test.py
@@ -152,7 +152,12 @@ class TestLTI13GradingService:
 
     @pytest.mark.parametrize("is_canvas", [True, False])
     def test_sync_grade(
-        self, svc, ltia_http_service, lti_v13_application_instance, is_canvas
+        self,
+        svc,
+        ltia_http_service,
+        lti_v13_application_instance,
+        is_canvas,
+        assignment,
     ):
         lms_user = factories.LMSUser(lti_v13_user_id=sentinel.user_id)
         if is_canvas:
@@ -162,7 +167,7 @@ class TestLTI13GradingService:
 
         response = svc.sync_grade(
             lti_v13_application_instance,
-            "LIS_OUTCOME_SERVICE_URL",
+            assignment,
             datetime(2022, 4, 4).isoformat(),
             lms_user,
             sentinel.grade,
@@ -328,6 +333,10 @@ class TestLTI13GradingService:
             misc_plugin=misc_plugin,
             lti_registration=lti_registration,
         )
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.Assignment(lis_outcome_service_url="LIS_OUTCOME_SERVICE_URL")
 
     @pytest.fixture
     def blackboard_svc(self, ltia_http_service, misc_plugin, lti_registration):

--- a/tests/unit/lms/services/lti_grading/factory_test.py
+++ b/tests/unit/lms/services/lti_grading/factory_test.py
@@ -11,13 +11,19 @@ from lms.services.lti_grading.factory import (
 
 class TestFactory:
     def test_v11(
-        self, pyramid_request, LTI11GradingService, http_service, oauth1_service
+        self,
+        pyramid_request,
+        LTI11GradingService,
+        http_service,
+        oauth1_service,
+        db_session,
     ):
         pyramid_request.lti_user.application_instance = Mock(lti_version="1.1")
 
         svc = service_factory(sentinel.context, pyramid_request)
 
         LTI11GradingService.assert_called_once_with(
+            db_session,
             sentinel.grading_url,
             http_service,
             oauth1_service,

--- a/tests/unit/lms/tasks/grading_test.py
+++ b/tests/unit/lms/tasks/grading_test.py
@@ -13,10 +13,7 @@ class TestGradingTasks:
         sync_grades()
 
         sync_grade.delay.assert_has_calls(
-            [
-                call(lis_outcome_service_url="URL", grading_sync_grade_id=grade.id)
-                for grade in grading_sync.grades
-            ],
+            [call(grading_sync_grade_id=grade.id) for grade in grading_sync.grades],
             any_order=True,
         )
         assert grading_sync.status == "in_progress"
@@ -30,7 +27,6 @@ class TestGradingTasks:
         sync_grades_complete,
     ):
         sync_grade(
-            lis_outcome_service_url="URL",
             grading_sync_grade_id=grading_sync.grades[0].id,
         )
 
@@ -41,7 +37,7 @@ class TestGradingTasks:
 
         grading_service.sync_grade.assert_called_once_with(
             lti_v13_application_instance,
-            "URL",
+            grading_sync.assignment,
             grading_sync.created.replace(tzinfo=UTC).isoformat(),
             grading_sync.grades[0].lms_user,
             grading_sync.grades[0].grade,
@@ -61,7 +57,6 @@ class TestGradingTasks:
 
         with pytest.raises(Exception):
             sync_grade(
-                lis_outcome_service_url="URL",
                 grading_sync_grade_id=grading_sync.grades[0].id,
             )
 
@@ -77,7 +72,6 @@ class TestGradingTasks:
         sync_grade.max_retries = 0
 
         sync_grade(
-            lis_outcome_service_url="URL",
             grading_sync_grade_id=grading_sync.grades[0].id,
         )
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6743

---


- Adapt the interface of sync_grade to take a whole Assignment

This allows to take the service URL directly form the assignment in both versions and help find the right membership object in LTI1.1

- Implement the LTI1.1 version of the method.



### Testing 

- Check that nothing has changed syncing grades of a LTI1.3 assignment

https://hypothesis.instructure.com/courses/319/assignments/7296



- Test syncing a LTI1.1, it should behave the same way

https://hypothesis.instructure.com/courses/125/assignments/7777

