### PR TITLE
Backfill migration for LMSGroupSet

### DIFF
--- a/lms/migrations/versions/ba295703738b_backfill_lmsgroupset.py
+++ b/lms/migrations/versions/ba295703738b_backfill_lmsgroupset.py
@@ -1,0 +1,39 @@
+"""Backfill LMSGroupSet."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ba295703738b"
+down_revision = "4b813a44a6c9"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            WITH backfill as (
+                SELECT lms_course.id lms_course_id, course_group_sets.id group_set_id, course_group_sets.name group_set_name
+                FROM grouping
+                JOIN lms_course ON grouping.authority_provided_id = lms_course.h_authority_provided_id
+                CROSS JOIN LATERAL jsonb_to_recordset(grouping.extra->'group_sets') as course_group_sets(id Text, name Text)
+            )
+            INSERT INTO lms_group_set (
+                lms_course_id,
+                lms_id,
+                name
+            )
+            SELECT
+                lms_course_id,
+                group_set_id,
+                group_set_name
+            FROM backfill
+            -- We are already inserting rows in the python code, leave those alone
+            ON CONFLICT (lms_course_id, lms_id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/tests/unit/lms/views/dashboard/pagination_test.py
+++ b/tests/unit/lms/views/dashboard/pagination_test.py
@@ -15,7 +15,7 @@ class TestGetPage:
     def test_when_no_next_page(self, pyramid_request, db_session):
         pyramid_request.parsed_params = {"limit": 100}
         courses = factories.Course.create_batch(5)
-        query = select(Course)
+        query = select(Course).order_by(Course.id)
         db_session.flush()
 
         items, pagination = get_page(pyramid_request, query, (Course.id,))
@@ -35,7 +35,7 @@ class TestGetPage:
     def test_it_calculates_next(self, pyramid_request, db_session):
         pyramid_request.parsed_params = {"limit": 1}
         courses = factories.Course.create_batch(5)
-        query = select(Course)
+        query = select(Course).order_by(Course.id)
         db_session.flush()
 
         items, pagination = get_page(pyramid_request, query, (Course.id,))


### PR DESCRIPTION
For: 

- https://github.com/hypothesis/lms/issues/6834


After storing new group sets in https://github.com/hypothesis/lms/pull/6837 we'll backfill thet new table based on information from Grouping.extra



### Testing

- Start configuring an assignment with groups. We record the group sets the moment we list them in the creation screen, no need to to finish the configuration process.


For example:

https://hypothesis.instructure.com/courses/125/assignments/7412/edit?name=Assignment%20creation%20-%20test%20&due_at=&points_possible=0

- Remove the rows on the new table

```
truncate lms_group_set;
```


- Run the migration

```
tox -e dev --run-command 'alembic upgrade head'     
dev run-test-pre: PYTHONHASHSEED='2142052960'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 4b813a44a6c9 -> ba295703738b, Backfill LMSGroupSet
```


- Check the rows in lms_group_set have been created based on the information in grouping:

```
select * from lms_group_set;
 id | lms_id |               name               | lms_course_id |          created           |          updated           
----+--------+----------------------------------+---------------+----------------------------+----------------------------
 29 | 121    | Test group set                   |           105 | 2024-11-05 08:43:51.641694 | 2024-11-05 08:43:51.641694
 30 | 122    | Empty group set                  |           105 | 2024-11-05 08:43:51.641694 | 2024-11-05 08:43:51.641694
 31 | 125    | PoC                              |           105 | 2024-11-05 08:43:51.641694 | 2024-11-05 08:43:51.641694
 32 | 129    | Group Set with No Students in It |           105 | 2024-11-05 08:43:51.641694 | 2024-11-05 08:43:51.641694
 33 | 389    | everyone                         |           105 | 2024-11-05 08:43:51.641694 | 2024-11-05 08:43:51.641694
(5 rows)
```