### PR TITLE
Use dataclasses for model definitions for Assignment and LMSUser

### DIFF
--- a/lms/db/__init__.py
+++ b/lms/db/__init__.py
@@ -6,7 +6,7 @@ import sqlalchemy
 import zope.sqlalchemy
 from sqlalchemy import text
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from sqlalchemy.orm.properties import ColumnProperty
 
 from lms.db._columns import varchar_enum
@@ -16,14 +16,14 @@ from lms.db._text_search import full_text_match
 __all__ = ("Base", "create_engine", "varchar_enum")
 
 
-Base = declarative_base(
+class Base(DeclarativeBase):
     # Create a default metadata object with naming conventions for indexes and
     # constraints. This makes changing such constraints and indexes with
     # alembic after creation much easier. See:
     #
     #   http://docs.sqlalchemy.org/en/latest/core/constraints.html#configuring-constraint-naming-conventions
     #
-    metadata=sqlalchemy.MetaData(
+    metadata = sqlalchemy.MetaData(
         naming_convention={
             "ix": "ix__%(column_0_label)s",
             "uq": "uq__%(table_name)s__%(column_0_name)s",
@@ -31,8 +31,7 @@ Base = declarative_base(
             "fk": "fk__%(table_name)s__%(column_0_name)s__%(referred_table_name)s",
             "pk": "pk__%(table_name)s",
         }
-    ),
-)
+    )
 
 
 def create_engine(database_url):

--- a/lms/events/event.py
+++ b/lms/events/event.py
@@ -117,7 +117,7 @@ class ModelChange:
 @dataclass
 class AuditTrailEvent(BaseEvent):
     @staticmethod
-    def notify(request: Request, instance: Base, source="admin_pages"):
+    def notify(request: Request, instance, source="admin_pages"):
         db = request.db
         model_changes = None
         if db.is_modified(instance):

--- a/lms/models/_mixins/__init__.py
+++ b/lms/models/_mixins/__init__.py
@@ -1,1 +1,4 @@
-from lms.models._mixins.created_updated import CreatedUpdatedMixin
+from lms.models._mixins.created_updated import (
+    CreatedUpdatedMixin,
+    CreatedUpdatedMixinAsDataClass,
+)

--- a/lms/models/_mixins/created_updated.py
+++ b/lms/models/_mixins/created_updated.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -8,4 +9,14 @@ class CreatedUpdatedMixin:
     created: Mapped[datetime] = mapped_column(server_default=sa.func.now())
     updated: Mapped[datetime] = mapped_column(
         server_default=sa.func.now(), onupdate=sa.func.now()
+    )
+
+
+@dataclass
+class CreatedUpdatedMixinAsDataClass:
+    """Duplicate of CreatedUpdatedMixin but compatible with models that use MappedAsDataclass."""
+
+    created: Mapped[datetime] = mapped_column(server_default=sa.func.now(), repr=False)
+    updated: Mapped[datetime] = mapped_column(
+        server_default=sa.func.now(), onupdate=sa.func.now(), repr=False
     )

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+# Mypy detects "Attributes without a default cannot follow attributes with one" but it seems like a false possitive
 from enum import StrEnum
 
 import sqlalchemy as sa
@@ -142,7 +144,7 @@ class Assignment(
 
     course_id: Mapped[int | None] = mapped_column(sa.ForeignKey(Course.id), index=True)
 
-    course: Mapped[Course | None] = relationship(Course, repr=None)
+    course: Mapped[Course | None] = relationship(Course, repr=False)
 
     lis_outcome_service_url: Mapped[str | None] = mapped_column()
     """URL of the grading serivce relevant for this assignment.

--- a/lms/models/grading_sync.py
+++ b/lms/models/grading_sync.py
@@ -30,6 +30,10 @@ class GradingSync(CreatedUpdatedMixin, Base):
 
     status: Mapped[str | None] = varchar_enum(AutoGradingSyncStatus)
 
+    grades: Mapped[list["GradingSyncGrade"]] = relationship(
+        "GradingSyncGrade", back_populates="grading_sync"
+    )
+
     created_by_id: Mapped[int] = mapped_column(ForeignKey("lms_user.id"))
     created_by: Mapped["LMSUser"] = relationship()
     """Who created this grade sync."""
@@ -58,7 +62,9 @@ class GradingSyncGrade(CreatedUpdatedMixin, Base):
     grading_sync_id: Mapped[int] = mapped_column(
         ForeignKey("grading_sync.id"), index=True
     )
-    grading_sync: Mapped[GradingSync] = relationship(backref="grades")
+    grading_sync: Mapped[GradingSync] = relationship(
+        "GradingSync", back_populates="grades"
+    )
 
     lms_user_id: Mapped[int] = mapped_column(ForeignKey("lms_user.id"), index=True)
     lms_user: Mapped["LMSUser"] = relationship()

--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,5 +1,5 @@
 from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Self, TypedDict
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
@@ -90,16 +90,20 @@ class Grouping(CreatedUpdatedMixin, Base):
     #:
     #: For example if the grouping represents a Canvas section or group then parent_id
     #: will reference the grouping for the course that the section or group belongs to.
-    parent_id = sa.Column(sa.Integer(), nullable=True)
+    parent_id: Mapped[int | None] = mapped_column()
+    parent: Mapped[Self | None] = sa.orm.relationship(
+        "Course",
+        remote_side=[id, application_instance_id],
+        foreign_keys=[parent_id, application_instance_id],
+        back_populates="children",
+        overlaps="application_instance",
+    )
+
     children = sa.orm.relationship(
         "Grouping",
         foreign_keys=[parent_id, application_instance_id],
-        backref=sa.orm.backref(
-            "parent",
-            remote_side=[id, application_instance_id],
-            overlaps="application_instance",
-        ),
         overlaps="application_instance",
+        back_populates="parent",
     )
 
     #: The LMS's ID for the grouping.

--- a/lms/models/lms_user.py
+++ b/lms/models/lms_user.py
@@ -7,13 +7,20 @@ These duplicate some of the information stored in User, the main differences bei
 """
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 from lms.db import Base
-from lms.models._mixins import CreatedUpdatedMixin
+from lms.models._mixins import CreatedUpdatedMixin, CreatedUpdatedMixinAsDataClass
 
 
-class LMSUser(CreatedUpdatedMixin, Base):
+class LMSUser(
+    MappedAsDataclass,
+    Base,
+    CreatedUpdatedMixinAsDataClass,
+    init=False,
+    eq=False,
+    unsafe_hash=True,
+):
     __tablename__ = "lms_user"
 
     __table_args__ = (
@@ -42,9 +49,9 @@ class LMSUser(CreatedUpdatedMixin, Base):
     h_userid: Mapped[str] = mapped_column(unique=True, index=True)
     """The userid value in H. This is calculated hashing tool_consumer_instance_guid and lti_user_id together."""
 
-    email: Mapped[str | None] = mapped_column()
+    email: Mapped[str | None] = mapped_column(repr=False)
 
-    display_name: Mapped[str | None] = mapped_column(index=True)
+    display_name: Mapped[str | None] = mapped_column(index=True, repr=False)
 
 
 class LMSUserApplicationInstance(CreatedUpdatedMixin, Base):

--- a/lms/models/lms_user.py
+++ b/lms/models/lms_user.py
@@ -1,3 +1,5 @@
+# mypy: disable-error-code="misc"
+# Mypy detects "Attributes without a default cannot follow attributes with one" but it seems like a false possitive
 """Models to represent users.
 
 These duplicate some of the information stored in User, the main differences being:

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -29,9 +29,11 @@ class Organization(CreatedUpdatedMixin, Base):
     )
     """Optional parent organization."""
 
-    children = sa.orm.relationship(
-        "Organization", backref=sa.orm.backref("parent", remote_side=[id])
+    parent = sa.orm.relationship(
+        "Organization", back_populates="children", remote_side=[id]
     )
+
+    children = sa.orm.relationship("Organization", back_populates="parent")
     """Get any children of this organization."""
 
     application_instances = sa.orm.relationship(

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -1,5 +1,6 @@
 import json
 from copy import deepcopy
+from typing import cast
 
 from sqlalchemy import Select, Text, column, func, select, union
 
@@ -299,6 +300,8 @@ class CourseService:
             type_=Grouping.Type.COURSE,
             copied_from=copied_from,
         )[0]
+        # upsert_groupings returns Groupings of type `type_`
+        course = cast(Course, course)
 
         self._upsert_lms_course(course, lti_params)
         return course

--- a/lms/services/grouping/service.py
+++ b/lms/services/grouping/service.py
@@ -131,7 +131,7 @@ class GroupingService:
             self._db.query(Grouping)
             .join(GroupingMembership)
             .join(User)
-            .join(course_grouping, Grouping.parent)
+            .join(course_grouping, Grouping.parent)  # type:ignore
             .filter(
                 User.user_id == user_id,
                 course_grouping.id == course.id,

--- a/lms/services/jwt_oauth2_token.py
+++ b/lms/services/jwt_oauth2_token.py
@@ -29,7 +29,6 @@ class JWTOAuth2TokenService:
             self._db.add(token)
 
         token.access_token = access_token
-        token.received_at = datetime.now()
         token.expires_at = datetime.now() + timedelta(seconds=expires_in)
 
         return token

--- a/lms/services/lti_registration.py
+++ b/lms/services/lti_registration.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import Query
+
 from lms.models import LTIRegistration
 
 
@@ -41,7 +43,7 @@ class LTIRegistrationService:
 
     def _registration_search_query(
         self, *, id_=None, issuer=None, client_id=None
-    ) -> LTIRegistration:
+    ) -> Query[LTIRegistration]:
         query = self._db.query(LTIRegistration)
         if id_:
             query = query.filter_by(id=id_)

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -90,7 +90,7 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
 
             instances = list(instances)  # Ensure we don't consume the generator
             for instance in instances:
-                instance.settings_focus_value = instance.settings.get(
+                instance.settings_focus_value = instance.settings.get(  # type: ignore
                     settings_group, settings_subkey
                 )
 

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -425,13 +425,14 @@ class TestAssignmentService:
         )
         db_session.flush()
 
-        assert set(
-            db_session.scalars(
+        assert {
+            assignment.id
+            for assignment in db_session.scalars(
                 svc.get_assignments(
                     instructor_h_userid=instructor_in_assignment.h_userid
                 )
             ).all()
-        ) == {assignment, assignment_not_launched_by_instructor}
+        } == {assignment.id, assignment_not_launched_by_instructor.id}
 
     def test_get_courses_assignments_count(
         self, svc, db_session, organization, course, application_instance

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -39,8 +39,8 @@ class TestAutoGradingService:
     def test_create_grade_sync(self, svc, db_session, assignment):
         creator = factories.LMSUser()
         lms_users = factories.LMSUser.create_batch(5)
-        grades = {lms_user: random.random() for lms_user in lms_users}
         db_session.flush()
+        grades = {lms_user: random.random() for lms_user in lms_users}
 
         grading_sync = svc.create_grade_sync(assignment, creator, grades)
 

--- a/tests/unit/lms/services/jwt_oauth2_token_test.py
+++ b/tests/unit/lms/services/jwt_oauth2_token_test.py
@@ -22,8 +22,7 @@ class TestJWTOAuth2TokenServiceTest:
         token = svc.save_token(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert token.access_token == "ACCESS_TOKEN"
-        assert token.received_at == datetime(2022, 4, 4, 0)
-        assert token.expires_at == token.received_at + timedelta(seconds=3600)
+        assert token.expires_at == datetime(2022, 4, 4) + timedelta(seconds=3600)
 
     @freeze_time("2022-04-04")
     def test_save_existing_token(self, svc, lti_registration, scopes):
@@ -36,7 +35,6 @@ class TestJWTOAuth2TokenServiceTest:
         token = svc.save_token(lti_registration, scopes, "ACCESS_TOKEN", 3600)
 
         assert existing_token == token
-        assert token.received_at == datetime(2022, 4, 4, 0)
         assert token.expires_at == datetime(2022, 4, 4, 1)
 
     @freeze_time("2022-04-04")


### PR DESCRIPTION
Using dataclasses gives us a better and configurable `__repr__` and other niceties. There is however a few considerations / gotchas in the process:

- We have to use the class approach to declare Base
- If we are using another classes as parents in the model, those have to also be dataclasses

Added a duplicated  CreatedUpdatedMixinAsDataClass to go around this. This class needs to be the last in the inheritance order.

- We can't use the generated `__init__` at least no in existing models without modifying the code base.

The generated `__init__` doesn't allow for SQLA's `__init__` methods behaviour were not passing a parameter ignores it, instead of setting it to a default (e.g. None).

This is a problem when we have a FK and a relationship and we want to use one or the other depending in on the situation, see: https://github.com/sqlalchemy/sqlalchemy/discussions/9383

- Existing `default` in fields should be renamed to `insert_default`. 

`default` being the data class default value vs the existing behaviour for new rows.


- To be as backward compatible ass possible we don't want the dataclas __eq__ method and we want to keep the models hashable, we use

```
eq=False,
unsafe_hash=True,
``` 

for that.


### Testing

In make shell check the new __repr__ of Assignment and LMSUser


```
In [1]: db.query(models.LMSUser).first()
Out[1]: LMSUser(id=984, tool_consumer_instance_guid='VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms', lti_user_id='ce59a6fd7321cafaefa129df1154a7f2a2282a65', lti_v13_user_id=None, h_userid='acct:70cfbc56877436bc743b1537f8aaec@lms.hypothes.is')

In [2]: db.query(models.Assignment).first()
Out[2]: Assignment(id=372, resource_link_id='_210_1', lti_v13_resource_link_id=None, tool_consumer_instance_guid='ffd33001ecc44524b80995d53385c6d4', document_url='https://en.wikipedia.org/wiki/Letter-winged_kite', is_gradable=False, title=None, deep_linking_uuid=None, course_id=None, lis_outcome_service_url=None, auto_grading_config_id=None)
```