### PR TITLE
Switch group set reads to the GroupSetService

### DIFF
--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -88,8 +88,8 @@ class CanvasGroupingPlugin(GroupingPlugin):
             )
         except CanvasAPIError as canvas_api_error:
             group_set_name = None
-            if group_set := self._request.find_service(name="course").find_group_set(
-                group_set_id=group_set_id
+            if group_set := self._group_set_service.find_group_set(
+                course.application_instance, group_set_id=group_set_id
             ):
                 group_set_name = group_set["name"]
 

--- a/lms/product/canvas/_plugin/grouping.py
+++ b/lms/product/canvas/_plugin/grouping.py
@@ -89,9 +89,9 @@ class CanvasGroupingPlugin(GroupingPlugin):
         except CanvasAPIError as canvas_api_error:
             group_set_name = None
             if group_set := self._group_set_service.find_group_set(
-                course.application_instance, group_set_id=group_set_id
+                course.application_instance, lms_id=group_set_id
             ):
-                group_set_name = group_set["name"]
+                group_set_name = group_set.name
 
             raise GroupError(
                 ErrorCodes.GROUP_SET_NOT_FOUND,

--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -93,7 +93,7 @@ class CourseCopyGroupsHelper:
 
         # Get the original group set from the DB
         group_set = self._group_set_service.find_group_set(
-            application_instance=course.application_instance, group_set_id=group_set_id
+            application_instance=course.application_instance, lms_id=group_set_id
         )
         if not group_set:
             # If we haven't found it could that either:
@@ -107,12 +107,12 @@ class CourseCopyGroupsHelper:
         # or another user might have done it before for us.
         if new_group_set := self._group_set_service.find_group_set(
             application_instance=course.application_instance,
-            name=group_set["name"],
+            name=group_set.name,
             context_id=course.lms_id,
         ):
             # We found a match, store it to save the search for next time
-            course.set_mapped_group_set_id(group_set_id, new_group_set["id"])
-            return new_group_set["id"]
+            course.set_mapped_group_set_id(group_set_id, new_group_set.lms_id)
+            return new_group_set.lms_id
 
         # No match
         return None

--- a/lms/services/course.py
+++ b/lms/services/course.py
@@ -362,44 +362,6 @@ class CourseService:
             )
         )
 
-    def find_group_set(self, group_set_id=None, name=None, context_id=None):
-        """
-        Find the first matching group set in this course.
-
-        Group sets are stored as part of Course.extra, this method allows to query and filter them.
-
-        :param context_id: Match only group sets of courses with this ID
-        :param name: Filter courses by name
-        :param group_set_id: Filter courses by ID
-        """
-        group_set = (
-            func.jsonb_to_recordset(Course.extra["group_sets"])
-            .table_valued(
-                column("id", Text), column("name", Text), joins_implicitly=True
-            )
-            .render_derived(with_types=True)
-        )
-
-        query = self._db.query(Grouping.id, group_set.c.id, group_set.c.name).filter(
-            Grouping.application_instance == self._application_instance
-        )
-
-        if context_id:
-            query = query.filter(Grouping.lms_id == context_id)
-
-        if group_set_id:
-            query = query.filter(group_set.c.id == group_set_id)
-
-        if name:
-            query = query.filter(
-                func.lower(func.trim(group_set.c.name)) == func.lower(func.trim(name))
-            )
-
-        if group_set := query.first():
-            return {"id": group_set.id, "name": group_set.name}
-
-        return None
-
     def get_by_id(self, id_: int) -> Course | None:
         return self._search_query(id_=id_).one_or_none()
 

--- a/lms/services/group_set.py
+++ b/lms/services/group_set.py
@@ -1,6 +1,8 @@
 from typing import TypedDict
 
-from lms.models.group_set import LMSGroupSet
+from sqlalchemy import Text, column, func, select, union
+
+from lms.models import Course, Grouping, LMSGroupSet
 from lms.services.upsert import bulk_upsert
 
 
@@ -45,6 +47,46 @@ class GroupSetService:
             index_elements=["lms_course_id", "lms_id"],
             update_columns=["name", "updated"],
         )
