### PR TITLE
Force user re-authorization for revoked tokens

### DIFF
--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -1,4 +1,8 @@
+import logging
+
 from lms.models.oauth2_token import Service
+
+log = logging.getLogger(__name__)
 
 
 class JWTError(Exception):
@@ -215,7 +219,10 @@ class CanvasAPIError(ExternalRequestError):
 
         error_description = response_json.get("error_description", "")
 
-        if {"message": "Invalid access token."} in errors:
+        if {"message": "Invalid access token."} in errors or {
+            "message": "Revoked access token."
+        } in errors:
+            log.info("Canvas token error, forcing re-authorization. %s", errors)
             raise OAuth2TokenError(refreshable=True, **kwargs) from cause
 
         if error_description == "refresh_token not found":

--- a/tests/unit/lms/services/exceptions_test.py
+++ b/tests/unit/lms/services/exceptions_test.py
@@ -186,6 +186,12 @@ class TestCanvasAPIError:
                 json.dumps({"errors": [{"message": "Invalid access token."}]}),
                 OAuth2TokenError,
             ),
+            # A 401 Unauthorized response from Canvas, revoked token
+            (
+                401,
+                json.dumps({"errors": [{"message": "Revoked access token."}]}),
+                OAuth2TokenError,
+            ),
             # A 401 Unauthorized response from Canvas, because our access token had
             # insufficient scopes;
             (


### PR DESCRIPTION
It's not entirely clear if this is caused by a new condition, the access is revoked or the error message that canvas emits has change it's wording.

Logging this situation with the error message to keep track of how often we see them in the logs.


### Testing

#### In `main` 

- Delete the token in canvas:

for `Working localhost (make devdata) API Key with All Required Scopes` 

in

https://hypothesis.instructure.com/profile/settings


- Launch https://hypothesis.instructure.com/courses/125/assignments/873
- You'll get an error

#### In this branch, `canvas-revoke`


- Launch again, you'll get a reauthorization prompt and will be able to launch after.

