### PR TITLE
Make syncing badge more subtle

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
@@ -67,13 +67,13 @@ function Badge({ type }: { type: BadgeType }) {
         {
           'bg-grey-7 text-white': type === 'new',
           'bg-grade-error-light text-grade-error': type === 'error',
-          'bg-grey-3 text-grey-7': type === 'syncing',
+          'bg-grey-2 text-grey-7': type === 'syncing',
         },
       )}
     >
       {type === 'new' && 'New'}
       {type === 'error' && 'Error'}
-      {type === 'syncing' && 'Syncing…'}
+      {type === 'syncing' && 'Syncing'}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -239,7 +239,7 @@ describe('GradeIndicator', () => {
     {
       status: 'in_progress',
       expectedBadge: 'syncing',
-      expectedBadgeText: 'Syncing…',
+      expectedBadgeText: 'Syncing',
     },
   ].forEach(({ status, expectedBadge, expectedBadgeText }) => {
     it('shows the corresponding badge based on status', () => {


### PR DESCRIPTION
Follow the [new designs](https://www.figma.com/design/ctCnzwkAyYArSNBYEshiCm/Hypothesis---LMS-Assignment-Grading?node-id=1981-147&node-type=frame&t=yMc9MmIArxsJe2tK-0) for the "syncing" badge in auto-grading assignments:

* Set a lighter background, which also improves contrast with text.
* Remove the text ellipsis, so that it is more consistent with other badges.

Before:

![image](https://github.com/user-attachments/assets/c46ec0f2-3c66-4a6e-8506-94768470839f)

After:

![image](https://github.com/user-attachments/assets/a27a2b78-35ef-41cf-8610-280275bbe0dc)