### PR TITLE
Display amount of items in dashboard filters

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/ContentWithBadge.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/ContentWithBadge.tsx
@@ -1,0 +1,42 @@
+import type { ComponentChildren } from 'preact';
+
+export type ContentWithBadgeProps = {
+  children: ComponentChildren;
+  count: number;
+
+  /**
+   * Indicates the count is a lower-bound on the total number of items, as
+   * opposed to an exact value.
+   * Defaults to false.
+   */
+  hasMoreItems?: boolean;
+};
+
+/**
+ * Display content next to a badge containing a count of items.
+ */
+export default function ContentWithBadge({
+  children,
+  count,
+  hasMoreItems = false,
+}: ContentWithBadgeProps) {
+  // We want to give a special treatment to the value 100 when there are more
+  // items, falling back to 99 to avoid using too much space.
+  // This will be the most common use case for paginated results, before users
+  // open the list and start scrolling down, so we want to keep it as long as
+  // possible.
+  const displayCount = count === 100 && hasMoreItems ? 99 : count;
+
+  return (
+    <div className="flex gap-x-2 items-center justify-between">
+      {children}
+      <div
+        className="px-2 -my-1 py-1 rounded font-bold bg-grey-3 text-grey-7"
+        data-testid="count-badge"
+      >
+        {displayCount}
+        {hasMoreItems && '+'}
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardActivityFilters.tsx
@@ -21,6 +21,7 @@ import type {
 import { useConfig } from '../../config';
 import { usePaginatedAPIFetch } from '../../utils/api';
 import TruncatedText from '../TruncatedText';
+import ContentWithBadge from './ContentWithBadge';
 import PaginatedMultiSelect from './PaginatedMultiSelect';
 
 /**
@@ -134,9 +135,6 @@ function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
   const segmentsName = segments.type === 'groups' ? 'groups' : 'sections';
   const segmentNameSingular = segments.type === 'groups' ? 'group' : 'section';
   const isNoneType = segments.type === 'none';
-  const allSegmentsText = isNoneType
-    ? 'No sections/groups'
-    : `All ${segmentsName}`;
 
   return (
     <MultiSelect
@@ -146,8 +144,12 @@ function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
       onChange={newSegmentIds => segments.onChange(newSegmentIds)}
       disabled={segments.entries.length === 0}
       buttonContent={
-        segments.selectedIds.length === 0 ? (
-          <>{allSegmentsText}</>
+        isNoneType ? (
+          'No sections/groups'
+        ) : segments.selectedIds.length === 0 ? (
+          <ContentWithBadge count={segments.entries.length}>
+            All {segmentsName}
+          </ContentWithBadge>
         ) : segments.selectedIds.length === 1 ? (
           segments.entries.find(
             s => s.h_authority_provided_id === segments.selectedIds[0],
@@ -161,7 +163,7 @@ function SegmentsMultiSelect({ segments }: { segments: SegmentsSelection }) {
       data-testid="segments-select"
     >
       <MultiSelect.Option value={undefined}>
-        {allSegmentsText}
+        All {segmentsName}
       </MultiSelect.Option>
       {segments.entries.map(entry => (
         <MultiSelect.Option
@@ -290,7 +292,12 @@ export default function DashboardActivityFilters({
           ) : coursesResult.isLoadingFirstPage ? (
             <>...</>
           ) : selectedCourseIds.length === 0 ? (
-            <>All courses</>
+            <ContentWithBadge
+              count={coursesResult.data?.length ?? 0}
+              hasMoreItems={coursesResult.hasMorePages}
+            >
+              All courses
+            </ContentWithBadge>
           ) : selectedCourseIds.length === 1 ? (
             coursesResult.data?.find(c => `${c.id}` === selectedCourseIds[0])
               ?.title ?? '1 course'
@@ -325,7 +332,12 @@ export default function DashboardActivityFilters({
           ) : assignmentsResults.isLoadingFirstPage ? (
             <>...</>
           ) : selectedAssignmentIds.length === 0 ? (
-            <>All assignments</>
+            <ContentWithBadge
+              count={assignmentsResults.data?.length ?? 0}
+              hasMoreItems={assignmentsResults.hasMorePages}
+            >
+              All assignments
+            </ContentWithBadge>
           ) : selectedAssignmentIds.length === 1 ? (
             assignmentsResults.data?.find(
               a => `${a.id}` === selectedAssignmentIds[0],
@@ -354,7 +366,12 @@ export default function DashboardActivityFilters({
           studentsResult.isLoadingFirstPage ? (
             <>...</>
           ) : students.selectedIds.length === 0 ? (
-            <>All students</>
+            <ContentWithBadge
+              count={studentsResult.data?.length ?? 0}
+              hasMoreItems={studentsResult.hasMorePages}
+            >
+              All students
+            </ContentWithBadge>
           ) : students.selectedIds.length === 1 ? (
             studentsResult.data?.find(
               s => s.h_userid === students.selectedIds[0],

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/ContentWithBadge-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/ContentWithBadge-test.js
@@ -1,0 +1,32 @@
+import { checkAccessibility } from '@hypothesis/frontend-testing';
+import { mount } from 'enzyme';
+
+import ContentWithBadge from '../ContentWithBadge';
+
+describe('ContentWithBadge', () => {
+  function createComponent(props) {
+    return mount(<ContentWithBadge {...props} />);
+  }
+
+  [
+    { count: 15, hasMoreItems: false, expectedValue: '15' },
+    { count: 581, hasMoreItems: false, expectedValue: '581' },
+    { count: 200, hasMoreItems: true, expectedValue: '200+' },
+    { count: 100, hasMoreItems: true, expectedValue: '99+' },
+    { count: 1000, hasMoreItems: true, expectedValue: '1000+' },
+  ].forEach(({ expectedValue, hasMoreItems, count }) => {
+    it('displays expected value in count badge', () => {
+      const wrapper = createComponent({ count, hasMoreItems });
+      const badge = wrapper.find('[data-testid="count-badge"]');
+
+      assert.equal(badge.text(), expectedValue);
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent({ count: 10 }),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/DashboardActivityFilters-test.js
@@ -139,6 +139,11 @@ describe('DashboardActivityFilters', () => {
         usePaginatedAPIFetch: fakeUsePaginatedAPIFetch,
       },
     });
+    // Do not mock ContentWithBadge, as it helps test scenarios where it is
+    // used vs scenarios where it isn't
+    $imports.$restore({
+      './ContentWithBadge': true,
+    });
   });
 
   afterEach(() => {
@@ -216,15 +221,21 @@ describe('DashboardActivityFilters', () => {
     assert.equal(getSelectContent(wrapper, 'students-select'), '...');
   });
 
-  it('shows placeholders when selection is empty', () => {
+  it('shows placeholders with count when selection is empty', () => {
     const wrapper = createComponent();
 
-    assert.equal(getSelectContent(wrapper, 'courses-select'), 'All courses');
+    assert.equal(
+      getSelectContent(wrapper, 'courses-select'),
+      `All courses${courses.length}`,
+    );
     assert.equal(
       getSelectContent(wrapper, 'assignments-select'),
-      'All assignments',
+      `All assignments${assignments.length}`,
     );
-    assert.equal(getSelectContent(wrapper, 'students-select'), 'All students');
+    assert.equal(
+      getSelectContent(wrapper, 'students-select'),
+      `All students${students.length}`,
+    );
   });
 
   [
@@ -596,12 +607,12 @@ describe('DashboardActivityFilters', () => {
       // No selection for groups
       {
         segmentsConfig: { type: 'groups' },
-        expectedButtonContent: 'All groups',
+        expectedButtonContent: 'All groups0',
       },
       // No selection for sections
       {
         segmentsConfig: { type: 'sections' },
-        expectedButtonContent: 'All sections',
+        expectedButtonContent: 'All sections0',
       },
       // "None" type
       {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.9.0",
+    "@hypothesis/frontend-shared": "^8.10.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,15 +1982,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.9.0":
-  version: 8.9.0
-  resolution: "@hypothesis/frontend-shared@npm:8.9.0"
+"@hypothesis/frontend-shared@npm:^8.10.1":
+  version: 8.10.1
+  resolution: "@hypothesis/frontend-shared@npm:8.10.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: bfe04718494b870a429c6ab7d1be8a656e13424b08e2cd1f9377a4622c1a16867ef7a450cccbfe37d8cc36236802db2babe13b93ca5da6feb19bc661d73f6728
+  checksum: 5358e632ab371aadb56ce42a4d0237d155e5523e3313fcc30114bd727b0414eb382ba8cf4edcc3be8dde1a1eb4e98f9cb077a8f3937442deba5bb8a3f9f2d9cc
   languageName: node
   linkType: hard
 
@@ -7287,7 +7287,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@babel/preset-typescript": ^7.26.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.9.0
+    "@hypothesis/frontend-shared": ^8.10.1
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.1


### PR DESCRIPTION
> Closes https://github.com/hypothesis/product-backlog/issues/1570
> Depends on https://github.com/hypothesis/lms/pull/6850

Display the amount of items in a dashboard filter when that filter does not have a selected value.

This will help users know the items in those lists get filtered when selecting anything in the other filters.

Since filters are paginated, we'll be showing different values based on a set of conditions:

* When there's only one page of results, we'll display the total amount of results.
* When we have loaded the first page, the page size is 100, and we know there's more pages, we'll display `99+`. This ensures we keep the badge as "small" as possible for as long as possible.
* When we have loaded more than one page and we know there's still more pages, we'll display the amount of results we have loaded so far, followed with the `+` sign, like `400+`.
* When there's multiple pages but we have loaded all of them, we'll display the total amount of results we have loaded.

![image](https://github.com/user-attachments/assets/4095e55f-40a4-40d8-b98c-6a63f3dc297b)

In addition, this PR also updates frontend-shared, in order to get a [fix for Select toggle buttons](https://github.com/hypothesis/frontend-shared/pull/1777).
