### PR TITLE
Backfill LMSSegment (sections)

### DIFF
--- a/lms/migrations/versions/2f7913c24b69_backfill_lms_segment_sections.py
+++ b/lms/migrations/versions/2f7913c24b69_backfill_lms_segment_sections.py
@@ -1,0 +1,58 @@
+"""Backfill lms_segment (sections)."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2f7913c24b69"
+down_revision = "2ff20de04a9d"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+        WITH backfill as (
+            -- Deduplicate "grouping" sections on authority_provided_id
+            SELECT DISTINCT ON (grouping.authority_provided_id)
+                "grouping".created,
+                "grouping".updated,
+                grouping.authority_provided_id,
+                grouping.lms_name,
+                grouping.lms_id,
+                "lms_course".id as lms_course_id
+            FROM "grouping"
+            -- Join grouping on itself to get the parent (course) data
+            JOIN "grouping" parent on parent.id = grouping.parent_id
+            -- Get the right LMSCourse row based on the parent
+            JOIN lms_course on lms_course.h_authority_provided_id = parent.authority_provided_id
+            -- Pick only sections
+            WHERE grouping.type ='canvas_section'
+            -- Pick the most recent version we've seen
+            ORDER BY grouping.authority_provided_id, "grouping".updated desc
+        )
+        INSERT INTO lms_segment (
+             created,
+             updated,
+             type,
+             h_authority_provided_id,
+             lms_id,
+             name,
+             lms_course_id
+        )
+        SELECT
+           created,
+           updated,
+           'canvas_section',
+           authority_provided_id,
+           lms_id,
+           lms_name,
+           lms_course_id
+        FROM backfill
+        -- We are already inserting rows in lms_segment in the python code, leave those alone
+        ON CONFLICT (h_authority_provided_id) DO NOTHING
+    """)
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6851


## Testing

- Launch a sections assignment: 

https://hypothesis.instructure.com/courses/125/assignments/874


- Check the values in LMSSegment:


``` 
select * from lms_segment where type = 'canvas_section';
 id  |      type      | lms_id |   name    |         h_authority_provided_id          | lms_course_id | lms_group_set_id |          created           |          updated
-----+----------------+--------+-----------+------------------------------------------+---------------+------------------+----------------------------+----------------------------
 127 | canvas_section | 144    | Section 1 | d2871e5e1c36b58f207d9ef5b22dcb7829f52e61 |           105 |                  | 2024-11-13 09:20:15.737572 | 2024-11-13 09:20:15.737572
 128 | canvas_section | 145    | Section 2 | f453c6124e4ead4471896f26e896c3e5bbf0bb36 |           105 |                  | 2024-11-13 09:20:15.737572 | 2024-11-13 09:20:15.737572
 129 | canvas_section | 146    | Section 3 | 83e64baad215f63057387910a1b41debc716a150 |           105 |                  | 2024-11-13 09:20:15.737572 | 2024-11-13 09:20:15.737572
```


- Delete them:

```truncate lms_segment cascade;```


- Apply the migration


```tox -e dev --run-command 'alembic upgrade head'```


- Select the sections again, compare them with the previous values:


```
select * from lms_segment where type = 'canvas_section';
 id  |      type      | lms_id |   name    |         h_authority_provided_id          | lms_course_id | lms_group_set_id |          created           |          updated
-----+----------------+--------+-----------+------------------------------------------+---------------+------------------+----------------------------+----------------------------
 130 | canvas_section | 146    | Section 3 | 83e64baad215f63057387910a1b41debc716a150 |           105 |                  | 2024-11-12 09:55:01.012244 | 2024-11-13 09:20:15.737572
 131 | canvas_section | 144    | Section 1 | d2871e5e1c36b58f207d9ef5b22dcb7829f52e61 |           105 |                  | 2024-11-12 09:55:01.012244 | 2024-11-13 09:20:15.737572
 132 | canvas_section | 145    | Section 2 | f453c6124e4ead4471896f26e896c3e5bbf0bb36 |           105 |                  | 2024-11-12 09:55:01.012244 | 2024-11-13 09:20:15.737572
(3 rows)
```

