### PR TITLE
Support for auto grading on the editing flow

### DIFF
--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -1,6 +1,11 @@
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.application_instance import ApplicationInstance, ApplicationSettings
-from lms.models.assignment import Assignment, AutoGradingConfig
+from lms.models.assignment import (
+    Assignment,
+    AutoGradingCalculation,
+    AutoGradingConfig,
+    AutoGradingType,
+)
 from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import (
     AssignmentMembership,

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -31,6 +31,14 @@ class AutoGradingConfig(Base):
     required_annotations: Mapped[int] = mapped_column()
     required_replies: Mapped[int | None] = mapped_column()
 
+    def asdict(self):
+        return {
+            "grading_type": self.grading_type,
+            "activity_calculation": self.activity_calculation,
+            "required_annotations": self.required_annotations,
+            "required_replies": self.required_replies,
+        }
+
 
 class Assignment(CreatedUpdatedMixin, Base):
     """

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -62,6 +62,10 @@ class LTIParams(dict):
             # authorization
             if param
             not in {"oauth_nonce", "oauth_timestamp", "oauth_signature", "id_token"}
+            |
+            # We also don't want to include parameters that are not part of the LTI spec
+            # but we might submit together in a form while creating and editing assigments.
+            {"auto_grading_config"}
         }
         form_fields.update(**kwargs)
         return form_fields

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -1,3 +1,4 @@
+import type { AutoGradingConfig } from '../api-types';
 import type { Content } from '../utils/content-item';
 
 export type FilePickerFormFieldsProps = {
@@ -20,6 +21,9 @@ export type FilePickerFormFieldsProps = {
 
   /** Assignment title chosen by the user, if supported by the current LMS. */
   title: string | null;
+
+  /** Auto-grading configuration for assignments where it is enabled */
+  autoGradingConfig: AutoGradingConfig | null;
 };
 
 /**
@@ -33,6 +37,7 @@ export default function FilePickerFormFields({
   content,
   formFields,
   groupSet,
+  autoGradingConfig,
 }: FilePickerFormFieldsProps) {
   return (
     <>
@@ -46,6 +51,13 @@ export default function FilePickerFormFields({
         <input name="document_url" type="hidden" value={content.url} />
       )}
       {title !== null && <input type="hidden" name="title" value={title} />}
+      {autoGradingConfig && (
+        <input
+          type="hidden"
+          name="auto_grading_config"
+          value={JSON.stringify(autoGradingConfig)}
+        />
+      )}
     </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -72,7 +72,13 @@ describe('FilePickerApp', () => {
    */
   function checkFormFields(
     wrapper,
-    { content, groupSet = null, formFields = {}, title = null },
+    {
+      content,
+      groupSet = null,
+      formFields = {},
+      title = null,
+      autoGradingConfig = null,
+    },
   ) {
     const fieldsComponent = wrapper.find('FilePickerFormFields');
     assert.deepEqual(fieldsComponent.props(), {
@@ -81,6 +87,7 @@ describe('FilePickerApp', () => {
       formFields: { ...fakeConfig.filePicker.formFields, ...formFields },
       groupSet,
       title,
+      autoGradingConfig,
     });
   }
 
@@ -403,6 +410,30 @@ describe('FilePickerApp', () => {
           },
           groupSet: useGroupSet ? 'groupSet1' : null,
         });
+      });
+    });
+
+    it('initializes auto_grading_config if assignment already has it', () => {
+      const autoGradingConfig = {
+        grading_type: 'scaled',
+        activity_calculation: 'separate',
+        required_annotations: 10,
+        required_replies: 5,
+      };
+      const url = 'https://example.com';
+
+      fakeConfig.assignment = {
+        auto_grading_config: autoGradingConfig,
+        document: { url },
+      };
+      fakeConfig.filePicker.autoGradingEnabled = true;
+
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      checkFormFields(wrapper, {
+        content: { type: 'url', url },
+        autoGradingConfig,
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -74,4 +74,21 @@ describe('FilePickerFormFields', () => {
     assert.isTrue(titleField.exists());
     assert.equal(titleField.prop('value'), 'Example assignment');
   });
+
+  it('renders `auto_grading_config` if `autoGradingConfig` prop is set', () => {
+    const autoGradingConfig = {
+      grading_type: 'scaled',
+      activity_calculation: 'separate',
+      required_annotations: 10,
+      required_replies: 5,
+    };
+    const formFields = createComponent({
+      content: { type: 'url', url: 'https://example.com/' },
+      autoGradingConfig,
+    });
+    const configField = formFields.find('input[name="auto_grading_config"]');
+
+    assert.isTrue(configField.exists());
+    assert.equal(configField.prop('value'), JSON.stringify(autoGradingConfig));
+  });
 });

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 
+import type { AutoGradingConfig } from './api-types';
 import type { AppLaunchServerErrorCode, OAuthServerErrorCode } from './errors';
 
 /**
@@ -70,6 +71,7 @@ export type SpeedGraderConfig = { submissionParams: object };
  */
 export type AssignmentConfig = {
   group_set_id: string | null;
+  auto_grading_config?: AutoGradingConfig;
   document: {
     url: string;
   };

--- a/lms/validation/__init__.py
+++ b/lms/validation/__init__.py
@@ -56,6 +56,7 @@ from lms.validation._base import (
 )
 from lms.validation._exceptions import LTIToolRedirect, ValidationError
 from lms.validation._lti_launch_params import (
+    AutoGradingConfigSchema,
     BasicLTILaunchSchema,
     ConfigureAssignmentSchema,
     DeepLinkingLTILaunchSchema,

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -1,3 +1,5 @@
+import json
+
 from marshmallow import (
     EXCLUDE,
     Schema,
@@ -183,3 +185,17 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     auto_grading_config = fields.Nested(
         AutoGradingConfigSchema, required=False, allow_none=True
     )
+
+    @pre_load
+    def _decode_auto_grading_config(self, data, **_kwargs):
+        auto_grading_config = data.get("auto_grading_config")
+
+        if auto_grading_config and isinstance(auto_grading_config, str):
+            try:
+                data["auto_grading_config"] = json.loads(auto_grading_config)
+            except json.decoder.JSONDecodeError as exc:
+                raise ValidationError(
+                    "Invalid json for nested field", "auto_grading_config"
+                ) from exc
+
+        return data

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -6,7 +6,7 @@ from marshmallow import (
     pre_load,
     validates_schema,
 )
-from marshmallow.validate import OneOf
+from marshmallow.validate import OneOf, Range
 
 from lms.validation._base import PyramidRequestSchema
 from lms.validation._exceptions import LTIToolRedirect
@@ -154,6 +154,22 @@ class DeepLinkingLTILaunchSchema(_CommonLTILaunchSchema):
     content_item_return_url = fields.Str(required=True)
 
 
+class AutoGradingConfigSchema(Schema):
+    """Schema for the auto grading options for an assignment."""
+
+    grading_type = fields.Str(
+        required=True, validate=OneOf(["all_or_nothing", "scaled"])
+    )
+    activity_calculation = fields.Str(
+        required=True, validate=OneOf(["cumulative", "separate"])
+    )
+
+    required_annotations = fields.Int(required=True, validate=Range(min=0))
+    required_replies = fields.Int(
+        required=False, allow_none=True, validate=Range(min=0)
+    )
+
+
 class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     """Schema for validating requests to the configure_assignment() view."""
 
@@ -164,3 +180,6 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     user_id = fields.Str(required=True)
     context_title = fields.Str(required=True)
     group_set = fields.Str(required=False, allow_none=True)
+    auto_grading_config = fields.Nested(
+        AutoGradingConfigSchema, required=False, allow_none=True
+    )

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -187,7 +187,11 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     )
 
     @pre_load
-    def _decode_auto_grading_config(self, data, **_kwargs):
+    def _load_auto_grading_config(self, data, **_kwargs):
+        """Load auto grading config.
+
+        "form" location doesn't accept Nested fields we'll accept the value as json and deserilize it here.
+        """
         auto_grading_config = data.get("auto_grading_config")
 
         if auto_grading_config and isinstance(auto_grading_config, str):

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -9,7 +9,6 @@ from lms.js_config_types import (
     APIAssignments,
     APICourse,
     APISegment,
-    AutoGradingConfig,
 )
 from lms.models import Assignment, Grouping, RoleScope, RoleType
 from lms.security import Permissions
@@ -117,12 +116,7 @@ class AssignmentViews:
             api_assignment["sections"] = self._groupings_to_api_segment(sections)
 
         if auto_grading_config := assignment.auto_grading_config:
-            api_assignment["auto_grading_config"] = AutoGradingConfig(
-                grading_type=auto_grading_config.grading_type,
-                activity_calculation=auto_grading_config.activity_calculation,
-                required_annotations=auto_grading_config.required_annotations,
-                required_replies=auto_grading_config.required_replies,
-            )
+            api_assignment["auto_grading_config"] = auto_grading_config.asdict()
 
         return api_assignment
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -117,7 +117,9 @@ class BasicLaunchViews:
             "filePicker": js_config["filePicker"],
         }
         if auto_grading_config := assignment.auto_grading_config:
-            assignment_config['assignment']["auto_grading_config"] = auto_grading_config.asdict()
+            assignment_config["assignment"]["auto_grading_config"] = (
+                auto_grading_config.asdict()
+            )
 
         return assignment_config
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -163,6 +163,9 @@ class BasicLaunchViews:
                 data={
                     "old_url": assignment.document_url,
                     "old_group_set_id": assignment.extra.get("group_set_id"),
+                    "old_auto_grading_configuration": assignment.auto_grading_config.asdict()
+                    if assignment.auto_grading_config
+                    else None,
                 },
             )
         )

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -102,8 +102,10 @@ class BasicLaunchViews:
             tool_consumer_instance_guid=self._guid,
             resource_link_id=self._resource_link_id,
         )
-        config = self._configure_js_for_file_picker(assignment, route="edit_assignment")
-        return {
+        js_config = self._configure_js_for_file_picker(
+            assignment, route="edit_assignment"
+        )
+        assignment_config = {
             # Info about the assignment's current configuration
             "assignment": {
                 "group_set_id": assignment.extra.get("group_set_id"),
@@ -112,8 +114,12 @@ class BasicLaunchViews:
                 },
             },
             # Data needed to re-configure it
-            "filePicker": config["filePicker"],
+            "filePicker": js_config["filePicker"],
         }
+        if auto_grading_config := assignment.auto_grading_config:
+            assignment_config['assignment']["auto_grading_config"] = auto_grading_config.asdict()
+
+        return assignment_config
 
     @view_config(
         route_name="configure_assignment",
@@ -274,6 +280,7 @@ class BasicLaunchViews:
             document_url=self.request.parsed_params["document_url"],
             group_set_id=self.request.parsed_params.get("group_set"),
             course=self.course,
+            auto_grading_config=self.request.parsed_params.get("auto_grading_config"),
         )
 
     def _configure_js_for_file_picker(

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -42,7 +42,6 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
-from marshmallow import Schema, validate
 from pyramid.view import view_config, view_defaults
 from webargs import fields
 
@@ -52,6 +51,7 @@ from lms.security import Permissions
 from lms.services import JWTService, UserService
 from lms.validation import DeepLinkingLTILaunchSchema
 from lms.validation._base import JSONPyramidRequestSchema
+from lms.validation._lti_launch_params import AutoGradingConfigSchema
 
 
 @view_config(
@@ -90,20 +90,6 @@ def deep_linking_launch(context, request):
     return {}
 
 
-class _AutoGradingConfigSchema(Schema):
-    grading_type = fields.Str(
-        required=True, validate=validate.OneOf(["all_or_nothing", "scaled"])
-    )
-    activity_calculation = fields.Str(
-        required=True, validate=validate.OneOf(["cumulative", "separate"])
-    )
-
-    required_annotations = fields.Int(required=True, validate=validate.Range(min=0))
-    required_replies = fields.Int(
-        required=False, allow_none=True, validate=validate.Range(min=0)
-    )
-
-
 class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     content_item_return_url = fields.Str(required=True)
     content = fields.Dict(required=True)
@@ -111,7 +97,7 @@ class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     title = fields.Str(required=False, allow_none=True)
 
     auto_grading_config = fields.Nested(
-        _AutoGradingConfigSchema, required=False, allow_none=True
+        AutoGradingConfigSchema, required=False, allow_none=True
     )
 
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -4,7 +4,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 
 from tests.factories import requests_ as requests
 from tests.factories.application_instance import ApplicationInstance
-from tests.factories.assignment import Assignment
+from tests.factories.assignment import Assignment, AutoGradingConfig
 from tests.factories.assignment_grouping import AssignmentGrouping
 from tests.factories.assignment_membership import (
     AssignmentMembership,

--- a/tests/factories/assignment.py
+++ b/tests/factories/assignment.py
@@ -13,3 +13,13 @@ Assignment = make_factory(
     extra={},
     title=Sequence(lambda n: f"Assignment {n}"),
 )
+
+
+AutoGradingConfig = make_factory(
+    models.AutoGradingConfig,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    activity_calculation=Faker("random_element", elements=list(models.AutoGradingType)),
+    grading_type=Faker("random_element", elements=list(models.AutoGradingCalculation)),
+    required_annotations=Faker("random_int"),
+    required_replies=Faker("random_int"),
+)

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -101,6 +101,7 @@ class TestLTIParams:
                 "oauth_nonce": "STRIPPED",
                 "oauth_timestamp": "STRIPPED",
                 "oauth_signature": "STRIPPED",
+                "auto_grading_config": "STRIPPED",
                 "id_token": "STRIPPED",
                 "other_values": "REMAIN",
             }

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -106,6 +106,7 @@ class TestBasicLaunchViews:
             data={
                 "old_url": assignment.document_url,
                 "old_group_set_id": assignment.extra.get.return_value,
+                "old_auto_grading_configuration": assignment.auto_grading_config.asdict.return_value,
             },
         )
         pyramid_request.registry.notify.has_call_with(LTIEvent.return_value)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6768


---

Commenting here on the overall process for some context.

For LMS that support DL and non-DL flows we look for the configuration on:

- Our DB, this will include the last made changed via editing

This is common for launches after the assignment has been created.

- The previous version of this request, this will kick start the config of the assignment for course copy.

This might be the case for first launches of course copied assignments.

- Finally Deeplinked configuration

This will be the fallback and common on the first launch of the assignment.


See:

https://github.com/hypothesis/lms/blob/main/lms/product/plugin/misc.py#L69-L83


This PR only deals with the editing side of things but it needs to make the other changes here for testing things as whole in D2L.



### Testing

- Launch https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3836/View?ou=6782 as an instructor

- Open the dashboard, the assignment is recognized as an autograding configured one.

- Back on the assignment, click "edit", the response from the server includes now the autograding settings:

```
 "assignment": {
        "group_set_id": null,
        "document": {
            "url": "d2l://file/course/6782/file_id/2618/"
        },
        "auto_grading_config": {
            "grading_type": "all_or_nothing",
            "activity_calculation": "cumulative",
            "required_annotations": 1,
            "required_replies": null
        }
    },
```

- Using something like https://github.com/hypothesis/lms/pull/6774 it's possible to test editing end to end on the same assignment.


### TODO 

- [x] Include configuration changes on the audit event.
