### PR TITLE
Consider LTI role to grant admin status in the dashboards

### DIFF
--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -7,12 +7,17 @@ These duplicate some of the information stored in Grouping and GroupingMembershi
     - LMSCourse membership stores role information, GroupingMembership doesn't.
 """
 
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from lms.db import Base
 from lms.models import ApplicationInstance
 from lms.models._mixins import CreatedUpdatedMixin
+
+if TYPE_CHECKING:
+    from lms.models import LMSUser, LTIRole
 
 
 class LMSCourse(CreatedUpdatedMixin, Base):
@@ -75,12 +80,15 @@ class LMSCourseMembership(CreatedUpdatedMixin, Base):
     lms_course_id: Mapped[int] = mapped_column(
         sa.ForeignKey("lms_course.id", ondelete="cascade"), index=True
     )
+    lms_course: Mapped[LMSCourse] = relationship()
 
     lms_user_id: Mapped[int] = mapped_column(
         sa.ForeignKey("lms_user.id", ondelete="cascade"), index=True
     )
+    lms_user: Mapped["LMSUser"] = relationship()
 
     lti_role_id: Mapped[int] = mapped_column(
         sa.ForeignKey("lti_role.id", ondelete="cascade"),
         index=True,
     )
+    lti_role: Mapped["LTIRole"] = relationship()

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -65,7 +65,7 @@ class LTIUser:
     """The user's email address."""
 
     @property
-    def h_user(self):
+    def h_user(self) -> HUser:
         """Return a models.HUser generated from this LTIUser."""
         return HUser.from_lti_user(self)
 

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -44,12 +44,6 @@ class DashboardViews:
         )
         self.dashboard_service = request.find_service(name="dashboard")
 
-        self.admin_organizations = (
-            self.dashboard_service.get_organizations_by_admin_email(
-                request.lti_user.email if request.lti_user else request.identity.userid
-            )
-        )
-
     @view_config(
         route_name="dashboard.launch.assignment",
         permission=Permissions.DASHBOARD_VIEW,

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -32,7 +32,11 @@ from tests.factories.grouping_membership import GroupingMembership
 from tests.factories.h_user import HUser
 from tests.factories.hubspot_company import HubSpotCompany
 from tests.factories.jwt_oauth2_token import JWTOAuth2Token
-from tests.factories.lms_course import LMSCourse, LMSCourseApplicationInstance
+from tests.factories.lms_course import (
+    LMSCourse,
+    LMSCourseApplicationInstance,
+    LMSCourseMembership,
+)
 from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride

--- a/tests/factories/lms_course.py
+++ b/tests/factories/lms_course.py
@@ -16,3 +16,7 @@ LMSCourse = make_factory(
 LMSCourseApplicationInstance = make_factory(
     models.LMSCourseApplicationInstance, FACTORY_CLASS=SQLAlchemyModelFactory
 )
+
+LMSCourseMembership = make_factory(
+    models.LMSCourseMembership, FACTORY_CLASS=SQLAlchemyModelFactory
+)


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1572

---

Give access to the dashboards for full organizations to users
that the LMS identifies as system wide admins (scope: system, type admin in our LTIRoles table)


### Testing



- Log into BB as an instructor, e.g. `blackboardteacher`
- Open a bunch of assignments in different courses (these are the "same" assignment in different copied courses)

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_36_1&course_id=_19_1

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1655_1&course_id=_153_1

https://aunltd-test.blackboard.com/webapps/blackboard/execute/blti/launchPlacement?blti_placement_id=_20_1&content_id=_1367_1&course_id=_139_1



- Log in as `administrator`, open just one of the assignments and go to the dashboards 
- Go to all courses, you'll see all three courses instead of just the one you launched as admin.
- Compare this with `main`, switch branches, refresh the dashboard, you'll only see one course.

