### PR TITLE
Make grades synced status more prominent

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/SyncGradesButton.tsx
@@ -1,4 +1,4 @@
-import { Button, LeaveIcon } from '@hypothesis/frontend-shared';
+import { Button, CheckIcon, LeaveIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 import { useParams } from 'wouter-preact';
@@ -69,11 +69,11 @@ export default function SyncGradesButton({
     updateSyncStatus('scheduled');
   }, [studentsToSync?.length, updateSyncStatus]);
 
-  const buttonContent = useMemo(() => {
-    if (!studentsToSync || (lastSync.isLoading && !lastSync.data)) {
-      return 'Loading...';
-    }
+  const isLoading = !studentsToSync || (lastSync.isLoading && !lastSync.data);
+  const allGradesAreSynced =
+    studentsToSync?.length === 0 && lastSync.data?.status === 'finished';
 
+  const buttonContent = useMemo(() => {
     if (
       lastSync.data &&
       ['scheduled', 'in_progress'].includes(lastSync.data.status)
@@ -116,14 +116,10 @@ export default function SyncGradesButton({
       );
     }
 
-    if (studentsToSync.length > 0) {
-      return `Sync ${studentsToSync.length} grades`;
-    }
-
-    return 'Grades synced';
+    const studentsToSyncAmount = studentsToSync?.length ?? 0;
+    return `Sync ${studentsToSyncAmount} ${studentsToSyncAmount === 1 ? 'grade' : 'grades'}`;
   }, [
     studentsToSync,
-    lastSync.isLoading,
     lastSync.data,
     lastSync.error,
     totalStudentsToSync,
@@ -159,7 +155,13 @@ export default function SyncGradesButton({
     updateSyncStatus,
   ]);
 
-  return (
+  return isLoading ? (
+    <span className="py-2 text-color-text-light">...</span>
+  ) : allGradesAreSynced ? (
+    <span className="py-2 font-bold text-green-success flex gap-1 items-center">
+      Grades synced <CheckIcon />
+    </span>
+  ) : (
     <Button variant="primary" onClick={syncGrades} disabled={buttonDisabled}>
       {buttonContent}
     </Button>

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/SyncGradesButton-test.js
@@ -78,8 +78,8 @@ describe('SyncGradesButton', () => {
     it('shows loading text when getting initial data', () => {
       const wrapper = createComponent(studentsToSync);
 
-      assert.equal(buttonText(wrapper), 'Loading...');
-      assert.isTrue(isButtonDisabled(wrapper));
+      assert.equal(wrapper.text(), '...');
+      assert.isFalse(wrapper.exists('Button'));
     });
   });
 
@@ -123,19 +123,26 @@ describe('SyncGradesButton', () => {
   });
 
   [
-    { students: studentsToSync, expectedAmount: studentsToSync.length },
+    {
+      students: studentsToSync,
+      expectedButtonText: `Sync ${studentsToSync.length} grades`,
+    },
     {
       students: [...studentsToSync, ...studentsToSync],
-      expectedAmount: studentsToSync.length * 2,
+      expectedButtonText: `Sync ${studentsToSync.length * 2} grades`,
     },
-  ].forEach(({ students, expectedAmount }) => {
+    {
+      students: [studentsToSync[0]],
+      expectedButtonText: 'Sync 1 grade',
+    },
+  ].forEach(({ students, expectedButtonText }) => {
     it('shows the amount of students to be synced when current status is "finished"', () => {
       const wrapper = createComponent(students, {
         isLoading: false,
         data: { status: 'finished', grades: [] },
       });
 
-      assert.equal(buttonText(wrapper), `Sync ${expectedAmount} grades`);
+      assert.equal(buttonText(wrapper), expectedButtonText);
       assert.isFalse(isButtonDisabled(wrapper));
     });
   });
@@ -156,8 +163,8 @@ describe('SyncGradesButton', () => {
       data: { status: 'finished', grades: [] },
     });
 
-    assert.equal(buttonText(wrapper), 'Grades synced');
-    assert.isTrue(isButtonDisabled(wrapper));
+    assert.equal(wrapper.text().trim(), 'Grades synced');
+    assert.isFalse(wrapper.exists('Button'));
   });
 
   it('submits grades when the button is clicked, then calls onSyncScheduled', async () => {


### PR DESCRIPTION
In order to make it more clear when all grades are synced, this PR changes what gets displayed when the last sync succeeded, and there are exactly zero new grades to sync.

So far we were displaying the sync button disabled, with the text "Grades synced". It made sense for the button to be disabled, as otherwise people would have expected something to happen when clicking it, but that made the "grades synced" message to be too subtle.

This PR changes that so that we display a more prominent success message in place of the button when grades are currently synced. That way the message is more clear and easy to spot, but people won't expect nothing to happen when clicking on it, as it is no longer a button.

Before:

![image](https://github.com/user-attachments/assets/810ce885-43a2-444d-8dd0-eca2a1c6e925)

After:

![check-after](https://github.com/user-attachments/assets/1a9f594b-e1a3-4781-9174-ea07a42ca02f)

https://github.com/user-attachments/assets/3ded2eb7-6e38-4fd9-8122-ca21915d1631

