### PR TITLE
Backfill LMSCourseMembership

### DIFF
--- a/lms/migrations/versions/50fb51c51314_backfill_lms_course_membership.py
+++ b/lms/migrations/versions/50fb51c51314_backfill_lms_course_membership.py
@@ -1,0 +1,44 @@
+"""Backfill lms_course_membership."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "50fb51c51314"
+down_revision = "a7e9dc7c4c0f"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+        WITH backfill as (
+            select lms_course.id lms_course_id, lms_user.id as lms_user_id, lti_role_id, min(assignment_membership.created) created, max(assignment_membership.updated) updated
+            from assignment_membership
+            join assignment on assignment_id = assignment.id join grouping on grouping.id = course_id
+            join lms_course on lms_course.h_authority_provided_id = grouping.authority_provided_id
+            join "user" on "user".id = assignment_membership.user_id
+            join  lms_user on lms_user.h_userid = "user".h_userid
+            group by lms_course.id, lms_user.id, lti_role_id
+        )
+        INSERT INTO lms_course_membership (
+            created,
+            updated,
+            lms_course_id,
+            lms_user_id,
+            lti_role_id
+        )
+        SELECT
+           created,
+           updated,
+           lms_course_id,
+           lms_user_id,
+           lti_role_id
+        FROM backfill
+        -- We are already inserting rows in the membership table in the python code, leave those alone
+        ON CONFLICT (lms_course_id, lms_user_id, lti_role_id) DO NOTHING
+    """)
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
For: 

- https://github.com/hypothesis/lms/issues/6575


We never stored course level membership information with roles. We only did that at the assignment level. 

Use the assignment level information to fill the parent course membership information. 

### Testing


- Truncate the target and source tables:

```
truncate assignment_membership, lms_course_membership cascade;
```


- Launch a bunch of assignments


https://hypothesis.instructure.com/courses/125/assignments/1833
https://hypothesis.instructure.com/courses/125/assignments/874
https://hypothesis.instructure.com/courses/319/assignments/3308



- Check the state of the table now:


```
 select lms_course_id, lms_user_id, lti_role_id from  lms_course_membership;
 lms_course_id | lms_user_id | lti_role_id
---------------+-------------+-------------
           104 |         982 |          17
           104 |         982 |          18
           104 |         982 |          20
           104 |         982 |          19
           105 |         982 |          21
(5 rows)
```


- Truncate just the target again:


```
truncate lms_course_membership cascade;
```

- Apply the migration

`tox -e dev --run-command 'alembic upgrade head'`


- Check the data again now:

```
select lms_course_id, lms_user_id, lti_role_id from  lms_course_membership;
 lms_course_id | lms_user_id | lti_role_id
---------------+-------------+-------------
           104 |         982 |          17
           104 |         982 |          19
           104 |         982 |          20
           104 |         982 |          18
           105 |         982 |          21
(5 rows)
```

which matches the data from before the last truncate.
