### PR TITLE
Display error "badge" when last auto-grading sync failed

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -6,6 +6,7 @@ import { useLocation, useParams, useSearch } from 'wouter-preact';
 import type {
   AssignmentDetails,
   GradingSync,
+  StudentGradingSync,
   StudentsMetricsResponse,
 } from '../../api-types';
 import { useConfig } from '../../config';
@@ -44,6 +45,28 @@ type StudentsTableRow = {
    */
   last_grade?: number | null;
 };
+
+/**
+ * Error to display when last grades sync failed, showing the number of
+ * individual student syncs that failed
+ */
+function SyncErrorMessage({ grades }: { grades: StudentGradingSync[] }) {
+  const count = useMemo(
+    () => grades.filter(g => g.status === 'failed').length,
+    [grades],
+  );
+
+  return (
+    <div
+      className={classnames(
+        'rounded px-2 py-1',
+        'font-bold text-grade-error bg-grade-error-light',
+      )}
+    >
+      Error syncing {count} {count === 1 ? 'grade' : 'grades'}
+    </div>
+  );
+}
 
 /**
  * Activity in a list of students that are part of a specific assignment
@@ -258,11 +281,18 @@ export default function AssignmentActivity() {
             )}
           </div>
         )}
-        <h2 className="text-lg text-brand font-semibold" data-testid="title">
-          {assignment.isLoading && 'Loading...'}
-          {assignment.error && 'Could not load assignment title'}
-          {assignment.data && title}
-        </h2>
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg text-brand font-semibold" data-testid="title">
+            {assignment.isLoading && 'Loading...'}
+            {assignment.error && 'Could not load assignment title'}
+            {assignment.data && title}
+          </h2>
+          <div aria-live="polite" aria-relevant="additions">
+            {lastSync.data && lastSync.data.status === 'failed' && (
+              <SyncErrorMessage grades={lastSync.data.grades} />
+            )}
+          </div>
+        </div>
       </div>
       <div className="flex justify-between items-end gap-x-4">
         {assignment.data && (

--- a/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
@@ -102,15 +102,6 @@ export default function SyncGradesButton({
       );
     }
 
-    if (lastSync.data?.status === 'failed') {
-      return (
-        <>
-          Error syncing. Click to retry
-          <LeaveIcon />
-        </>
-      );
-    }
-
     if (
       lastSync.error &&
       // The API returns 404 when current assignment has never been synced.

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -675,6 +675,42 @@ describe('AssignmentActivity', () => {
         );
       });
     });
+
+    [
+      { failedGrades: 0, expectedErrorText: null },
+      { failedGrades: 1, expectedErrorText: 'Error syncing 1 grade' },
+      { failedGrades: 5, expectedErrorText: 'Error syncing 5 grades' },
+    ].forEach(({ failedGrades, expectedErrorText }) => {
+      it('shows error message when last sync failed', () => {
+        setUpFakeUseAPIFetch({
+          ...activeAssignment,
+          auto_grading_config: {},
+        });
+
+        const failed = failedGrades > 0;
+        const grades = [{ status: 'finished' }];
+
+        for (let i = 0; i < failedGrades; i++) {
+          grades.push({ status: 'failed' });
+        }
+
+        fakeUsePolledAPIFetch.returns({
+          data: {
+            status: failed ? 'failed' : 'finished',
+            grades,
+          },
+          isLoading: false,
+        });
+
+        const wrapper = createComponent();
+        const errorMessage = wrapper.find('SyncErrorMessage');
+
+        assert.equal(errorMessage.exists(), failed);
+        if (failed) {
+          assert.equal(errorMessage.text(), expectedErrorText);
+        }
+      });
+    });
   });
 
   context('when assignment has segments', () => {

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
@@ -112,16 +112,6 @@ describe('SyncGradesButton', () => {
     });
   });
 
-  it('shows syncing errors and allows to retry', () => {
-    const wrapper = createComponent(studentsToSync, {
-      isLoading: false,
-      data: { status: 'failed', grades: [] },
-    });
-
-    assert.equal(buttonText(wrapper), 'Error syncing. Click to retry');
-    assert.isFalse(isButtonDisabled(wrapper));
-  });
-
   it('shows error when checking current sync status', () => {
     const wrapper = createComponent(studentsToSync, {
       isLoading: false,


### PR DESCRIPTION
Part of #6716

When the last sync status is `failed`, display the error information in a separated UI control, instead of the sync button itself.

The sync button should transition to the "Sync grades" state, so that grades that failed last time can be retried.

![image](https://github.com/user-attachments/assets/b3568b20-f55b-4299-b011-3ee3fc510f42)

The designs also include a tooltip with the list of students whose grades failed to sync. However, we are also going to represent the individual sync statuses in every student row (see https://github.com/hypothesis/lms/pull/6756), so this may end up being duplicate information and I decided to not implement that here for now.

### Testing steps

To test this, set the status of the last `grading_sync` to `failed`, as well as some of the `grading_sync_grade` that correspond to that sync.