### PR TITLE
Use assignment roster data when available and the FF is enabled

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -57,7 +57,7 @@ class ApplicationSettings(JSONSettings):
         JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
         JSONSetting("hypothesis", "auto_grading_enabled", asbool),
         JSONSetting("hypothesis", "auto_grading_sync_enabled", asbool),
-        JSONSetting("hypothesis", "dashboard_rosters", asbool),
+        JSONSetting("dashboard", "rosters", asbool),
         JSONSetting("dashboard", "assignment_segments_filter_enabled", asbool),
     )
 

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -190,7 +190,10 @@ class DashboardService:
         ):
             # If rostering is enabled and we do have the data, use it
             query = self._roster_service.get_assignment_roster(
-                assignment, h_userids=h_userids
+                assignment,
+                role_scope=RoleScope.COURSE,
+                role_type=RoleType.LEARNER,
+                h_userids=h_userids,
             )
 
         else:

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -182,7 +182,7 @@ class DashboardService:
         rosters_enabled = (
             assignment.course
             and assignment.course.application_instance.settings.get(
-                "hypothesis", "dashboard_rosters"
+                "dashboard", "rosters"
             )
         )
         if rosters_enabled and self._roster_service.assignment_roster_exists(

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -169,7 +169,7 @@ class UserService:
         if h_userids:
             query = query.where(LMSUser.h_userid.in_(h_userids))
 
-        return query.order_by(LMSUser.display_name, LMSUser.id)
+        return query
 
     def get_users_for_course(
         self,

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -120,7 +120,7 @@
                         <fieldset class="box">
                             <legend class="label has-text-centered">Dashboard settings</legend>
                             {{ settings_checkbox("Enable segments filter in assignment view", "dashboard", "assignment_segments_filter_enabled", default=False) }}
-                            {{ settings_checkbox("Enable roster data", "hypothesis", "dashboard_rosters", default=False) }}
+                            {{ settings_checkbox("Enable roster data", "dashboard", "rosters", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/templates/admin/assignment/show.html.jinja2
+++ b/lms/templates/admin/assignment/show.html.jinja2
@@ -19,14 +19,5 @@
       <legend class="label has-text-centered">Course</legend>
       {{ macros.course_preview(request, assignment.course) }}
     </fieldset>
-
-    <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Roster</legend>
-        {% if roster %}
-            {{ macros.roster_table(request, roster) }}
-        {% else %}
-            <legend class="label has-text-centered">No roster information</legend>
-        {% endif %}
-    </fieldset>
 </div>
 {% endblock %}

--- a/lms/templates/admin/course/show.html.jinja2
+++ b/lms/templates/admin/course/show.html.jinja2
@@ -32,16 +32,7 @@
         {% else %}
             <legend class="label has-text-centered">No assignments</legend>
         {% endif %}
-    </fieldset>
 
-    <fieldset class="box mt-6">
-        <legend class="label has-text-centered">Roster</legend>
-        {% if roster %}
-            {{ macros.roster_table(request, roster) }}
-        {% else %}
-            <legend class="label has-text-centered">No roster information</legend>
-        {% endif %}
     </fieldset>
-
 </div>
 {% endblock %}

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -108,20 +108,16 @@
             <table class="table is-fullwidth">
                 <thead>
                     <tr>
-                        {% if route %}
                         <th></th>
-                        {% endif %}
                         {% for field in fields %}<th>{{ field.label }}</th>{% endfor %}
                     </tr>
                 </thead>
                 <tbody>
                     {% for object in objects %}
                         <tr>
-                            {% if route %}
                             <td>
                                 <a class="button" href="{{ request.route_url(route, id_=object.id) }}">View</a>
                             </td>
-                            {% endif %}
                             {% for field in fields %}<td>{{ auto_format(object[field.name], html=html) }}</td>{% endfor %}
                         </tr>
                     {% endfor %}
@@ -282,12 +278,3 @@
         {"label": "Context ID", "name": "lms_id"},
     ]) }}
 {% endmacro %}
-{% macro roster_table(request, roster_users) %}
-    {{ object_list_table(request, None, roster_users,
-        fields=[
-        {"label": "Name", "name": "display_name"},
-        {"label": "H Userid", "name": "h_userid"},
-        {"label": "LTI user id", "name": "lti_user_id"},
-    ]) }}
-{% endmacro %}
-

--- a/lms/views/admin/assignment.py
+++ b/lms/views/admin/assignment.py
@@ -6,14 +6,12 @@ from pyramid.view import view_config, view_defaults
 from lms.events import AuditTrailEvent, ModelChange
 from lms.models import Assignment, EventType
 from lms.security import Permissions
-from lms.services import RosterService
 
 
 @view_defaults(request_method="GET", permission=Permissions.ADMIN)
 class AdminAssignmentViews:
     def __init__(self, request) -> None:
         self.request = request
-        self.roster_service: RosterService = request.find_service(RosterService)
         self.assignment_service = request.find_service(name="assignment")
 
     @view_config(
@@ -24,8 +22,9 @@ class AdminAssignmentViews:
     )
     def show(self):
         assignment = self._get_or_404()
-        roster = self.roster_service.get_assignment_roster(assignment)
-        return {"assignment": assignment, "roster": roster}
+        return {
+            "assignment": assignment,
+        }
 
     @view_config(
         route_name="admin.assignment.dashboard",

--- a/lms/views/admin/course.py
+++ b/lms/views/admin/course.py
@@ -8,7 +8,7 @@ from webargs import fields
 from lms.events import AuditTrailEvent, ModelChange
 from lms.models import Course, EventType
 from lms.security import Permissions
-from lms.services import InvalidPublicId, OrganizationService, RosterService
+from lms.services import InvalidPublicId, OrganizationService
 from lms.validation._base import PyramidRequestSchema
 from lms.views.admin import flash_validation
 from lms.views.admin._schemas import EmptyStringInt
@@ -33,7 +33,6 @@ class AdminCourseViews:
         self.organization_service: OrganizationService = request.find_service(
             OrganizationService
         )
-        self.roster_service: RosterService = request.find_service(RosterService)
 
     @view_config(
         route_name="admin.courses",
@@ -53,9 +52,8 @@ class AdminCourseViews:
     def show(self):
         course_id = self.request.matchdict["id_"]
         course = self._get_course_or_404(course_id)
-        roster = self.roster_service.get_course_roster(course.lms_course)
 
-        return {"course": course, "roster": roster}
+        return {"course": course}
 
     @view_config(
         route_name="admin.courses.dashboard",

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -216,12 +216,8 @@ class UserViews:
             assignment = self.dashboard_service.get_request_assignment(
                 self.request, assignment_ids[0]
             )
-
-            return self.user_service.get_users_for_assignment(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
-                assignment_id=assignment.id,
-                h_userids=h_userids,
+            return self.dashboard_service.get_assignment_roster(
+                assignment=assignment, h_userids=h_userids
             )
 
         # Single course fetch

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -240,7 +240,7 @@ class TestDashboardService:
     def test_get_assignment_roster_with(
         self, svc, application_instance, roster_service
     ):
-        application_instance.settings.set("hypothesis", "dashboard_rosters", True)
+        application_instance.settings.set("dashboard", "rosters", True)
         assignment = factories.Assignment(
             course=factories.Course(application_instance=application_instance)
         )

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -248,7 +248,10 @@ class TestDashboardService:
         roster = svc.get_assignment_roster(assignment, sentinel.h_userids)
 
         roster_service.get_assignment_roster.assert_called_once_with(
-            assignment, h_userids=sentinel.h_userids
+            assignment,
+            role_scope=RoleScope.COURSE,
+            role_type=RoleType.LEARNER,
+            h_userids=sentinel.h_userids,
         )
         assert (
             roster

--- a/tests/unit/lms/views/admin/assignment_test.py
+++ b/tests/unit/lms/views/admin/assignment_test.py
@@ -9,21 +9,16 @@ from lms.views.admin.assignment import AdminAssignmentViews
 from tests import factories
 
 
-@pytest.mark.usefixtures("roster_service")
 class TestAdminAssignmentViews:
-    def test_show(self, pyramid_request, assignment_service, views, roster_service):
+    def test_show(self, pyramid_request, assignment_service, views):
         pyramid_request.matchdict["id_"] = sentinel.id
 
         response = views.show()
 
         assignment_service.get_by_id.assert_called_once_with(id_=sentinel.id)
-        roster_service.get_assignment_roster.assert_called_once_with(
-            assignment_service.get_by_id.return_value
-        )
 
         assert response == {
             "assignment": assignment_service.get_by_id.return_value,
-            "roster": roster_service.get_assignment_roster.return_value,
         }
 
     def test_show_not_found(self, pyramid_request, assignment_service, views):

--- a/tests/unit/lms/views/admin/course_test.py
+++ b/tests/unit/lms/views/admin/course_test.py
@@ -10,21 +10,17 @@ from lms.views.admin.course import AdminCourseViews
 from tests import factories
 
 
-@pytest.mark.usefixtures("course_service", "organization_service", "roster_service")
+@pytest.mark.usefixtures("course_service", "organization_service")
 class TestAdminCourseViews:
-    def test_show(self, pyramid_request, course_service, views, roster_service):
+    def test_show(self, pyramid_request, course_service, views):
         pyramid_request.matchdict["id_"] = sentinel.id_
 
         response = views.show()
 
         course_service.get_by_id.assert_called_once_with(id_=sentinel.id_)
-        roster_service.get_course_roster.assert_called_once_with(
-            course_service.get_by_id.return_value.lms_course
-        )
 
         assert response == {
             "course": course_service.get_by_id.return_value,
-            "roster": roster_service.get_course_roster.return_value,
         }
 
     def test_show_not_found(self, pyramid_request, course_service, views):

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -102,7 +102,7 @@ class TestUserViews:
             )
         else:
             db_session.flush()
-            user_service.get_users_for_assignment.return_value = select(User).where(
+            dashboard_service.get_assignment_roster.return_value = select(User).where(
                 User.id.in_(
                     [
                         u.id
@@ -168,7 +168,6 @@ class TestUserViews:
         self,
         views,
         pyramid_request,
-        user_service,
         h_api,
         student,
         dashboard_service,
@@ -197,7 +196,7 @@ class TestUserViews:
             auto_grading_service.get_last_grades.return_value = {}
 
         db_session.flush()
-        user_service.get_users_for_assignment.return_value = select(User).where(
+        dashboard_service.get_assignment_roster.return_value = select(User).where(
             User.id.in_(
                 [u.id for u in [student, student_no_annos, student_no_annos_no_name]]
             )


### PR DESCRIPTION
Use assignment roster data when available and the FF is enabled.

Fallback to the "launch based" roster otherwise

## Testing


We have three main cases.

- We have the feature flag enabled and we have the roster data
- We have the feature flag enabled and we don't have the roster data
- We have the feature flag disabled


#### Get the assignment roster for one assignment

Launch 

https://hypothesis.instructure.com/courses/319/assignments/3336


in `make shell`


```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```


##### Enable the FF for the LTI1.3 AI:

(dashboard section, enable roster data)

http://localhost:8001/admin/instances/102/settings



#### Open the dashboard for that assignment from

https://hypothesis.instructure.com/courses/319/assignments/3336


- You'll see a bunch of students in the list and dropdown.
- You can filter by user using the drop down.


### Disable the FF

http://localhost:8001/admin/instances/102/settings


- Refresh the dashboard, you'll see less students (if any) only the ones that have launched.



#### Remove the roster data.

- Enable the FF again, http://localhost:8001/admin/instances/102/settings
- Make sure the roster students appear on the dashboard refreshing it.
- Truncate assignment_roster in `make sql`:


```
truncate assignment_roster ;
TRUNCATE TABLE
```

- Refresh the assignment again, you'll see only the launch data again.



