### PR TITLE
Store group set information in the new LMSGroupSet table

### DIFF
--- a/lms/models/grouping.py
+++ b/lms/models/grouping.py
@@ -1,5 +1,5 @@
 from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
@@ -174,17 +174,6 @@ class MoodleGroup(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.MOODLE_GROUP}
 
 
-class GroupSet(TypedDict):
-    """
-    Group sets are a collection of student groups.
-
-    We store them in Course.extra
-    """
-
-    id: str
-    name: str
-
-
 class Course(Grouping):
     __mapper_args__ = {"polymorphic_identity": Grouping.Type.COURSE}
 
@@ -198,22 +187,6 @@ class Course(Grouping):
         primaryjoin="Grouping.authority_provided_id == foreign(LMSCourse.h_authority_provided_id)",
         backref=sa.orm.backref("course"),
     )
-
-    def set_group_sets(self, group_sets: list[dict]):
-        """
-        Store this course's available group sets.
-
-        We keep record of these for bookkeeping and as the basics to
-        dealt with groups while doing course copy.
-        """
-        # Different LMS might return additional fields but we only interested in the ID and the name.
-        # We explicitly cast ID to string to homogenise the data in all LMS's.
-        group_sets = [{"id": str(g["id"]), "name": g["name"]} for g in group_sets]
-        self.extra["group_sets"] = group_sets
-
-    def get_group_sets(self) -> list[GroupSet]:
-        """Get this course's available group sets."""
-        return self.extra.get("group_sets", [])
 
     def get_mapped_page_id(self, page_id):
         """

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -17,6 +17,7 @@ from lms.services.exceptions import (
     OAuth2TokenError,
     SerializableError,
 )
+from lms.services.group_set import GroupSetService
 from lms.services.h_api import HAPI, HAPIError
 from lms.services.hubspot import HubSpotService
 from lms.services.jstor import JSTORService
@@ -44,7 +45,7 @@ from lms.services.vitalsource import VitalSourceService
 from lms.services.youtube import YouTubeService
 
 
-def includeme(config):
+def includeme(config):  # noqa: PLR0915
     config.register_service_factory("lms.services.http.factory", name="http")
     config.register_service_factory(
         "lms.services.oauth_http.factory", name="oauth_http"
@@ -152,6 +153,9 @@ def includeme(config):
     )
     config.register_service_factory(MoodleAPIClient.factory, iface=MoodleAPIClient)
     config.register_service_factory("lms.services.roster.factory", iface=RosterService)
+    config.register_service_factory(
+        "lms.services.group_set.factory", iface=GroupSetService
+    )
     config.register_service_factory(
         "lms.services.auto_grading.factory", iface=AutoGradingService
     )

--- a/lms/services/group_set.py
+++ b/lms/services/group_set.py
@@ -1,0 +1,34 @@
+from typing import TypedDict
+
+
+class GroupSetDict(TypedDict):
+    """
+    Group sets are a collection of student groups.
+
+    We store them in Course.extra
+    """
+
+    id: str
+    name: str
+
+
+class GroupSetService:
+    def store_group_sets(self, course, group_sets: list[dict]):
+        """
+        Store this course's available group sets.
+
+        We keep record of these for bookkeeping and as the basics to
+        dealt with groups while doing course copy.
+        """
+        # Different LMS might return additional fields but we only interested in the ID and the name.
+        # We explicitly cast ID to string to homogenise the data in all LMS's.
+        group_sets = [{"id": str(g["id"]), "name": g["name"]} for g in group_sets]
+        course.extra["group_sets"] = group_sets
+
+    def get_group_sets(self, course) -> list[GroupSetDict]:
+        """Get this course's available group sets."""
+        return course.extra.get("group_sets", [])
+
+
+def factory(_context, _request):
+    return GroupSetService()

--- a/tests/unit/lms/models/group_set_test.py
+++ b/tests/unit/lms/models/group_set_test.py
@@ -1,0 +1,53 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.group_set import GroupSetService, factory
+from tests import factories
+
+
+class TestGroupSetService:
+    @pytest.mark.parametrize(
+        "group_set,expected",
+        [
+            # No extra keys
+            (
+                {"id": "1", "name": "name", "extra": "value"},
+                {"id": "1", "name": "name"},
+            ),
+            # String ID
+            ({"id": 1111, "name": "name"}, {"id": "1111", "name": "name"}),
+        ],
+    )
+    def test_set_group_sets(self, group_set, expected, svc):
+        course = factories.Course(extra={})
+
+        svc.store_group_sets(course, [group_set])
+
+        assert course.extra["group_sets"] == [expected]
+
+    def test_get_group_sets(self, svc):
+        course = factories.Course(extra={"group_sets": sentinel.group_sets})
+
+        assert svc.get_group_sets(course) == sentinel.group_sets
+
+    def test_get_group_set_empty(self, svc):
+        course = factories.Course(extra={})
+
+        assert not svc.get_group_sets(course)
+
+    @pytest.fixture
+    def svc(self):
+        return GroupSetService()
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, GroupSetService):
+        service = factory(sentinel.context, pyramid_request)
+
+        GroupSetService.assert_called_once_with()
+        assert service == GroupSetService.return_value
+
+    @pytest.fixture
+    def GroupSetService(self, patch):
+        return patch("lms.services.group_set.GroupSetService")

