### PR TITLE
Route email digest tasks to their own queue

### DIFF
--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -38,6 +38,8 @@ app.conf.update(
         "interval_start": 0.2,
         "interval_step": 0.2,
     },
+    # Automatically try to establish the connection to the AMQP broker on Celery startup if it is unavailable.
+    broker_connection_retry_on_startup=True,
     task_routes={
         # Route all email_digests task to their own queue
         "lms.tasks.email_digests.*": "email_digests",

--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -38,6 +38,10 @@ app.conf.update(
         "interval_start": 0.2,
         "interval_step": 0.2,
     },
+    task_routes={
+        # Route all email_digests task to their own queue
+        "lms.tasks.email_digests.*": "email_digests",
+    },
     # Tell Celery to kill any task run (by raising
     # celery.exceptions.SoftTimeLimitExceeded) if it takes longer than
     # task_soft_time_limit seconds.


### PR DESCRIPTION
Needs: https://github.com/hypothesis/lms/pull/6661

After adding a new queue on startup we'll send email digests tasks to the new queue. Existing task will still execute in the old queue.


### Testing

- Start the server with `make dev` or restart it
- Go over http://localhost:8001/admin/email send a few emails
- Tags will get executed:

```
worker-email-digests (stderr) | [2024-10-22 15:26:33,251: INFO/MainProcess] Task lms.tasks.email_digests.send_instructor_email_digest[6641d500-babc-48bc-9418-af1fa4ac295f] received
worker-email-digests (stderr) | [2024-10-22 15:26:33,448: INFO/ForkPoolWorker-16] lms.tasks.email_digests.send_instructor_email_digest[6641d500-babc-48bc-9418-af1fa4ac295f] Task lms.tasks.email_digests.send_instructor_email_digest[6641d500-babc-48bc-9418-af1fa4ac295f] succeeded in 0.19559066195506603s: None
worker-email-digests (stderr) | [2024-10-22 15:26:34,379: INFO/MainProcess] Task lms.tasks.email_digests.send_instructor_email_digest[5be024c5-191e-4cc7-bfa9-039dc69386c9] received
worker-email-digests (stderr) | [2024-10-22 15:26:34,429: INFO/ForkPoolWorker-16] lms.tasks.email_digests.send_instructor_email_digest[5be024c5-191e-4cc7-bfa9-039dc69386c9] Task lms.tasks.email_digests.send_instructor_email_digest[5be024c5-191e-4cc7-bfa9-039dc69386c9] succeeded in 0.04851568298181519s: None
worker-email-digests (stderr) | [2024-10-22 15:26:35,210: INFO/MainProcess] Task lms.tasks.email_digests.send_instructor_email_digest[827595f2-c225-484f-95a3-9e74b9927eff] received
worker-email-digests (stderr) | [2024-10-22 15:26:35,259: INFO/ForkPoolWorker-16] lms.tasks.email_digests.send_instructor_email_digest[827595f2-c225-484f-95a3-9e74b9927eff] Task lms.tasks.email_digests.send_instructor_email_digest[827595f2-c225-484f-95a3-9e74b9927eff] succeeded in 0.04665517102694139s: None
```


- Stop the worker on the new queue:

```
.tox/dev/bin/supervisorctl -c conf/supervisord-dev.conf stop worker-email-digests
```

- Enqueue a few more emails on the admin page
- Nothing on the logs
- Start the queue again

```
.tox/dev/bin/supervisorctl -c conf/supervisord-dev.conf start worker-email-digests
```

- Jobs get executed now
- 