### PR TITLE
Display organization name in dashboard when available

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AllCoursesActivity.tsx
@@ -8,6 +8,7 @@ import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { courseURL } from '../../utils/dashboard/navigation';
+import { rootViewTitle } from '../../utils/dashboard/root-view-title';
 import { useDocumentTitle } from '../../utils/hooks';
 import DashboardActivityFilters from './DashboardActivityFilters';
 import FormattedDate from './FormattedDate';
@@ -26,8 +27,9 @@ type CoursesTableRow = {
 export default function AllCoursesActivity() {
   const { dashboard } = useConfig(['dashboard']);
   const { routes } = dashboard;
+  const title = rootViewTitle(dashboard);
 
-  useDocumentTitle('All courses');
+  useDocumentTitle(title);
 
   const { organizationPublicId } = useParams();
   const { filters, updateFilters, urlWithFilters } = useDashboardFilters();
@@ -51,7 +53,9 @@ export default function AllCoursesActivity() {
 
   return (
     <div className="flex flex-col gap-y-5">
-      <h2 className="text-lg text-brand font-semibold">All courses</h2>
+      <h2 className="text-lg text-brand font-semibold" data-testid="title">
+        {title}
+      </h2>
       <DashboardActivityFilters
         students={{
           selectedIds: studentIds,

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -14,6 +14,7 @@ import { useConfig } from '../../config';
 import { useAPIFetch, usePolledAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { courseURL } from '../../utils/dashboard/navigation';
+import { rootViewTitle } from '../../utils/dashboard/root-view-title';
 import { useDocumentTitle } from '../../utils/hooks';
 import { type QueryParams, replaceURLParams } from '../../utils/url';
 import RelativeTime from '../RelativeTime';
@@ -264,8 +265,11 @@ export default function AssignmentActivity() {
         {assignment.data && (
           <div className="mb-3 mt-1 w-full flex items-center">
             <DashboardBreadcrumbs
-              allCoursesLink={urlWithFilters({ studentIds }, { path: '' })}
               links={[
+                {
+                  title: rootViewTitle(dashboard),
+                  href: urlWithFilters({ studentIds }, { path: '' }),
+                },
                 {
                   title: assignment.data.course.title,
                   href: urlWithFilters(

--- a/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/CourseActivity.tsx
@@ -12,6 +12,7 @@ import { useConfig } from '../../config';
 import { useAPIFetch } from '../../utils/api';
 import { useDashboardFilters } from '../../utils/dashboard/hooks';
 import { assignmentURL } from '../../utils/dashboard/navigation';
+import { rootViewTitle } from '../../utils/dashboard/root-view-title';
 import { useDocumentTitle } from '../../utils/hooks';
 import { replaceURLParams } from '../../utils/url';
 import DashboardActivityFilters from './DashboardActivityFilters';
@@ -83,10 +84,15 @@ export default function CourseActivity() {
       <div>
         <div className="mb-3 mt-1 w-full">
           <DashboardBreadcrumbs
-            allCoursesLink={urlWithFilters(
-              { assignmentIds, studentIds },
-              { path: '' },
-            )}
+            links={[
+              {
+                title: rootViewTitle(dashboard),
+                href: urlWithFilters(
+                  { assignmentIds, studentIds },
+                  { path: '' },
+                ),
+              },
+            ]}
           />
         </div>
         <h2 className="text-lg text-brand font-semibold" data-testid="title">

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardBreadcrumbs.tsx
@@ -4,7 +4,6 @@ import {
   Link,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
-import { useMemo } from 'preact/hooks';
 import { Link as RouterLink } from 'wouter-preact';
 
 export type BreadcrumbLink = {
@@ -13,9 +12,7 @@ export type BreadcrumbLink = {
 };
 
 export type DashboardBreadcrumbsProps = {
-  /** Link to the "All courses" view. Defaults to '' */
-  allCoursesLink?: string;
-  /** More links to append to the breadcrumb after the "All courses" one */
+  /** List of links to display in breadcrumb */
   links?: BreadcrumbLink[];
 };
 
@@ -38,24 +35,15 @@ function BreadcrumbLink({ title, href }: BreadcrumbLink) {
  * Navigation breadcrumbs showing a list of links
  */
 export default function DashboardBreadcrumbs({
-  allCoursesLink = '',
   links = [],
 }: DashboardBreadcrumbsProps) {
-  const linksWithHome = useMemo(
-    (): BreadcrumbLink[] => [
-      { title: 'All courses', href: allCoursesLink },
-      ...links,
-    ],
-    [allCoursesLink, links],
-  );
-
   return (
     <div
       className="flex flex-row gap-0.5 grow font-semibold"
       data-testid="breadcrumbs-container"
     >
-      {linksWithHome.map(({ title, href }, index) => {
-        const isLastLink = index === linksWithHome.length - 1;
+      {links.map(({ title, href }, index) => {
+        const isLastLink = index === links.length - 1;
         return (
           <span
             key={`${index}${href}`}
@@ -66,10 +54,10 @@ export default function DashboardBreadcrumbs({
               // Distribute max width for every link as evenly as possible.
               // These must be static values for Tailwind to detect them.
               // See https://tailwindcss.com/docs/content-configuration#dynamic-class-names
-              'md:max-w-[50%]': linksWithHome.length === 2,
-              'md:max-w-[33%]': linksWithHome.length === 3,
-              'md:max-w-[25%]': linksWithHome.length === 4,
-              'md:max-w-[230px]': linksWithHome.length > 4,
+              'md:max-w-[50%]': links.length === 2,
+              'md:max-w-[33%]': links.length === 3,
+              'md:max-w-[25%]': links.length === 4,
+              'md:max-w-[230px]': links.length > 4,
             })}
           >
             <BreadcrumbLink href={href} title={title} />

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AllCoursesActivity-test.js
@@ -87,7 +87,6 @@ describe('AllCoursesActivity', () => {
   }
 
   /**
-   *
    * @param {'students' | 'assignments' | 'courses'} filterProp
    */
   function updateFilter(wrapper, filterProp, ids) {
@@ -95,6 +94,24 @@ describe('AllCoursesActivity', () => {
     act(() => filters.prop(filterProp).onChange(ids));
     wrapper.update();
   }
+
+  [
+    { organization: undefined, expectedTitle: 'All courses' },
+    {
+      organization: {
+        name: 'University of Hypothesis',
+      },
+      expectedTitle: 'University of Hypothesis',
+    },
+  ].forEach(({ organization, expectedTitle }) => {
+    it('sets expected page title', () => {
+      fakeConfig.dashboard.organization = organization;
+      const wrapper = createComponent();
+
+      assert.equal(wrapper.find('[data-testid="title"]').text(), expectedTitle);
+      assert.equal(document.title, `${expectedTitle} - Hypothesis`);
+    });
+  });
 
   it('sets loading state in table while data is loading', () => {
     fakeUseAPIFetch.returns({ isLoading: true });

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardBreadcrumbs-test.js
@@ -14,17 +14,7 @@ describe('DashboardBreadcrumbs', () => {
         links: links.map(title => ({ title, href: `/${title}` })),
       });
 
-      // Breadcrumbs always renders a static extra link for the home page
-      assert.equal(wrapper.find('BreadcrumbLink').length, links.length + 1);
-    });
-  });
-
-  [undefined, '/foo', '/home?foo=bar'].forEach(allCoursesLink => {
-    it('uses all courses link if provided', () => {
-      const wrapper = createComponent({ allCoursesLink, links: [] });
-      const firstLink = wrapper.find('BreadcrumbLink').first();
-
-      assert.equal(firstLink.prop('href'), allCoursesLink ?? '');
+      assert.equal(wrapper.find('BreadcrumbLink').length, links.length);
     });
   });
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -281,6 +281,11 @@ export type DashboardUser = {
   display_name: string;
 };
 
+export type DashboardOrganization = {
+  name: string;
+  public_id: string;
+};
+
 export type DashboardConfig = {
   routes: DashboardRoutes;
   user: DashboardUser;
@@ -295,6 +300,14 @@ export type DashboardConfig = {
    * segments filter.
    */
   assignment_segments_filter_enabled: boolean;
+
+  /**
+   * Organization-related information.
+   *
+   * Only present when the dashboard is opened for a particular
+   * organization: `/dashboard/orgs/{org_public_id}`
+   */
+  organization?: DashboardOrganization;
 };
 
 /**

--- a/lms/static/scripts/frontend_apps/utils/dashboard/root-view-title.ts
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/root-view-title.ts
@@ -1,0 +1,11 @@
+import type { DashboardConfig } from '../../config';
+
+/**
+ * Return the title for the dashboard's root view.
+ *
+ * That is the organization name if the dashboard was launched for one specific
+ * org, or 'All courses' otherwise.
+ */
+export function rootViewTitle(dashboardConfig: DashboardConfig): string {
+  return dashboardConfig.organization?.name ?? 'All courses';
+}

--- a/lms/static/scripts/frontend_apps/utils/dashboard/test/root-view-title-test.js
+++ b/lms/static/scripts/frontend_apps/utils/dashboard/test/root-view-title-test.js
@@ -1,0 +1,20 @@
+import { rootViewTitle } from '../root-view-title';
+
+describe('rootViewTitle', () => {
+  [
+    {
+      config: {},
+      expectedTitle: 'All courses',
+    },
+    {
+      config: {
+        organization: { name: 'University of Hypothesis' },
+      },
+      expectedTitle: 'University of Hypothesis',
+    },
+  ].forEach(({ config, expectedTitle }) => {
+    it('returns expected title for provided config', () => {
+      assert.equal(rootViewTitle(config), expectedTitle);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/hypothesis/product-backlog/issues/1567

This PR changes the logic in the dashboard so that we display the organization name in the breadcrumb and "All courses" section, if the dashboard was opened for one particular org.

![image](https://github.com/user-attachments/assets/c868b6dd-4cb4-42bc-8d11-326067b76c0f)

![image](https://github.com/user-attachments/assets/cafa9ef0-356a-413e-9afc-7ed4fcbb643e)

### Testing steps

1. Open a course in the LMS admin, for example http://localhost:8001/admin/courses/1
2. In the upper-right corner, click "Open instructor dashboard"
3. You should see the organization name in the breadcrumbs top level element.
4. If you navigate to that element, AKA "All courses", you should see the organization's name as the view's title.
5. Now open the dashboard from an assignment in the LMS.
6. The elements mentioned above should display the text "All courses" now, as it has been up until now.