--- a/tests/unit/lms/models/grouping_test.py
+++ b/tests/unit/lms/models/grouping_test.py
@@ -53,35 +53,6 @@ class TestCourse:
 
         assert course.extra["course_copy_file_mappings"]["OLD"] == "NEW"
 
-    @pytest.mark.parametrize(
-        "group_set,expected",
-        [
-            # No extra keys
-            (
-                {"id": "1", "name": "name", "extra": "value"},
-                {"id": "1", "name": "name"},
-            ),
-            # String ID
-            ({"id": 1111, "name": "name"}, {"id": "1111", "name": "name"}),
-        ],
-    )
-    def test_set_group_sets(self, group_set, expected):
-        course = factories.Course(extra={})
-
-        course.set_group_sets([group_set])
-
-        assert course.extra["group_sets"] == [expected]
-
-    def test_get_group_set(self):
-        course = factories.Course(extra={"group_sets": sentinel.group_sets})
-
-        assert course.get_group_sets() == sentinel.group_sets
-
-    def test_get_group_set_empty(self):
-        course = factories.Course(extra={})
-
-        assert not course.get_group_sets()
-
     def test_get_mapped_group_set_empty_extra(self):
         course = factories.Course(extra={})
 

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -219,10 +219,11 @@ class TestCanvasGroupingPlugin:
             == enabled
         )
 
-    def test_factory(self, pyramid_request, canvas_api_client):
+    def test_factory(self, pyramid_request, canvas_api_client, group_set_service):
         plugin = CanvasGroupingPlugin.factory(sentinel.context, pyramid_request)
         assert isinstance(plugin, CanvasGroupingPlugin)
         assert plugin._canvas_api == canvas_api_client  # noqa: SLF001
+        assert plugin._group_set_service == group_set_service  # noqa: SLF001
 
     @pytest.fixture
     def course(self):
@@ -231,7 +232,10 @@ class TestCanvasGroupingPlugin:
         )
 
     @pytest.fixture
-    def plugin(self, canvas_api_client, pyramid_request):
+    def plugin(self, canvas_api_client, pyramid_request, group_set_service):
         return CanvasGroupingPlugin(
-            canvas_api_client, strict_section_membership=False, request=pyramid_request
+            canvas_api_client,
+            strict_section_membership=False,
+            request=pyramid_request,
+            group_set_service=group_set_service,
         )

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -10,7 +10,7 @@ from lms.services.roster import RosterService, factory
 from tests import factories
 
 
-class TestRosterServiceService:
+class TestRosterService:
     def test_fetch_course_roster(
         self,
         svc,

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -28,6 +28,7 @@ from lms.services.file import FileService
 from lms.services.grading_info import GradingInfoService
 from lms.services.grant_token import GrantTokenService
 from lms.services.group_info import GroupInfoService
+from lms.services.group_set import GroupSetService
 from lms.services.grouping import GroupingService
 from lms.services.h_api import HAPI
 from lms.services.http import HTTPService
@@ -78,6 +79,7 @@ __all__ = (
     "grading_info_service",
     "grant_token_service",
     "group_info_service",
+    "group_set_service",
     "grouping_service",
     "h_api",
     "http_service",
@@ -194,6 +196,11 @@ def course_service(mock_service):
 @pytest.fixture
 def roster_service(mock_service):
     return mock_service(RosterService)
+
+
+@pytest.fixture
+def group_set_service(mock_service):
+    return mock_service(GroupSetService)
 
 
 @pytest.fixture


### PR DESCRIPTION
For: 

- https://github.com/hypothesis/lms/issues/6834


We currently only store group sets as a json array in "Grouping.extra". This is awkward to query and impossible to relate to other tables.

After creating LMS GroupSet we'll start recording groups sets in both tables in parallel.


### Testing

- Start configuring an assignment with groups. We record the group sets the moment we list them in the creation screen, no need to to finish the configuration process.


For example:

https://hypothesis.instructure.com/courses/125/assignments/7412/edit?name=Assignment%20creation%20-%20test%20&due_at=&points_possible=0



- Check the data in the DB

#### Groups sets in the old location


```
select extra->'group_sets' from grouping where type = 'course' and extra->'group_sets' is not null;
                                                                                                    ?column?                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 [{"id": "121", "name": "Test group set"}, {"id": "122", "name": "Empty group set"}, {"id": "125", "name": "PoC"}, {"id": "129", "name": "Group Set with No Students in It"}, {"id": "389", "name": "everyone"}]
```

#### Groups sets in the new location


```
select * from lms_group_set;
 id | lms_id |               name               | lms_course_id |         created          |         updated          
----+--------+----------------------------------+---------------+--------------------------+--------------------------
  6 | 121    | Test group set                   |           105 | 2024-11-04 13:28:48.4531 | 2024-11-04 13:28:48.4531
  7 | 122    | Empty group set                  |           105 | 2024-11-04 13:28:48.4531 | 2024-11-04 13:28:48.4531
  8 | 125    | PoC                              |           105 | 2024-11-04 13:28:48.4531 | 2024-11-04 13:28:48.4531
  9 | 129    | Group Set with No Students in It |           105 | 2024-11-04 13:28:48.4531 | 2024-11-04 13:28:48.4531
 10 | 389    | everyone                         |           105 | 2024-11-04 13:28:48.4531 | 2024-11-04 13:28:48.4531
(5 rows)
```
