### PR TITLE
Enable ruff's RET504 rule

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -42,9 +42,7 @@ class LTIParams(dict):
         # This would be good if we could extract this as a product plugin (or
         # something similar), but unfortunately there's currently a circular
         # dependency where LTI params are required to get the product
-        lti_params = _apply_canvas_quirks(lti_params, request)
-
-        return lti_params
+        return _apply_canvas_quirks(lti_params, request)
 
     def serialize(self, **kwargs) -> dict:
         """

--- a/lms/services/canvas_studio.py
+++ b/lms/services/canvas_studio.py
@@ -204,7 +204,7 @@ class CanvasStudioService:
 
         :param state: `state` query param for the authorization request
         """
-        auth_url = urlunparse(
+        return urlunparse(
             (
                 "https",
                 self._domain,
@@ -221,8 +221,6 @@ class CanvasStudioService:
                 "",
             )
         )
-
-        return auth_url
 
     def _token_url(self) -> str:
         """Return the URL of the Canvas Studio OAuth token endpoint."""
@@ -375,8 +373,7 @@ class CanvasStudioService:
 
         for caption in captions:
             if caption["status"] == "published":
-                url = urljoin(self._canvas_studio_site(), caption["url"])
-                return url
+                return urljoin(self._canvas_studio_site(), caption["url"])
 
         return None
 

--- a/lms/services/jwt.py
+++ b/lms/services/jwt.py
@@ -73,9 +73,7 @@ class JWTService:
         payload = copy.deepcopy(payload)
         payload["exp"] = datetime.datetime.utcnow() + lifetime
 
-        jwt_str = jwt.encode(payload, secret, algorithm="HS256")
-
-        return jwt_str
+        return jwt.encode(payload, secret, algorithm="HS256")
 
     def decode_lti_token(self, id_token: str) -> dict:
         """

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -96,13 +96,12 @@ class LTIAHTTPService:
             LOG.error("Non-json response: %s", response.text)
             raise
 
-        token = self._jwt_oauth2_token_service.save_token(
+        return self._jwt_oauth2_token_service.save_token(
             lti_registration=lti_registration,
             scopes=scopes,
             access_token=token_data["access_token"],
             expires_in=token_data["expires_in"],
         )
-        return token
 
 
 def factory(_context, request):

--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -87,8 +87,7 @@ class MoodleAPIClient:
 
     def course_contents(self, course_id: int) -> list[dict]:
         url = self._api_url(Function.GET_COURSE_CONTENTS)
-        response = self._request(url, params={"courseid": course_id})
-        return response
+        return self._request(url, params={"courseid": course_id})
 
     def list_files(self, course_id: int):
         contents = self.course_contents(course_id)

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -126,18 +126,10 @@ class UserService:
 
     def _user_search_query(self, application_instance_id, user_id) -> Select:
         """Generate a query for searching for users."""
-
-        query = select(User)
-
-        # Normally we'd have an `if application_instance_id` here, for a proper
-        # search query builder, but at the moment all arguments are mandatory,
-        # and doing that would give us a coverage gap.
-        query = query.where(User.application_instance_id == application_instance_id)
-
-        # Ditto `if user_id`
-        query = query.where(User.user_id == user_id)
-
-        return query
+        return select(User).where(
+            User.application_instance_id == application_instance_id,
+            User.user_id == user_id,
+        )
 
     def get_users(  # noqa: PLR0913, PLR0917
         self,

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -50,16 +50,15 @@ class AdminAssignmentViews:
             )
         )
 
-        # We can only navigate to assignments via their course, assigmentl.course won't be null
+        # We can only navigate to assignments via their course, assignment.course won't be null
         assert assignment.course
-        response = HTTPFound(
+        return HTTPFound(
             location=self.request.route_url(
                 "dashboard.organization.assignment",
                 assignment_id=assignment.id,
                 public_id=assignment.course.application_instance.organization.public_id,
             ),
         )
-        return response
 
     def _get_or_404(self) -> Assignment:
         if assignment := self.assignment_service.get_by_id(

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -80,14 +80,13 @@ class AdminCourseViews:
             )
         )
 
-        response = HTTPFound(
+        return HTTPFound(
             location=self.request.route_url(
                 "dashboard.organization.course",
                 public_id=course.application_instance.organization.public_id,
                 course_id=course.id,
             ),
         )
-        return response
 
     @view_config(
         route_name="admin.courses",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ ignore = [
     "PLR2004", # Magic values, we mostly get it on HTTP status codes
 
     # Disabled during the pylint migration, ideally we'll enable this after we are settled in ruff
-    "RET504",
     "RET501",
     "PLR6301",
     "PLR1702",

--- a/tests/bdd/higher_order_gherkin.py
+++ b/tests/bdd/higher_order_gherkin.py
@@ -121,9 +121,7 @@ def {function_name}({signature}):
         )
     )
 """
-        python_code = cls.FORMAT_REMOVER.sub("", python_code)
-
-        return python_code
+        return cls.FORMAT_REMOVER.sub("", python_code)
 
     @classmethod
     def _function_name(cls, name):

--- a/tests/unit/lms/views/api/blackboard/authorize_test.py
+++ b/tests/unit/lms/views/api/blackboard/authorize_test.py
@@ -94,10 +94,7 @@ class TestOAuth2Redirect:
 
 @pytest.fixture(autouse=True)
 def OAuthCallbackSchema(patch):
-    OAuthCallbackSchema = patch(
-        "lms.views.api.blackboard.authorize.OAuthCallbackSchema"
-    )
-    return OAuthCallbackSchema
+    return patch("lms.views.api.blackboard.authorize.OAuthCallbackSchema")
 
 
 @pytest.fixture

--- a/tests/unit/lms/views/api/d2l/authorize_test.py
+++ b/tests/unit/lms/views/api/d2l/authorize_test.py
@@ -104,8 +104,7 @@ class TestOAuth2RedirectError:
 
 @pytest.fixture(autouse=True)
 def OAuthCallbackSchema(patch):
-    OAuthCallbackSchema = patch("lms.views.api.d2l.authorize.OAuthCallbackSchema")
-    return OAuthCallbackSchema
+    return patch("lms.views.api.d2l.authorize.OAuthCallbackSchema")
 
 
 @pytest.fixture

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -301,10 +301,7 @@ def oauth_http_service(mock_service):
 
 @pytest.fixture
 def async_oauth_http_service(mock_service):
-    async_oauth_http_service = mock_service(
-        AsyncOAuthHTTPService, service_name="async_oauth_http"
-    )
-    return async_oauth_http_service
+    return mock_service(AsyncOAuthHTTPService, service_name="async_oauth_http")
 
 
 @pytest.fixture


### PR DESCRIPTION
See: https://docs.astral.sh/ruff/rules/unnecessary-assign/

I could see this being annoying while debugging etc but it can be cleaned when committing.