### PR TITLE
Avoid loading next page in PaginatedMultiSelect when scrolling up

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
@@ -89,6 +89,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
   onChange,
 }: PaginatedMultiSelectProps<TResult, TSelect>) {
   const lastOptionRef = useRef<HTMLElement | null>(null);
+  const lastListboxScrollPosition = useRef(0);
 
   return (
     <MultiSelect
@@ -100,7 +101,14 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
       buttonContent={buttonContent}
       data-testid={`${entity}-select`}
       onListboxScroll={e => {
-        if (elementScrollIsAtBottom(e.target as HTMLUListElement)) {
+        const element = e.target as HTMLUListElement;
+        const newScrollPosition = element.scrollTop;
+        const isScrollingDown =
+          newScrollPosition > lastListboxScrollPosition.current;
+
+        lastListboxScrollPosition.current = newScrollPosition;
+
+        if (isScrollingDown && elementScrollIsAtBottom(element)) {
           result.loadNextPage();
         }
       }}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
@@ -95,11 +95,11 @@ describe('PaginatedMultiSelect', () => {
       return { select, fakeLoadNextPage };
     }
 
-    function scrollTo(select, scrollHeight) {
+    function scrollTo(select, { scrollHeight, scrollTop = 100 }) {
       select.props().onListboxScroll({
         target: {
-          scrollTop: 100,
           clientHeight: 50,
+          scrollTop,
           scrollHeight,
         },
       });
@@ -108,15 +108,26 @@ describe('PaginatedMultiSelect', () => {
     it('loads next page when scroll is at the bottom', () => {
       const { select, fakeLoadNextPage } = getScrollableSelect();
 
-      scrollTo(select, 160);
+      scrollTo(select, { scrollHeight: 160 });
       assert.called(fakeLoadNextPage);
     });
 
     it('does nothing when scroll is not at the bottom', () => {
       const { select, fakeLoadNextPage } = getScrollableSelect();
 
-      scrollTo(select, 250);
+      scrollTo(select, { scrollHeight: 250 });
       assert.notCalled(fakeLoadNextPage);
+    });
+
+    it('does not scroll again if scrolling up', () => {
+      const { select, fakeLoadNextPage } = getScrollableSelect();
+
+      // We scroll down, then a little bit up, still inside the offset gap
+      scrollTo(select, { scrollHeight: 160, scrollTop: 155 });
+      scrollTo(select, { scrollHeight: 160, scrollTop: 150 });
+
+      // The page is attempted to load only once, and ignored when scrolling up
+      assert.calledOnce(fakeLoadNextPage);
     });
   });
 


### PR DESCRIPTION
This PR aims to fix two somewhat related but different issues:

1. Avoid loading next page in `PaginatedMultiSelect` when scrolling up:
    Since we don't trigger next page loads when reaching the very bottom, but at a certain offset (20px ATM), it can happen that the user scrolls to the very bottom, and then scrolling a few pixels back up would trigger more loads, because we are still inside that offset gap.
2. Avoid a scroll event to be triggered when a new page of results is loaded:
    Right before the new items are appended, the loading indicator is removed from the scrollable area that is the target for the scroll event, reducing its size. If the scroll is inside the offset gap, that triggers a new scroll event.

The good thing is that solving point 1 also solves point 2, because reducing the height of the scrollable area while you are at the very bottom is evaluated as scrolling up when comparing scroll positions.

This PR now tracks a reference to the last scrolled position, and compares it with the new one every time the scroll event is triggered, in order to know if scroll is going down, and otherwise ignore it.

### Testing steps

If you don't have any filter with more than 100 items (the default page size), you can fake it by applying this diff:

```diff
diff --git a/lms/views/dashboard/pagination.py b/lms/views/dashboard/pagination.py
index 0cc61a3a8..b8a26ac1e 100644
--- a/lms/views/dashboard/pagination.py
+++ b/lms/views/dashboard/pagination.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-MAX_ITEMS_PER_PAGE = 100
+MAX_ITEMS_PER_PAGE = 6
 """Maximum number of items to return in paginated endpoints"""
 ```

6 items allows for the scroll to appear in the listbox and will probably produce more than 2 pages.

1. Apply the diff above.
2. Go to the dashboard http://localhost:8001/dashboard
3. Open the browser dev tools and enable network throttling, so that loading pages is slower.
4. Open one of the listboxes and scroll down. Once the loading indicator appears scroll down again to reach the bottom.
5. When the second page finishes loading, there should not be an attempt on loading any further pages.

If the same is done in `main`, once the second page has been loaded, you will notice the third page load is triggered.

### TODO

- [x] Add a test