### PR TITLE
Refactor user view, center calls to UserService.get_users

### DIFF
--- a/lms/models/lms_user.py
+++ b/lms/models/lms_user.py
@@ -46,6 +46,11 @@ class LMSUser(CreatedUpdatedMixin, Base):
 
     display_name: Mapped[str | None] = mapped_column(index=True)
 
+    @property
+    def user_id(self) -> str:
+        """Alias lti_user_id to user_if for compatilbiity with models.User."""
+        return self.lti_user_id
+
 
 class LMSUserApplicationInstance(CreatedUpdatedMixin, Base):
     """Record of on which installs (application instances) we have seen one user."""

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -342,20 +342,24 @@ class AssignmentService:
         """Get the relevant groups for the assignment from the DB."""
         if group_set_id := assignment.extra.get("group_set_id"):
             return self._db.scalars(
-                select(Grouping).where(
+                select(Grouping)
+                .where(
                     Grouping.parent_id == assignment.course_id,
                     Grouping.extra["group_set_id"].astext == str(group_set_id),
                 )
+                .order_by(Grouping.lms_name.asc())
             ).all()
         return []
 
     def get_assignment_sections(self, assignment) -> Sequence[Grouping]:
         """Get the relevant groups for the assignment from the DB."""
         return self._db.scalars(
-            select(Grouping).where(
+            select(Grouping)
+            .where(
                 Grouping.parent_id == assignment.course_id,
                 Grouping.type == "canvas_section",
             )
+            .order_by(Grouping.lms_name.asc())
         ).all()
 
     def _update_auto_grading_config(

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -34,22 +34,8 @@ class DashboardService:
         self._organization_service = organization_service
         self._h_authority = h_authority
 
-    def get_request_assignment(self, request) -> Assignment:
+    def get_request_assignment(self, request, assigment_id: int) -> Assignment:
         """Get and authorize an assignment for the given request."""
-        # Requests that are scoped to one assignment on the URL parameter
-        assigment_id = request.matchdict.get("assignment_id")
-        if not assigment_id:
-            # Request that are scoped to a single assignment but as a query parameter
-            assigment_id = request.parsed_params.get("assignment_id")
-
-        if (
-            not assigment_id
-            and request.parsed_params.get("assignment_ids")
-            and len(request.parsed_params["assignment_ids"]) == 1
-        ):
-            # Request that take a list of assignments, but we only recieved one, the requests is scoped to that one assignment
-            assigment_id = request.parsed_params["assignment_ids"][0]
-
         assignment = self._assignment_service.get_by_id(assigment_id)
         if not assignment:
             raise HTTPNotFound()
@@ -73,18 +59,8 @@ class DashboardService:
 
         return assignment
 
-    def get_request_course(self, request):
+    def get_request_course(self, request, course_id: int):
         """Get and authorize a course for the given request."""
-        # Requests that are scoped to one course on the URL parameter
-        course_id = request.matchdict.get("course_id")
-        if (
-            not course_id
-            and request.parsed_params.get("course_ids")
-            and len(request.parsed_params["course_ids"]) == 1
-        ):
-            # Request that take a list of courses, but we only recieved one, the requests is scoped to that one course
-            course_id = request.parsed_params["course_ids"][0]
-
         course = self._course_service.get_by_id(course_id)
         if not course:
             raise HTTPNotFound()

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -196,6 +196,9 @@ class HAPI:
         h_userids: list[str] | None = None,
         resource_link_ids: list[str] | None = None,
     ) -> list[AnnotationCounts]:
+        if not group_authority_ids:
+            return []
+
         filters = {
             "groups": group_authority_ids,
             "assignment_ids": resource_link_ids,

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -99,7 +99,9 @@ class AssignmentViews:
         permission=Permissions.DASHBOARD_VIEW,
     )
     def assignment(self) -> APIAssignment:
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.request.matchdict["assignment_id"]
+        )
         api_assignment = APIAssignment(
             id=assignment.id,
             title=assignment.title,
@@ -135,7 +137,9 @@ class AssignmentViews:
             self.request
         )
 
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.request.matchdict["course_id"]
+        )
         course_students = self.request.db.scalars(
             self.user_service.get_users(
                 course_ids=[course.id],

--- a/lms/views/dashboard/api/course.py
+++ b/lms/views/dashboard/api/course.py
@@ -137,7 +137,9 @@ class CourseViews:
         permission=Permissions.DASHBOARD_VIEW,
     )
     def course(self) -> APICourse:
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.request.matchdict["course_id"]
+        )
         return {
             "id": course.id,
             "title": course.lms_name,

--- a/lms/views/dashboard/api/grading.py
+++ b/lms/views/dashboard/api/grading.py
@@ -45,7 +45,9 @@ class DashboardGradingViews:
         schema=AutoGradeSyncSchema,
     )
     def create_grading_sync(self):
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.request.matchdict["assignment_id"]
+        )
 
         if self.auto_grading_service.get_in_progress_sync(assignment):
             self.request.response.status_int = 400
