### PR TITLE
Ignore leading and trailing whitespace when extracting book IDs

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/vitalsource-test.js
@@ -4,6 +4,9 @@ describe('extractBookID', () => {
   [
     'https://bookshelf.vitalsource.com/#/books/9781400847402X',
 
+    // Leading and trailing whitespace are ignored
+    '  https://bookshelf.vitalsource.com/#/books/9781400847402X  ',
+
     // It does not matter if there are path elements after the book ID
     'https://bookshelf.vitalsource.com/#/books/9781400847402X/foo/bar',
 
@@ -28,7 +31,11 @@ describe('extractBookID', () => {
     // Another alphanumeric string earlier in URL should be ignored
     'https://bookshelf.vitalsource.com/1039439489/#/books/9781400847402X/foo/bar',
 
+    // Book ID on its own
     '9781400847402X',
+
+    // Book ID with leading and trailing whitespace
+    '  9781400847402X  ',
   ].forEach(input => {
     it(`should parse book ID from "${input}""`, () => {
       assert.equal(extractBookID(input), '9781400847402X');

--- a/lms/static/scripts/frontend_apps/utils/vitalsource.ts
+++ b/lms/static/scripts/frontend_apps/utils/vitalsource.ts
@@ -22,11 +22,12 @@
  *  `input`
  */
 export function extractBookID(input: string): string | null {
-  const urlMatches = input.match(/books\/([0-9A-Z-]+)(\/|$)/);
+  const trimmedInput = input.trim();
+  const urlMatches = trimmedInput.match(/books\/([0-9A-Z-]+)(\/|$)/);
   if (urlMatches) {
     return urlMatches[1];
   }
-  const bookIDMatches = input.match(/^([0-9A-Z-]+)$/);
+  const bookIDMatches = trimmedInput.match(/^([0-9A-Z-]+)$/);
   if (bookIDMatches) {
     return bookIDMatches[1];
   }


### PR DESCRIPTION
Ignore leading or trailing whitespace in the input field when extracting VitalSource book IDs from the user's input in the assignment picker.

This is currently implemented in `extractBookID`, which mirrors how we do this for JSTOR, but could alternatively have been implemented as part of the input control.

Fixes https://github.com/hypothesis/support/issues/142 (see this issue for test case)