### PR TITLE
Add extra logging for Moodle's file check

### DIFF
--- a/lms/services/moodle.py
+++ b/lms/services/moodle.py
@@ -1,9 +1,12 @@
+import logging
 from enum import Enum, StrEnum
 from typing import Literal, NotRequired, TypedDict
 
 from lms.services.aes import AESService
 from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService
+
+LOG = logging.getLogger(__name__)
 
 
 class Function(StrEnum):
@@ -139,6 +142,8 @@ class MoodleAPIClient:
         # We don't want to download the full file so we'll do a HEAD request and assume:
         #   - JSON response, it's an error response
         #   - Anything else, it's  the file we are after
+
+        LOG.info("Headers from Moodle file check %s", response.headers)
         return not response.headers["content-type"].startswith("application/json")
 
     def page(self, course_id, page_id) -> dict | None:


### PR DESCRIPTION
See: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1730387908831469
---

We are seeing a school response that doesn't seem to contain the content type header we rely on to determine if a file still exists in Moodle.

Before we try alternative approaches to detect if a file exists lets add some logging to check the response headers.

One possible explanation could be that we are dealing with two different issues issues:

- The server doesn't return the content type header for this request

Maybe a different Moodle version? Some server configured in front of Moodle strips them.

- The file doesn't exist on the server or we can access it for some reason.



