### PR TITLE
Cancel polled API fetches after a number of attempts

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -342,11 +342,26 @@ export default function AssignmentActivity() {
           />
         )}
         {isAutoGradingAssignment && auto_grading_sync_enabled && (
-          <SyncGradesButton
-            studentsToSync={studentsToSync}
-            lastSync={lastSync}
-            onSyncScheduled={onSyncScheduled}
-          />
+          <>
+            {!lastSync.canceled ? (
+              <SyncGradesButton
+                studentsToSync={studentsToSync}
+                lastSync={lastSync}
+                onSyncScheduled={onSyncScheduled}
+              />
+            ) : (
+              <div
+                className={classnames(
+                  'rounded p-2',
+                  'border border-grade-error',
+                  'font-bold text-grade-error bg-grade-error-light',
+                )}
+                data-testid="long-sync-error"
+              >
+                Syncing is taking too long. Reload the page.
+              </div>
+            )}
+          </>
         )}
       </div>
       <OrderableActivityTable

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -748,6 +748,28 @@ describe('AssignmentActivity', () => {
         }
       });
     });
+
+    [true, false].forEach(canceled => {
+      it('shows error message if syncing takes too long', () => {
+        setUpFakeUseAPIFetch({
+          ...activeAssignment,
+          auto_grading_config: {},
+        });
+        fakeUsePolledAPIFetch.returns({
+          canceled,
+          data: { status: 'in_progress' },
+          isLoading: false,
+        });
+
+        const wrapper = createComponent();
+
+        assert.equal(wrapper.exists('SyncGradesButton'), !canceled);
+        assert.equal(
+          wrapper.exists('[data-testid="long-sync-error"]'),
+          canceled,
+        );
+      });
+    });
   });
 
   context('when assignment has segments', () => {


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6765

To avoid an infinite amount of refreshes when using `usePolledAPIFetch`, add an option to define a maximum amount after which we will stop polling.

If this amount is reached, we will set a flag in the hook's result object, that can then be used to display some piece of UI indicating what happened and how to proceed.

I reckon it is hard to find a sensible default for this option, but for now I have set a value which is equivalent to waiting ~30 seconds, plus the time all refreshes take until that happens. Based on what we have seen so far, this should be enough for auto-grading status checks, but we may need to tune this up.

[Grabación de pantalla desde 2024-10-07 17-31-41.webm](https://github.com/user-attachments/assets/62f899a8-ae8b-4897-9a6a-65939599eaaf)

### Testing steps

1. Check out this branch
2. Manually update the most recent `grading_sync` entry in your local DB and set status to `in_progress`.
3. Apply this diff, so that the max refreshes is not too high and you can see the result quickly:
    ```diff
    diff --git a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
    index 5614e3d0b..602f7f3a4 100644
    --- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
    +++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
    @@ -146,6 +146,7 @@ export default function AssignmentActivity() {
       const lastSync = usePolledAPIFetch<GradingSync>({
         path: syncURL,
         params: lastSyncParams,
    +    maxRefreshes: 10,
         // Keep polling as long as sync is in progress
         shouldRefresh: result =>
           !!result.data &&
    ```
4. Open an auto-grading assignment. The syn button should be in a syncing status for about 5 seconds, and then you should see an error like the one on the screen recording above.