### PR TITLE
Update to frontend-shared 8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.8.0",
+    "@hypothesis/frontend-shared": "^8.9.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,15 +1982,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.8.0":
-  version: 8.8.0
-  resolution: "@hypothesis/frontend-shared@npm:8.8.0"
+"@hypothesis/frontend-shared@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "@hypothesis/frontend-shared@npm:8.9.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: c6e1e9359400dabc12e03cb4f805ba5b4404d930a45a46a2a62e710e199e51f3c8c950b1d205c3b6276e7ffba3350bf8b16b8dea29a15884ccae7ac326a76769
+  checksum: bfe04718494b870a429c6ab7d1be8a656e13424b08e2cd1f9377a4622c1a16867ef7a450cccbfe37d8cc36236802db2babe13b93ca5da6feb19bc661d73f6728
   languageName: node
   linkType: hard
 
@@ -7287,7 +7287,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@babel/preset-typescript": ^7.26.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.8.0
+    "@hypothesis/frontend-shared": ^8.9.0
     "@hypothesis/frontend-testing": ^1.2.2
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.1


### PR DESCRIPTION
Update to frontend-shared 8.9, and fix a few tests that are broken due to the [change in Select](https://github.com/hypothesis/frontend-shared/pull/1762), that makes listbox content not to be rendered while it is closed.

The changes in tests involve:

1. Making sure the Select has been opened before trying to query for options or any other content that is rendered inside the listbox. One of the changes in frontend-shared 8.9 is that the listbox content is only rendered while it's open.
2. Attaching the component under test to an actual DOM element. This is required because the Select's listbox is displayed using the popover API, which throws if you try to use it on an unattached element.