### PR TITLE
Return pageSize and hasMorePages as part of usePaginatedAPIFetch result

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/api-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/api-test.js
@@ -566,6 +566,10 @@ describe('usePaginatedAPIFetch', () => {
           {!result.isLoading &&
             (result.data ? result.data.join(',') : 'No content')}
         </div>
+        <div data-testid="page-size">{result.pageSize ?? 'No page size'}</div>
+        <div data-testid="has-more-pages">
+          {result.hasMorePages ? 'Yes' : 'No'}
+        </div>
 
         <button
           onClick={() => result.loadNextPage()}
@@ -587,6 +591,14 @@ describe('usePaginatedAPIFetch', () => {
 
   function getMainContent(wrapper) {
     return wrapper.find('[data-testid="main-content"]').text();
+  }
+
+  function getPageSize(wrapper) {
+    return wrapper.find('[data-testid="page-size"]').text();
+  }
+
+  function getHasMorePages(wrapper) {
+    return wrapper.find('[data-testid="has-more-pages"]').text();
   }
 
   function reRender(wrapper) {
@@ -651,6 +663,21 @@ describe('usePaginatedAPIFetch', () => {
       params: { foo: 'bar' },
     });
     assert.equal(getMainContent(wrapper), 'No content');
+  });
+
+  it('returns page size when API indicates there is a `next` page', () => {
+    const wrapper = createComponent();
+
+    assert.equal(getPageSize(wrapper), `${pageResults[0].items.length}`);
+    assert.equal(getHasMorePages(wrapper), 'Yes');
+  });
+
+  it('does not return page size when API indicates there is only one page', () => {
+    mockFetchResult(pageResults[2]);
+    const wrapper = createComponent();
+
+    assert.equal(getPageSize(wrapper), 'No page size');
+    assert.equal(getHasMorePages(wrapper), 'No');
   });
 });
 


### PR DESCRIPTION
This PR updates the result returned by `usePaginatedAPIFetch`, so that two new properties are included:

* `hasMorePages`: It's `true` if the server indicates there are still more pages to load, and `false` otherwise.
* `pageSize`: Indicates the maximum amount of items per page, or it's `undefined` if there's only one page.

These are useful for https://github.com/hypothesis/product-backlog/issues/1570, as they will allow us to display an exact number of items in the dropdown, or something like `100+` where 100 is the page size, but allowing to change the page sizes for every individual dropdown, without having to change the logic to represent the count badge.

### Todo

- [x] Add test