### PR TITLE
Reserve less space for main dashboard column in large resolutions

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/OrderableActivityTable.tsx
@@ -51,8 +51,8 @@ export default function OrderableActivityTable<T>({
           // For assignments with auto-grading, a fifth column is displayed.
           // In that case, we need to reserve less space for the first column,
           // otherwise the rest overflow.
-          'lg:w-[60%] md:w-[45%]': index === 0 && columns.length < 5,
-          'lg:w-[45%] md:w-[30%]': index === 0 && columns.length >= 5,
+          'lg:w-[55%] md:w-[45%]': index === 0 && columns.length < 5,
+          'lg:w-[40%] md:w-[30%]': index === 0 && columns.length >= 5,
         }),
       })),
     [columns],


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/135?pane=issue&itemId=85690196

In some languages (like en-US), formatted dates displayed in the LMS dashboard need a bit more space than with other previously tested languages (like es-ES).

This PR reduces a bit the space reserved for the main dashboard table column in large resolutions, so that the rest of the columns have more available space and dates do not overflow.

Before:

![Captura desde 2024-11-06 15-07-37](https://github.com/user-attachments/assets/bb7c0f87-15c4-4b8d-bd76-80d4d5475b1c)

After:

![Captura desde 2024-11-06 15-07-17](https://github.com/user-attachments/assets/42e6ad59-1d15-4eb3-a725-499671984361)

### Considerations

The reason dates overflow is because we use `white-space: nowrap` to avoid multiple lines, which are also not great. However, this has the side effect that, depending on the language, we may run out of space.

It would be good to test a few more languages, most common ones, and ensure we don't face similar issues, even with the changes introduced here.