### PR TITLE
Expose organization info in the dashboard

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -146,8 +146,16 @@ class User(TypedDict):
     display_name: str
 
 
+class APIOrganization(TypedDict):
+    public_id: str
+    name: str
+
+
 class DashboardConfig(TypedDict):
     user: User
+    organization: NotRequired[APIOrganization]
+    """Organization data for dashboard access scoped to one organization. For staff members only."""
+
     routes: DashboardRoutes
 
     auto_grading_sync_enabled: bool

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from lms.error_code import ErrorCode
 from lms.events import LTIEvent
-from lms.js_config_types import DashboardConfig, DashboardRoutes, User
+from lms.js_config_types import APIOrganization, DashboardConfig, DashboardRoutes, User
 from lms.models import ApplicationInstance, Assignment, Course, Grouping
 from lms.product.blackboard import Blackboard
 from lms.product.canvas import Canvas
@@ -19,6 +19,7 @@ from lms.services import (
     EventService,
     HAPIError,
     JSTORService,
+    OrganizationService,
     VitalSourceService,
 )
 from lms.validation.authentication import BearerTokenSchema
@@ -298,6 +299,14 @@ class JSConfig:
                 ),
             }
         )
+        if self._request.has_permission(Permissions.STAFF) and (
+            request_public_id := self._request.matchdict.get("public_id")
+        ):
+            organization_service = self._request.find_service(OrganizationService)
+            organization = organization_service.get_by_public_id(request_public_id)
+            self._config["dashboard"]["organization"] = APIOrganization(
+                name=organization.name, public_id=request_public_id
+            )
 
     def enable_lti_launch_mode(self, course, assignment: Assignment):
         """

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -761,7 +761,9 @@ class TestEnableDashboardMode:
             "assignment_segments_filter_enabled": assignment_segments_filter_setting,
         }
 
-    def test_user_when_staff(self, js_config, pyramid_request_staff_member, context):
+    def test_user_when_staff(
+        self, js_config, pyramid_request_staff_member, context, organization_service
+    ):
         js_config = JSConfig(context, pyramid_request_staff_member)
         js_config.enable_dashboard_mode(token_lifetime_seconds=100)
         config = js_config.asdict()
@@ -769,6 +771,10 @@ class TestEnableDashboardMode:
         assert config["dashboard"]["user"] == {
             "is_staff": True,
             "display_name": "staff@example.com",
+        }
+        assert config["dashboard"]["organization"] == {
+            "name": organization_service.get_by_public_id.return_value.name,
+            "public_id": sentinel.public_id,
         }
         # Grade syncing always disabled for staff
         assert not config["dashboard"]["auto_grading_sync_enabled"]
@@ -781,6 +787,7 @@ class TestEnableDashboardMode:
             userid="staff@example.com",
             identity=Identity("staff@example.com", [Permissions.STAFF]),
         )
+        pyramid_request.matchdict["public_id"] = sentinel.public_id
         pyramid_request.lti_user = None
         return pyramid_request
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1567


This will allow to expose the name of the scoped organization in the staff dashboards.


## Testing 

- Open an organization in the admin pages
- Open the dashboard from there
- Check the config returned by the BE:

```
"auto_grading_sync_enabled": null,
"organization": {
  "name": "University of Hypothesis", "public_id": "us.lms.org.kXFNz2fJQBaQ3l5ZKF3nJA"
}, 
"routes":...
```

