### PR TITLE
Forward auto-grading config when editing an assignment

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -1,3 +1,4 @@
+import type { AutoGradingConfig } from '../api-types';
 import type { Content } from '../utils/content-item';
 
 export type FilePickerFormFieldsProps = {
@@ -20,6 +21,9 @@ export type FilePickerFormFieldsProps = {
 
   /** Assignment title chosen by the user, if supported by the current LMS. */
   title: string | null;
+
+  /** Auto-grading configuration for assignments where it is enabled */
+  autoGradingConfig: AutoGradingConfig | null;
 };
 
 /**
@@ -33,6 +37,7 @@ export default function FilePickerFormFields({
   content,
   formFields,
   groupSet,
+  autoGradingConfig,
 }: FilePickerFormFieldsProps) {
   return (
     <>
@@ -46,6 +51,13 @@ export default function FilePickerFormFields({
         <input name="document_url" type="hidden" value={content.url} />
       )}
       {title !== null && <input type="hidden" name="title" value={title} />}
+      {autoGradingConfig && (
+        <input
+          type="hidden"
+          name="auto_grading_config"
+          value={JSON.stringify(autoGradingConfig)}
+        />
+      )}
     </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -73,7 +73,13 @@ describe('FilePickerApp', () => {
    */
   function checkFormFields(
     wrapper,
-    { content, groupSet = null, formFields = {}, title = null },
+    {
+      content,
+      groupSet = null,
+      formFields = {},
+      title = null,
+      autoGradingConfig = null,
+    },
   ) {
     const fieldsComponent = wrapper.find('FilePickerFormFields');
     assert.deepEqual(fieldsComponent.props(), {
@@ -82,6 +88,7 @@ describe('FilePickerApp', () => {
       formFields: { ...fakeConfig.filePicker.formFields, ...formFields },
       groupSet,
       title,
+      autoGradingConfig,
     });
   }
 
@@ -404,6 +411,30 @@ describe('FilePickerApp', () => {
           },
           groupSet: useGroupSet ? 'groupSet1' : null,
         });
+      });
+    });
+
+    it('initializes auto_grading_config if assignment already has it', () => {
+      const autoGradingConfig = {
+        grading_type: 'scaled',
+        activity_calculation: 'separate',
+        required_annotations: 10,
+        required_replies: 5,
+      };
+      const url = 'https://example.com';
+
+      fakeConfig.assignment = {
+        auto_grading_config: autoGradingConfig,
+        document: { url },
+      };
+      fakeConfig.filePicker.autoGradingEnabled = true;
+
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      checkFormFields(wrapper, {
+        content: { type: 'url', url },
+        autoGradingConfig,
       });
     });
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -74,4 +74,21 @@ describe('FilePickerFormFields', () => {
     assert.isTrue(titleField.exists());
     assert.equal(titleField.prop('value'), 'Example assignment');
   });
+
+  it('renders `auto_grading_config` if `autoGradingConfig` prop is set', () => {
+    const autoGradingConfig = {
+      grading_type: 'scaled',
+      activity_calculation: 'separate',
+      required_annotations: 10,
+      required_replies: 5,
+    };
+    const formFields = createComponent({
+      content: { type: 'url', url: 'https://example.com/' },
+      autoGradingConfig,
+    });
+    const configField = formFields.find('input[name="auto_grading_config"]');
+
+    assert.isTrue(configField.exists());
+    assert.equal(configField.prop('value'), JSON.stringify(autoGradingConfig));
+  });
 });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6769

Implement logic so that the assignment edition form is initialized with current auto-grading config if it exists and the feature flag is enabled.

Additionally, forward this config in form fields so that assignments can edit their auto-grading config or even disable/enable it entirely.

https://github.com/user-attachments/assets/8e112b5d-285c-4a31-8171-b4ae0b3697ac