### PR TITLE
Make dashboard filters listboxes render always inside the viewport

### DIFF
--- a/lms/static/scripts/frontend_apps/components/TruncatedText.tsx
+++ b/lms/static/scripts/frontend_apps/components/TruncatedText.tsx
@@ -1,0 +1,55 @@
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+import { useLayoutEffect, useRef, useState } from 'preact/hooks';
+
+export type TruncatedTextProps = JSX.HTMLAttributes<HTMLSpanElement> & {
+  children: string;
+  className?: never;
+  classes?: string | string[];
+};
+
+/**
+ * A text container that elides its content.
+ *
+ * If the text overflows, the full content is added as a title for the
+ * container.
+ */
+export default function TruncatedText({
+  children,
+  title,
+  classes,
+  ...htmlAttrs
+}: TruncatedTextProps) {
+  const [overflow, setOverflow] = useState(false);
+  const ref = useRef<HTMLSpanElement | null>(null);
+
+  useLayoutEffect(() => {
+    const element = ref.current!;
+    const computeIsOverflowing = () =>
+      setOverflow(element.scrollWidth > element.clientWidth);
+
+    // Check if element is overflowing on initial render
+    computeIsOverflowing();
+    // Re-check when the element is resized
+    const observer = new ResizeObserver(computeIsOverflowing);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [children]);
+
+  // An explicitly set `title` takes priority. Otherwise, use the content as
+  // the title on overflow.
+  const overflowTitle = title ?? (overflow ? children : undefined);
+
+  return (
+    <span
+      ref={ref}
+      className={classnames('truncate', classes)}
+      title={overflowTitle}
+      data-testid="truncated-text"
+      {...htmlAttrs}
+    >
+      {children}
+    </span>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -20,6 +20,7 @@ import type {
 } from '../../api-types';
 import { useConfig } from '../../config';
 import { usePaginatedAPIFetch } from '../../utils/api';
+import TruncatedText from '../TruncatedText';
 import PaginatedMultiSelect from './PaginatedMultiSelect';
 
 /**
@@ -92,7 +93,7 @@ function AssignmentOption({
   return (
     <MultiSelect.Option value={`${assignment.id}`} elementRef={elementRef}>
       <div className="flex flex-col gap-0.5">
-        {assignment.title}
+        <TruncatedText>{assignment.title}</TruncatedText>
         <div className="text-grey-6 text-xs">
           {formatDateTime(assignment.created)}
         </div>
@@ -115,13 +116,13 @@ function StudentOption({
 
   return (
     <MultiSelect.Option value={student.h_userid} elementRef={elementRef}>
-      <span
-        className={hasDisplayName ? undefined : 'italic'}
+      <TruncatedText
+        classes={hasDisplayName ? undefined : 'italic'}
         title={hasDisplayName ? undefined : `User ID: ${student.lms_id}`}
         data-testid="option-content-wrapper"
       >
         {displayName}
-      </span>
+      </TruncatedText>
     </MultiSelect.Option>
   );
 }
@@ -167,7 +168,7 @@ function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
           key={entry.h_authority_provided_id}
           value={entry.h_authority_provided_id}
         >
-          {entry.name}
+          <TruncatedText>{entry.name}</TruncatedText>
         </MultiSelect.Option>
       ))}
     </MultiSelect>
@@ -304,7 +305,7 @@ export default function DashboardActivityFilters({
             value={`${course.id}`}
             elementRef={elementRef}
           >
-            {course.title}
+            <TruncatedText>{course.title}</TruncatedText>
           </MultiSelect.Option>
         )}
       />

--- a/lms/static/scripts/frontend_apps/components/test/TruncatedText-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/TruncatedText-test.js
@@ -1,0 +1,50 @@
+import { mount } from 'enzyme';
+
+import TruncatedText from '../TruncatedText';
+
+describe('TruncatedText', () => {
+  let wrappers;
+  let containers;
+
+  beforeEach(() => {
+    wrappers = [];
+    containers = [];
+  });
+
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+    containers.forEach(container => container.remove());
+  });
+
+  function createComponent(content, title) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const wrapper = mount(
+      <div className="flex w-96">
+        <TruncatedText title={title}>{content}</TruncatedText>
+      </div>,
+      { attachTo: container },
+    );
+
+    containers.push(container);
+    wrappers.push(wrapper);
+
+    return wrapper.find('[data-testid="truncated-text"]');
+  }
+
+  [
+    { content: 'short', isTruncated: false },
+    { content: 'long'.repeat(100), isTruncated: true },
+  ].forEach(({ content, isTruncated }) => {
+    it('adds title when content gets truncated', () => {
+      const wrapper = createComponent(content);
+      assert.equal(wrapper.prop('title'), isTruncated ? content : undefined);
+    });
+
+    it('favors explicitly provided title regardless of whether text is truncated', () => {
+      const wrapper = createComponent(content, 'Provided title');
+      assert.equal(wrapper.prop('title'), 'Provided title');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.7.0",
+    "@hypothesis/frontend-shared": "^8.8.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,15 +1982,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.7.0":
-  version: 8.7.0
-  resolution: "@hypothesis/frontend-shared@npm:8.7.0"
+"@hypothesis/frontend-shared@npm:^8.8.0":
+  version: 8.8.0
+  resolution: "@hypothesis/frontend-shared@npm:8.8.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 646087a5d592080e7bdd336ecd18df047450b15c3410b4bd39b36a41702bfcdbbf39b378ad3a17a2442b825dfc0500d10c25be24b6c2a9d814052f33d3e2fe11
+  checksum: c6e1e9359400dabc12e03cb4f805ba5b4404d930a45a46a2a62e710e199e51f3c8c950b1d205c3b6276e7ffba3350bf8b16b8dea29a15884ccae7ac326a76769
   languageName: node
   linkType: hard
 
@@ -7135,7 +7135,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@babel/preset-typescript": ^7.26.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.7.0
+    "@hypothesis/frontend-shared": ^8.8.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.1


### PR DESCRIPTION
> Alternative to https://github.com/hypothesis/lms/pull/6812
> Part of https://github.com/hypothesis/product-backlog/issues/1561

Update dashboard filtering dropdowns so that:

1. Their listboxes never render out of the viewport, trying to make a smarter use of available space.
2. Their listboxes never grow bigger than the body.
3. Options with big content are truncated with `text-overflow: ellipsis`.
4. A `title` is added with the full content of listbox options when they have been truncated.

> [!NOTE]
> Points 1 and 2 are implicitly applied by updating frontend-shared to v8.8, which brings changes from https://github.com/hypothesis/frontend-shared/pull/1746

https://github.com/user-attachments/assets/d74a1b41-1d60-4e7a-bca6-bf8067869853

### Considerations

This approach has the problem that content may not be fully displayed in mobile devices, as they cannot take advantage of the dynamic `title`.

However, by inspecting real production data, it has been concluded that text should usually not overflow in most of cases.

If this becomes a problem in future, we could check the screen size via [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) and avoid truncation altogether in small resolutions, where the content would wrap multiple times.