@@ -85,7 +87,9 @@ class DashboardGradingViews:
         permission=Permissions.GRADE_ASSIGNMENT,
     )
     def get_grading_sync(self):
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.request.matchdict["assignment_id"]
+        )
         if grading_sync := self.auto_grading_service.get_last_sync(assignment):
             return self._serialize_grading_sync(grading_sync)
 

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -110,7 +110,9 @@ class UserViews:
     )
     def students_metrics(self) -> APIStudents:
         """Fetch the stats for one particular assignment."""
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.request.parsed_params["assignment_id"]
+        )
 
         request_segment_authority_provided_ids = self.request.parsed_params.get(
             "segment_authority_provided_ids"
@@ -211,7 +213,9 @@ class UserViews:
             and not segment_authority_provided_ids
         ):
             # Fetch the assignment to be sure the current user has access to it.
-            assignment = self.dashboard_service.get_request_assignment(self.request)
+            assignment = self.dashboard_service.get_request_assignment(
+                self.request, assignment_ids[0]
+            )
 
             return self.user_service.get_users_for_assignment(
                 role_scope=RoleScope.COURSE,
@@ -223,7 +227,9 @@ class UserViews:
         # Single course fetch
         if course_ids and len(course_ids) == 1 and not segment_authority_provided_ids:
             # Fetch the course to be sure the current user has access to it.
-            course = self.dashboard_service.get_request_course(self.request)
+            course = self.dashboard_service.get_request_course(
+                self.request, course_id=course_ids[0]
+            )
 
             return self.user_service.get_users_for_course(
                 role_scope=RoleScope.COURSE,

--- a/lms/views/dashboard/views.py
+++ b/lms/views/dashboard/views.py
@@ -81,7 +81,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        assignment = self.dashboard_service.get_request_assignment(self.request)
+        assignment = self.dashboard_service.get_request_assignment(
+            self.request, self.request.matchdict["assignment_id"]
+        )
         self.request.context.js_config.enable_dashboard_mode(
             AUTHORIZATION_DURATION_SECONDS
         )
@@ -105,7 +107,9 @@ class DashboardViews:
 
         Authenticated via the LTIUser present in a cookie making this endpoint accessible directly in the browser.
         """
-        course = self.dashboard_service.get_request_course(self.request)
+        course = self.dashboard_service.get_request_course(
+            self.request, self.request.matchdict["course_id"]
+        )
         self.request.context.js_config.enable_dashboard_mode(
             AUTHORIZATION_DURATION_SECONDS
         )

--- a/tests/unit/lms/models/lms_user_test.py
+++ b/tests/unit/lms/models/lms_user_test.py
@@ -1,0 +1,10 @@
+from lms.models import RSAKey
+from tests import factories
+
+
+class TestLMSUser:
+    def test_user_id(self):
+        lms_user = factories.LMSUser()
+
+        assert lms_user.lti_user_id
+        assert lms_user.lti_user_id == lms_user.user_id

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -66,6 +66,15 @@ class TestDashboardService:
 
         assert svc.get_request_assignment(pyramid_request)
 
+    def test_get_request_assignment_for_parsed_params_assignment_id(
+        self, pyramid_request, assignment_service, svc
+    ):
+        pyramid_request.parsed_params = {"assignment_ids": [sentinel.parsed_params_id]}
+
+        svc.get_request_assignment(pyramid_request)
+
+        assignment_service.get_by_id.assert_called_once_with(sentinel.parsed_params_id)
+
     def test_get_request_course_404(
         self,
         pyramid_request,
@@ -93,6 +102,15 @@ class TestDashboardService:
         course_service.is_member.return_value = False
 
         assert svc.get_request_course(pyramid_request)
+
+    def test_get_request_for_parsed_params_course_ids(
+        self, pyramid_request, course_service, svc
+    ):
+        pyramid_request.parsed_params = {"course_ids": [sentinel.parsed_params_id]}
+
+        svc.get_request_course(pyramid_request)
+
+        course_service.get_by_id.assert_called_once_with(sentinel.parsed_params_id)
 
     def test_get_request_course_for_admin(
         self,

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -12,35 +12,31 @@ pytestmark = pytest.mark.usefixtures("h_api", "assignment_service")
 
 class TestDashboardService:
     def test_get_request_assignment_404(self, pyramid_request, assignment_service, svc):
-        pyramid_request.matchdict["assignment_id"] = sentinel.id
         assignment_service.get_by_id.return_value = None
 
         with pytest.raises(HTTPNotFound):
-            svc.get_request_assignment(pyramid_request)
+            svc.get_request_assignment(pyramid_request, sentinel.id)
 
     def test_get_request_assignment_403(self, pyramid_request, course_service, svc):
-        pyramid_request.matchdict["assignment_id"] = sentinel.id
         course_service.is_member.return_value = False
 
         with pytest.raises(HTTPUnauthorized):
-            svc.get_request_assignment(pyramid_request)
+            svc.get_request_assignment(pyramid_request, sentinel.id)
 
     def test_get_request_assignment_for_staff(
         self, pyramid_request, assignment_service, pyramid_config, svc
     ):
         pyramid_config.testing_securitypolicy(permissive=True)
-        pyramid_request.matchdict["assignment_id"] = sentinel.id
         assignment_service.is_member.return_value = False
 
-        assert svc.get_request_assignment(pyramid_request)
+        assert svc.get_request_assignment(pyramid_request, sentinel.id)
 
     def test_get_request_assignment(
         self, pyramid_request, course_service, svc, assignment_service
     ):
-        pyramid_request.matchdict["assignment_id"] = sentinel.id
         course_service.is_member.return_value = True
 
-        assert svc.get_request_assignment(pyramid_request)
+        assert svc.get_request_assignment(pyramid_request, sentinel.id)
 
         course_service.is_member.assert_called_once_with(
             assignment_service.get_by_id.return_value.course,
@@ -62,18 +58,7 @@ class TestDashboardService:
         assignment_service.get_by_id.return_value = assignment
         get_request_admin_organizations.return_value = [organization]
 
-        pyramid_request.matchdict["assignment_id"] = sentinel.id
-
-        assert svc.get_request_assignment(pyramid_request)
-
-    def test_get_request_assignment_for_parsed_params_assignment_id(
-        self, pyramid_request, assignment_service, svc
-    ):
-        pyramid_request.parsed_params = {"assignment_ids": [sentinel.parsed_params_id]}
-
-        svc.get_request_assignment(pyramid_request)
-
-        assignment_service.get_by_id.assert_called_once_with(sentinel.parsed_params_id)
+        assert svc.get_request_assignment(pyramid_request, sentinel.id)
 
     def test_get_request_course_404(
         self,
@@ -81,36 +66,24 @@ class TestDashboardService:
         course_service,
         svc,
     ):
-        pyramid_request.matchdict["course_id"] = sentinel.id
         course_service.get_by_id.return_value = None
 
         with pytest.raises(HTTPNotFound):
-            svc.get_request_course(pyramid_request)
+            svc.get_request_course(pyramid_request, sentinel.id)
 
     def test_get_request_course_403(self, pyramid_request, course_service, svc):
-        pyramid_request.matchdict["course_id"] = sentinel.id
         course_service.is_member.return_value = False
 
         with pytest.raises(HTTPUnauthorized):
-            svc.get_request_course(pyramid_request)
+            svc.get_request_course(pyramid_request, sentinel.id)
 
     def test_get_request_course_for_staff(
         self, pyramid_request, course_service, pyramid_config, svc
     ):
         pyramid_config.testing_securitypolicy(permissive=True)
-        pyramid_request.matchdict["course_id"] = sentinel.id
         course_service.is_member.return_value = False
 
-        assert svc.get_request_course(pyramid_request)
-
-    def test_get_request_for_parsed_params_course_ids(
-        self, pyramid_request, course_service, svc
-    ):
-        pyramid_request.parsed_params = {"course_ids": [sentinel.parsed_params_id]}
-
-        svc.get_request_course(pyramid_request)
-
-        course_service.get_by_id.assert_called_once_with(sentinel.parsed_params_id)
+        assert svc.get_request_course(pyramid_request, sentinel.id)
 
     def test_get_request_course_for_admin(
         self,
@@ -123,15 +96,13 @@ class TestDashboardService:
     ):
         course_service.get_by_id.return_value = course
         get_request_admin_organizations.return_value = [organization]
-        pyramid_request.matchdict["course_id"] = sentinel.id
 
-        assert svc.get_request_course(pyramid_request)
+        assert svc.get_request_course(pyramid_request, sentinel.id)
 
     def test_get_request_course(self, pyramid_request, course_service, svc):
-        pyramid_request.matchdict["course_id"] = sentinel.id
         course_service.is_member.return_value = True
 
-        assert svc.get_request_course(pyramid_request)
+        assert svc.get_request_course(pyramid_request, sentinel.id)
 
     def test_add_dashboard_admin(self, svc, db_session):
         admin = svc.add_dashboard_admin(

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -184,6 +184,12 @@ class TestHAPI:
             stream=False,
         )
 
+    def test_get_annotation_counts_with_no_groups(self, h_api, http_service):
+        assert not h_api.get_annotation_counts(
+            group_authority_ids=[], group_by=sentinel.group_by
+        )
+        http_service.request.assert_not_called()
+
     def test_get_groups(self, h_api, http_service):
         groups = [
             {"authority_provided_id": "group_1"},

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -64,7 +64,7 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
 
         assert response == {
@@ -91,7 +91,7 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
 
         assert response == {
@@ -119,7 +119,7 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         assignment_service.get_assignment_groups.assert_called_once_with(assignment)
 
@@ -146,7 +146,7 @@ class TestAssignmentViews:
         response = views.assignment()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         assignment_service.get_assignment_sections.assert_called_once_with(assignment)
 

--- a/tests/unit/lms/views/dashboard/api/course_test.py
+++ b/tests/unit/lms/views/dashboard/api/course_test.py
@@ -94,7 +94,9 @@ class TestCourseViews:
 
         response = views.course()
 
-        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
+        dashboard_service.get_request_course.assert_called_once_with(
+            pyramid_request, sentinel.id
+        )
 
         assert response == {
             "id": course.id,

--- a/tests/unit/lms/views/dashboard/api/grading_test.py
+++ b/tests/unit/lms/views/dashboard/api/grading_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, sentinel
 
 import pytest
 from h_matchers import Any
@@ -20,6 +20,7 @@ class TestDashboardGradingViews:
         dashboard_service,
         assignment,
     ):
+        pyramid_request.matchdict = {"assignment_id": sentinel.id}
         dashboard_service.get_request_assignment.return_value = assignment
         auto_grading_service.get_in_progress_sync.return_value = None
         pyramid_request.parsed_params["grades"] = [
@@ -29,7 +30,7 @@ class TestDashboardGradingViews:
         views.create_grading_sync()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         auto_grading_service.get_in_progress_sync.assert_called_once_with(
             dashboard_service.get_request_assignment.return_value
@@ -44,12 +45,13 @@ class TestDashboardGradingViews:
         dashboard_service,
         assignment,
     ):
+        pyramid_request.matchdict = {"assignment_id": sentinel.id}
         dashboard_service.get_request_assignment.return_value = assignment
 
         views.create_grading_sync()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         auto_grading_service.get_in_progress_sync.assert_called_once_with(
             dashboard_service.get_request_assignment.return_value
@@ -65,6 +67,7 @@ class TestDashboardGradingViews:
         assignment,
         db_session,
     ):
+        pyramid_request.matchdict = {"assignment_id": sentinel.id}
         pyramid_request.parsed_params["grades"] = [
             {"h_userid": "STUDENT_1", "grade": 0.5},
             {"h_userid": "STUDENT_2", "grade": 1},
@@ -78,7 +81,7 @@ class TestDashboardGradingViews:
         response = views.create_grading_sync()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         auto_grading_service.get_in_progress_sync.assert_called_once_with(
             dashboard_service.get_request_assignment.return_value
@@ -105,11 +108,12 @@ class TestDashboardGradingViews:
         dashboard_service,
         grading_sync,
     ):
+        pyramid_request.matchdict = {"assignment_id": sentinel.id}
         auto_grading_service.get_last_sync.return_value = grading_sync
         response = views.get_grading_sync()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         auto_grading_service.get_last_sync.assert_called_once_with(
             dashboard_service.get_request_assignment.return_value
@@ -132,6 +136,7 @@ class TestDashboardGradingViews:
     def test_get_grading_sync_not_found(
         self, auto_grading_service, views, pyramid_request
     ):
+        pyramid_request.matchdict = {"assignment_id": sentinel.id}
         auto_grading_service.get_last_sync.return_value = None
 
         response = views.get_grading_sync()

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -38,6 +38,7 @@ class TestUserViews:
             course_ids=sentinel.course_ids,
             assignment_ids=sentinel.assignment_ids,
             segment_authority_provided_ids=sentinel.segment_authority_provided_ids,
+            h_userids=None,
         )
         get_page.assert_called_once_with(
             pyramid_request,

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -119,7 +119,7 @@ class TestUserViews:
         response = views.students_metrics()
 
         dashboard_service.get_request_assignment.assert_has_calls(
-            [call(pyramid_request)]
+            [call(pyramid_request, sentinel.id)]
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],
@@ -184,6 +184,7 @@ class TestUserViews:
 
         pyramid_request.parsed_params = {
             "h_userids": sentinel.h_userids,
+            "assignment_id": sentinel.assignment_id,
         }
         assignment = factories.Assignment(course=factories.Course())
         assignment.auto_grading_config = AutoGradingConfig(
@@ -207,7 +208,10 @@ class TestUserViews:
         response = views.students_metrics()
 
         dashboard_service.get_request_assignment.assert_has_calls(
-            [call(pyramid_request), call(pyramid_request)]
+            [
+                call(pyramid_request, sentinel.assignment_id),
+                call(pyramid_request, assignment.id),
+            ]
         )
         h_api.get_annotation_counts.assert_called_once_with(
             [g.authority_provided_id for g in assignment.groupings],
@@ -277,7 +281,9 @@ class TestUserViews:
 
         views._students_query(assignment_ids=None, segment_authority_provided_ids=None)  # noqa: SLF001
 
-        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
+        dashboard_service.get_request_course.assert_called_once_with(
+            pyramid_request, sentinel.course_id
+        )
         user_service.get_users_for_course.assert_called_once_with(
             role_scope=RoleScope.COURSE,
             role_type=RoleType.LEARNER,

--- a/tests/unit/lms/views/dashboard/views_test.py
+++ b/tests/unit/lms/views/dashboard/views_test.py
@@ -48,7 +48,7 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         self.assert_cookie_value(pyramid_request.response)
@@ -63,7 +63,9 @@ class TestDashboardViews:
 
         views.course_show()
 
-        dashboard_service.get_request_course.assert_called_once_with(pyramid_request)
+        dashboard_service.get_request_course.assert_called_once_with(
+            pyramid_request, sentinel.id
+        )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
         self.assert_cookie_value(pyramid_request.response)
 
@@ -91,7 +93,7 @@ class TestDashboardViews:
         views.assignment_show()
 
         dashboard_service.get_request_assignment.assert_called_once_with(
-            pyramid_request
+            pyramid_request, sentinel.id
         )
         pyramid_request.context.js_config.enable_dashboard_mode.assert_called_once()
 


### PR DESCRIPTION
We can use the same helper method in the metrics and the dropdown API views.

This will become more useful once we include the roster concept, allowing to tweak the UserService call only in one place.



### Testing

- Sanity check the dashboard, listing users metrics and users in the drop down while applying different filters.