### PR TITLE
Rename "Scaled" grading type to "Proportional"

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -226,6 +226,9 @@ type AssignmentWithCourse = Assignment & {
  * - scaled: students may get a proportional grade based on the amount of
  *           annotations. If requirement is 4, and they created 3, they'll
  *           get a 75%
+ *
+ * @todo `scaled` is now referenced as `proportional` in user-facing texts.
+ *       We should consolidate it eventually.
  */
 export type GradingType = 'all_or_nothing' | 'scaled';
 

--- a/lms/static/scripts/frontend_apps/components/AutoGradingConfigurator.tsx
+++ b/lms/static/scripts/frontend_apps/components/AutoGradingConfigurator.tsx
@@ -122,16 +122,16 @@ export default function AutoGradingConfigurator({
               }
             >
               <RadioGroup.Radio
-                value="all_or_nothing"
-                subtitle={<small>Must meet minimum requirements.</small>}
+                value="scaled"
+                subtitle={<small>3 annotations out of 4 is 75%</small>}
               >
-                All or nothing
+                Proportional
               </RadioGroup.Radio>
               <RadioGroup.Radio
-                value="scaled"
-                subtitle={<small>Proportional to percent completed.</small>}
+                value="all_or_nothing"
+                subtitle={<small>3 annotations out of 4 is 0%</small>}
               >
-                Scaled
+                All or nothing
               </RadioGroup.Radio>
             </RadioGroup>
           </div>

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -203,7 +203,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       if (!assignmentAutoGradingConfig) {
         return {
           enabled: false,
-          grading_type: 'all_or_nothing',
+          grading_type: 'scaled',
           activity_calculation: 'cumulative',
           required_annotations: 1,
         };

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -6,7 +6,7 @@ import GradeIndicator from '../GradeIndicator';
 
 describe('GradeIndicator', () => {
   const defaultConfig = {
-    grading_type: 'all_or_nothing',
+    grading_type: 'scaled',
     activity_calculation: 'separate',
     required_annotations: 1,
     required_replies: 1,

--- a/lms/static/scripts/frontend_apps/components/test/AutoGradingConfigurator-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AutoGradingConfigurator-test.js
@@ -10,7 +10,7 @@ describe('AutoGradingConfigurator', () => {
 
   beforeEach(() => {
     fakeAutoGradingConfig = {
-      grading_type: 'all_or_nothing',
+      grading_type: 'scaled',
       activity_calculation: 'cumulative',
       required_annotations: 1,
     };
@@ -80,7 +80,7 @@ describe('AutoGradingConfigurator', () => {
         assert.equal(inputs.length, activityCalculation === 'separate' ? 2 : 1);
         assert.equal(
           firstInput.text(),
-          `Annotations${activityCalculation === 'cumulative' ? ' and replies' : ''}Minimum`,
+          `Annotations${activityCalculation === 'cumulative' ? ' and replies' : ''}Goal`,
         );
       });
     });


### PR DESCRIPTION
> Part of https://github.com/orgs/hypothesis/projects/135/views/1?pane=issue&itemId=85690560

This PR makes a few changes in the auto-grading configuration form, based on users feedback:

* Rename "Scaled" grading type to "Proportional". The change applies to user-facing texts only, as the internal value leaks to the BE and database. We can consolidate it later.
* Make "Proportional" the default grading type, and therefore, display it as the first option.
* Change subtitles for both grading types so that they explain how they work with an example.

Before:
![Captura desde 2024-11-07 10-35-23](https://github.com/user-attachments/assets/87bdeaa0-87f3-453b-8ce9-1120f033057e)

After:
![Captura desde 2024-11-07 10-34-22](https://github.com/user-attachments/assets/cc4fb3c7-2361-4bb6-a951-094dda0a7ac9)

