### PR TITLE
Exclude `auto_grading_config` from LTIParams serialization

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -62,6 +62,10 @@ class LTIParams(dict):
             # authorization
             if param
             not in ["oauth_nonce", "oauth_timestamp", "oauth_signature", "id_token"]
+            +
+            # We also don't want to include parameters that are not part of the LTI spec
+            # but we might submit together in a form while creating and editing assigments.
+            ["auto_grading_config"]
         }
         form_fields.update(**kwargs)
         return form_fields

--- a/tests/unit/lms/models/lti_params_test.py
+++ b/tests/unit/lms/models/lti_params_test.py
@@ -101,6 +101,7 @@ class TestLTIParams:
                 "oauth_nonce": "STRIPPED",
                 "oauth_timestamp": "STRIPPED",
                 "oauth_signature": "STRIPPED",
+                "auto_grading_config": "STRIPPED",
                 "id_token": "STRIPPED",
                 "other_values": "REMAIN",
             }


### PR DESCRIPTION
The creation and editing flow uses a form based API where we first serialize LTIParams for the frontend which then forwards it back to the server with the addition of any configuration for the assignment on the same form namespace.

LTIParams serialization doesn't whitelist a list of LTI parameters to forwards but instead includes every form parameter of the request except the authorization related ones.

When creation or edit includes the auto_grading_config option, this is included in the form by the FE, the BE reads the config from the form to make the changes to the assignment but also includes that key in the `formFields` serialized LTIParams for the next editing attempt.

We'll exclude `auto_grading_config` from LTIParams serialize as is not part of the LTI spec and just an internal API value. The FE will include this value in the form when necessary.