+
+    def find_group_set(
+        self, application_instance, group_set_id=None, name=None, context_id=None
+    ) -> GroupSetDict | None:
+        """
+        Find the first matching group set in this course.
+
+        Group sets are stored as part of Course.extra, this method allows to query and filter them.
+
+        :param context_id: Match only group sets of courses with this ID
+        :param name: Filter courses by name
+        :param group_set_id: Filter courses by ID
+        """
+        group_set = (
+            func.jsonb_to_recordset(Course.extra["group_sets"])
+            .table_valued(
+                column("id", Text), column("name", Text), joins_implicitly=True
+            )
+            .render_derived(with_types=True)
+        )
+
+        query = self._db.query(Grouping.id, group_set.c.id, group_set.c.name).filter(
+            Grouping.application_instance == application_instance
+        )
+
+        if context_id:
+            query = query.filter(Grouping.lms_id == context_id)
+
+        if group_set_id:
+            query = query.filter(group_set.c.id == group_set_id)
+
+        if name:
+            query = query.filter(
+                func.lower(func.trim(group_set.c.name)) == func.lower(func.trim(name))
+            )
+
+        if group_set := query.first():
+            return {"id": group_set.id, "name": group_set.name}
+
+        return None
 
 
 def factory(_context, request):

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -37,6 +37,7 @@ from tests.factories.lms_course import (
     LMSCourseApplicationInstance,
     LMSCourseMembership,
 )
+from tests.factories.lms_group_set import LMSGroupSet
 from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride

--- a/tests/factories/lms_group_set.py
+++ b/tests/factories/lms_group_set.py
@@ -1,0 +1,6 @@
+from factory import make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+LMSGroupSet = make_factory(models.LMSGroupSet, FACTORY_CLASS=SQLAlchemyModelFactory)

--- a/tests/unit/lms/product/canvas/_plugin/grouping_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/grouping_test.py
@@ -110,9 +110,9 @@ class TestCanvasGroupingPlugin:
         assert canvas_api_client.group_category_groups.return_value == api_groups
 
     def test_get_groups_for_instructor_group_set_not_found(
-        self, grouping_service, canvas_api_client, course, plugin, course_service
+        self, grouping_service, canvas_api_client, course, plugin, group_set_service
     ):
-        course_service.find_group_set.return_value = None
+        group_set_service.find_group_set.return_value = None
         canvas_api_client.group_category_groups.side_effect = CanvasAPIError()
 
         with pytest.raises(GroupError) as err:
@@ -120,8 +120,8 @@ class TestCanvasGroupingPlugin:
                 grouping_service, course, sentinel.group_set_id
             )
 
-        course_service.find_group_set.assert_called_once_with(
-            group_set_id=sentinel.group_set_id
+        group_set_service.find_group_set.assert_called_once_with(
+            course.application_instance, lms_id=sentinel.group_set_id
         )
         assert err.value.error_code == ErrorCodes.GROUP_SET_NOT_FOUND
         assert err.value.details == {
@@ -130,9 +130,11 @@ class TestCanvasGroupingPlugin:
         }
 
     def test_get_groups_for_instructor_group_set_not_found_with_original_name(
-        self, grouping_service, canvas_api_client, course, plugin, course_service
+        self, grouping_service, canvas_api_client, course, plugin, group_set_service
     ):
-        course_service.find_group_set.return_value = {"name": sentinel.name}
+        group_set_service.find_group_set.return_value = factories.LMSGroupSet(
+            name=sentinel.name
+        )
         canvas_api_client.group_category_groups.side_effect = CanvasAPIError()
 
         with pytest.raises(GroupError) as err:
@@ -140,8 +142,8 @@ class TestCanvasGroupingPlugin:
                 grouping_service, course, sentinel.group_set_id
             )
 
