### PR TITLE
Fix SASS warnings due to deprecated functions

### DIFF
--- a/lms/static/styles/moodle_pages/moodle_pages.scss
+++ b/lms/static/styles/moodle_pages/moodle_pages.scss
@@ -13,6 +13,8 @@
 //   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/preset/default.scss
 //   * https://github.com/moodle/moodle/blob/main/theme/boost/scss/bootstrap/_variables.scss
 
+@use 'sass:color';
+
 // These are some of the sass variables defined in the files mentioned above:
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
   'Helvetica Neue', Arial, 'Noto Sans', 'Liberation Sans', sans-serif,
@@ -23,7 +25,7 @@ $font-size-base: 0.9375rem;
 $gray-600: #6a737b;
 $gray-900: #1d2125;
 $link-color: #ec7f13;
-$link-hover-color: darken($link-color, 15%);
+$link-hover-color: color.adjust($link-color, $lightness: -15%, $space: hsl);
 
 body {
   font-family: $font-family-sans-serif;


### PR DESCRIPTION
Migrate from SASS' global `darken` function, which is deprecated, to the `sass:color`'s module `color.adjust` function.

This solves two warnings reported by SASS:

```
DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.adjust instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
28 │ $link-hover-color: darken($link-color, 15%);
   │                    ^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    lms/static/styles/moodle_pages/moodle_pages.scss 28:20  root stylesheet

DEPRECATION WARNING: darken() is deprecated. Suggestions:

color.scale($color, $lightness: -30%)
color.adjust($color, $lightness: -15%)

More info: https://sass-lang.com/d/color-functions

   ╷
28 │ $link-hover-color: darken($link-color, 15%);
   │                    ^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    lms/static/styles/moodle_pages/moodle_pages.scss 28:20  root stylesheet
```

The migration from `darken` to `color.adjust` is documented here https://sass-lang.com/documentation/modules/color/#darken. I used that to decide what parameters to pass to `color.adjust`.