### PR TITLE
Fix assignment membership query to handle multiple rows per student/role

### DIFF
--- a/lms/services/lti_grading/_v11.py
+++ b/lms/services/lti_grading/_v11.py
@@ -76,12 +76,12 @@ class LTI11GradingService(LTIGradingService):
             select(LMSUserAssignmentMembership).where(
                 LMSUserAssignmentMembership.lms_user_id == lms_user.id,
                 LMSUserAssignmentMembership.assignment_id == assignment.id,
+                LMSUserAssignmentMembership.lti_v11_lis_result_sourcedid.is_not(None),
             )
-        ).one()
+        ).first()
         assert (
-            assignment_membership.lti_v11_lis_result_sourcedid
-        ), "Trying to grade a student without lti_v11_lis_result_sourcedid"
-
+            assignment_membership and assignment_membership.lti_v11_lis_result_sourcedid
+        ), "Trying to grade a student without a membership or membership without lti_v11_lis_result_sourcedid"
         request = self._record_score_payload(
             score=score,
             user_grading_id=assignment_membership.lti_v11_lis_result_sourcedid,


### PR DESCRIPTION
Fixes:

https://hypothesis.sentry.io/issues/5974852740/?alert_rule_id=4849653&alert_type=issue&notification_uuid=26f3c7e6-6154-42d0-acb5-a246e9e0217f&project=259908&referrer=slack


We store one membership role per assignment, course and role. The existing query used SQLA .one() while querying by just assignment and student which would raise one more that one role existed.

Use .first instead and assert the existence of the membership object below.

The existing assert on  lti_v11_lis_result_sourcedid is there for the typechecker benefit but we also include that condition on the query