-        course_service.find_group_set.assert_called_once_with(
-            group_set_id=sentinel.group_set_id
+        group_set_service.find_group_set.assert_called_once_with(
+            course.application_instance, lms_id=sentinel.group_set_id
         )
         assert err.value.error_code == ErrorCodes.GROUP_SET_NOT_FOUND
         assert err.value.details == {

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -280,39 +280,6 @@ class TestCourseService:
             update_columns=["updated"],
         )
 
-    @pytest.mark.usefixtures("course_with_group_sets")
-    @pytest.mark.parametrize(
-        "params",
-        (
-            {"context_id": "context_id", "group_set_id": "ID", "name": "NAME"},
-            {"context_id": "context_id", "name": "NAME"},
-            {"context_id": "context_id", "name": "name"},
-            {"context_id": "context_id", "name": "NAME    "},
-            {"context_id": "context_id", "group_set_id": "ID"},
-        ),
-    )
-    def test_find_group_set(self, svc, params):
-        group_set = svc.find_group_set(**params)
-
-        assert group_set["id"] == "ID"
-        assert group_set["name"] == "NAME"
-
-    @pytest.mark.usefixtures("course_with_group_sets")
-    @pytest.mark.parametrize(
-        "params",
-        (
-            {"context_id": "context_id", "group_set_id": "NOID", "name": "NAME"},
-            {"context_id": "context_id", "group_set_id": "ID", "name": "NONAME"},
-            {"context_id": "no_context_id", "group_set_id": "ID", "name": "NAME"},
-        ),
-    )
-    def test_find_group_set_no_matches(self, svc, params):
-        assert not svc.find_group_set(**params)
-
-    @pytest.mark.usefixtures("course_with_group_sets")
-    def test_find_group_set_returns_first_result(self, svc):
-        assert svc.find_group_set()
-
     @pytest.mark.parametrize(
         "param,field",
         (
@@ -474,22 +441,6 @@ class TestCourseService:
             authority_provided_id=grouping_service.get_authority_provided_id.return_value,
             lms_id="context_id",
         )
-
-    @pytest.fixture
-    def course_with_group_sets(self, course):
-        course.extra = {
-            "group_sets": [
-                {
-                    "id": "ID",
-                    "name": "NAME",
-                },
-                {
-                    "id": "NOT MATCHING ID NOISE",
-                    "name": "NOT MATCHING NAME NOISE",
-                },
-            ]
-        }
-        return course
 
     @pytest.fixture
     def application_instance(self, application_instance):


### PR DESCRIPTION
For: 

- https://github.com/hypothesis/lms/issues/6834



### Testing

Reading group sets is used during course copy.




- First we need to fetch the groups on the original course to simulate it's initial configuration (when we store the groups).

Open https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/2132/View **as an instructor** (I use `Marcos.Prieto`) edit it and force loading the group sets. No need to save the edit.


- Check the groups set are in the DB



```
select * from lms_group_set;
 id | lms_id |          name          | lms_course_id |          created           |          updated           
----+--------+------------------------+---------------+----------------------------+----------------------------
 38 | 22     | Group Category testing |           339 | 2024-11-07 14:23:43.794203 | 2024-11-07 14:23:43.794203
 39 | 23     | Empty group category   |           339 | 2024-11-07 14:23:43.794203 | 2024-11-07 14:23:43.794203
 40 | 26     | Support test Group Set |           339 | 2024-11-07 14:23:43.794203 | 2024-11-07 14:23:43.794203
 41 | 65     | MMC Category Settings  |           339 | 2024-11-07 14:23:43.794203 | 2024-11-07 14:23:43.794203
(4 rows)
```


- Launch the equivalent assignment in a copied course as a student that was not part of the original course, for example: `StudentInNoCourses`

https://aunltd.brightspacedemo.com/d2l/le/content/6888/viewContent/2656/View?ou=6888 


- Group sets now include the group sets from the new course

```
68 | 63     | Group Category testing |           823 | 2024-11-07 15:06:17.22955  | 2024-11-07 15:06:17.22955
 69 | 64     | Support test Group Set |           823 | 2024-11-07 15:06:17.22955  | 2024-11-07 15:06:17.22955
```

- And we have stored their equivalence (still in grouping) for course copy:

```
select extra->'course_copy_group_set_mappings' from grouping where type = 'course' and lms_id  = '6888';
   ?column?   
--------------
 {"22": "63"}
(1 row)
```
