### PR TITLE
Display amount of items in dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -19,7 +19,7 @@ import type {
   StudentsResponse,
 } from '../../api-types';
 import { useConfig } from '../../config';
-import { usePaginatedAPIFetch } from '../../utils/api';
+import { ITEMS_PER_PAGE, usePaginatedAPIFetch } from '../../utils/api';
 import { useElementIsTruncated } from '../../utils/hooks';
 import PaginatedMultiSelect from './PaginatedMultiSelect';
 
@@ -173,6 +173,24 @@ function StudentOption({
 }
 
 /**
+ * A badge to display an amount of items in a filter, as long as it is greater
+ * than 0.
+ * If the value is greater than the page size, we display 99+ instead, since
+ * the actual value is not known
+ */
+function CountBadge({ count }: { count?: number }) {
+  if (!count) {
+    return null;
+  }
+
+  return (
+    <div className="px-2 py-1 rounded font-bold bg-grey-3 text-grey-7">
+      {count < ITEMS_PER_PAGE ? count : `${ITEMS_PER_PAGE - 1}+`}
+    </div>
+  );
+}
+
+/**
  * A MultiSelect to list a collection of groups or sections (AKA segments).
  */
 function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
@@ -190,9 +208,17 @@ function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
       value={segments.selectedIds}
       onChange={newSegmentIds => segments.onChange(newSegmentIds)}
       disabled={segments.entries.length === 0}
+      buttonClasses={classnames({
+        // Reduce button vertical padding to compensate for the count badge
+        // padding
+        'py-1':
+          segments.selectedIds.length === 0 && segments.entries.length > 0,
+      })}
       buttonContent={
         segments.selectedIds.length === 0 ? (
-          <>{allSegmentsText}</>
+          <div className="flex gap-x-2 items-center">
+            {allSegmentsText} <CountBadge count={segments.entries.length} />
+          </div>
         ) : segments.selectedIds.length === 1 ? (
           segments.entries.find(
             s => s.h_authority_provided_id === segments.selectedIds[0],
@@ -328,13 +354,20 @@ export default function DashboardActivityFilters({
             ? courses.onChange(newCourseIds)
             : newCourseIds.length === 0 && courses.onClear()
         }
+        buttonClasses={classnames({
+          // Reduce button vertical padding to compensate for the count badge
+          // padding
+          'py-1': coursesResult.data?.length && selectedCourseIds.length === 0,
+        })}
         buttonContent={
           activeCourse ? (
             activeCourse.title
           ) : coursesResult.isLoadingFirstPage ? (
             <>...</>
           ) : selectedCourseIds.length === 0 ? (
-            <>All courses</>
+            <div className="flex gap-x-2 items-center">
+              All courses <CountBadge count={coursesResult.data?.length} />
+            </div>
           ) : selectedCourseIds.length === 1 ? (
             coursesResult.data?.find(c => `${c.id}` === selectedCourseIds[0])
               ?.title ?? '1 course'
@@ -362,13 +395,23 @@ export default function DashboardActivityFilters({
             ? assignments.onChange(newAssignmentIds)
             : newAssignmentIds.length === 0 && assignments.onClear()
         }
+        buttonClasses={classnames({
+          // Reduce button vertical padding to compensate for the count badge
+          // padding
+          'py-1':
+            assignmentsResults.data?.length &&
+            selectedAssignmentIds.length === 0,
+        })}
         buttonContent={
           activeAssignment ? (
             activeAssignment.title
           ) : assignmentsResults.isLoadingFirstPage ? (
             <>...</>
           ) : selectedAssignmentIds.length === 0 ? (
-            <>All assignments</>
+            <div className="flex gap-x-2 items-center">
+              All assignments{' '}
+              <CountBadge count={assignmentsResults.data?.length} />
+            </div>
           ) : selectedAssignmentIds.length === 1 ? (
             assignmentsResults.data?.find(
               a => `${a.id}` === selectedAssignmentIds[0],
@@ -393,11 +436,19 @@ export default function DashboardActivityFilters({
         result={studentsResult}
         value={students.selectedIds}
         onChange={newStudentIds => students.onChange(newStudentIds)}
+        buttonClasses={classnames({
+          // Reduce button vertical padding to compensate for the count badge
+          // padding
+          'py-1':
+            studentsResult.data?.length && students.selectedIds.length === 0,
+        })}
         buttonContent={
           studentsResult.isLoadingFirstPage ? (
             <>...</>
           ) : students.selectedIds.length === 0 ? (
-            <>All students</>
+            <div className="flex gap-x-2 items-center">
+              All students <CountBadge count={studentsResult.data?.length} />
+            </div>
           ) : students.selectedIds.length === 1 ? (
             studentsResult.data?.find(
               s => s.h_userid === students.selectedIds[0],

--- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
@@ -70,6 +70,7 @@ export type PaginatedMultiSelectProps<TResult, TSelect> = {
   ) => ComponentChildren;
   entity: FiltersEntity;
   buttonContent?: ComponentChildren;
+  buttonClasses?: string;
   value: TSelect[];
   onChange: (newValue: TSelect[]) => void;
 };
@@ -85,6 +86,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
   entity,
   renderOption,
   buttonContent,
+  buttonClasses,
   value,
   onChange,
 }: PaginatedMultiSelectProps<TResult, TSelect>) {
@@ -98,6 +100,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
       aria-label={`Select ${entity}`}
       containerClasses="!w-auto min-w-44"
       buttonContent={buttonContent}
+      buttonClasses={buttonClasses}
       data-testid={`${entity}-select`}
       onListboxScroll={e => {
         if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -317,6 +317,8 @@ export type PaginatedFetchResult<T> = Omit<FetchResult<T>, 'mutate'> & {
   loadNextPage: () => void;
 };
 
+export const ITEMS_PER_PAGE = 100;
+
 /**
  * Hook that fetches paginated data using authenticated API requests.
  * It expects the result to include pagination info in a `pagination` prop.
@@ -341,7 +343,7 @@ export function usePaginatedAPIFetch<
 
   const fetchResult = useAPIFetch<FetchType>(
     nextPageURL ?? path,
-    !nextPageURL ? params : undefined,
+    !nextPageURL ? { ...params, limit: `${ITEMS_PER_PAGE}` } : undefined,
   );
 
   const loadNextPage = useCallback(() => {


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6812
> Part of https://github.com/hypothesis/product-backlog/issues/1570

Display the amount of items in a dashboard filter when that filter does not have a selected value.

This will help users know the items in those filters get filtered when selecting anything in the other filters.

Since filters are paginated, when the amount of items is equal or greater than the page size, we assume there are potentially more items and simply display "99+" (100 is the page size).

https://github.com/user-attachments/assets/bea89ffd-3246-4c62-9f91-682167b5bd67

