### PR TITLE
Reduce batch size for H's groups bulk API call

### DIFF
--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -155,7 +155,7 @@ class HAPI:
         groups: Sequence[str],
         annotations_created_after: datetime,
         annotations_created_before: datetime,
-        batch_size: int = 1000,
+        batch_size: int = 250,
     ) -> Iterator[HAPIGroup]:
         """
         Fetch groups that have annotations created between two dates.


### PR DESCRIPTION
We keep seeing calls to this endpoint taking over 10s. The main culprit is the query the endpoint makes to get which groups have annotations. Reducing the number of groups we query per API calls should bring the API time down.


We can see the current total number of groups in this paper trail query.

https://my.papertrailapp.com/groups/14104911/events?focus=1789133066271342592&q=Generating+report+for

It seems like we have a few organizations with a few thousands of groups which should translate to one API call per 1000 groups now and calls for 250 groups after merging this.