### PR TITLE
Make dashboard filters listboxes render always inside the viewport

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/hooks.ts
+++ b/lms/static/scripts/frontend_apps/utils/hooks.ts
@@ -1,3 +1,4 @@
+import type { MutableRef } from 'preact/hooks';
 import { useEffect, useState } from 'preact/hooks';
 
 // Global counter used to create a unique ids
@@ -56,4 +57,33 @@ export function usePlaceholderDocumentTitleInDev() {
 
     return () => window.navigation?.removeEventListener('navigate', listener);
   }, []);
+}
+
+/**
+ * Determines if an element is truncated due to content or text hidden overflow
+ */
+export function useElementIsTruncated<T extends HTMLElement>(
+  elementRef: MutableRef<T | null>,
+): boolean {
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) {
+      return () => {};
+    }
+
+    const computeIsTruncated = () =>
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+
+    // Check if element ius truncated on mount
+    computeIsTruncated();
+    // Re-check when the element intersects with the viewport
+    const observer = new IntersectionObserver(computeIsTruncated);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [elementRef]);
+
+  return isTruncated;
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.7.0",
+    "@hypothesis/frontend-shared": "^8.8.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,15 +1982,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.7.0":
-  version: 8.7.0
-  resolution: "@hypothesis/frontend-shared@npm:8.7.0"
+"@hypothesis/frontend-shared@npm:^8.8.0":
+  version: 8.8.0
+  resolution: "@hypothesis/frontend-shared@npm:8.8.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 646087a5d592080e7bdd336ecd18df047450b15c3410b4bd39b36a41702bfcdbbf39b378ad3a17a2442b825dfc0500d10c25be24b6c2a9d814052f33d3e2fe11
+  checksum: c6e1e9359400dabc12e03cb4f805ba5b4404d930a45a46a2a62e710e199e51f3c8c950b1d205c3b6276e7ffba3350bf8b16b8dea29a15884ccae7ac326a76769
   languageName: node
   linkType: hard
 
@@ -7135,7 +7135,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@babel/preset-typescript": ^7.26.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.7.0
+    "@hypothesis/frontend-shared": ^8.8.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.1


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/1561

Update dashboard filtering dropdowns so that:

1. Their listboxes never render out of the viewport, trying to make a smarter use of available space.
2. Their listboxes never grow bigger than the body.
3. Options with big content are truncated with `text-overflow: ellipsis`.
4. A `title` is added with the full content of listbox options when they have been truncated.

https://github.com/user-attachments/assets/086727c7-9a68-4799-b2e3-e69c15ddcf9f

### Considerations

This approach has the problem that content may not be fully displayed in mobile devices, as they cannot take advantage of the dynamic `title`.

However, by inspecting real production data, it has been concluded that text should usually not overflow in 99% of cases.

If this becomes a problem in future, we could check the screen size via [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) and avoid truncation altogether in small resolutions, where the content would wrap multiple times.