### PR TITLE
Expose assignment.is_gradable in the dashboard API

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -96,6 +96,8 @@ class APIAssignment(TypedDict):
     id: int
     title: str
     created: str
+    is_gradable: bool
+
     course: NotRequired[APICourse]
 
     sections: NotRequired[list[APISegment]]

--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -86,6 +86,7 @@ class AssignmentViews:
                     id=assignment.id,
                     title=assignment.title,
                     created=assignment.created,
+                    is_gradable=assignment.is_gradable,
                 )
                 for assignment in assignments
             ],
@@ -106,6 +107,7 @@ class AssignmentViews:
             id=assignment.id,
             title=assignment.title,
             created=assignment.created,
+            is_gradable=assignment.is_gradable,
             course=APICourse(
                 id=assignment.course.id,
                 title=assignment.course.lms_name,
@@ -189,6 +191,7 @@ class AssignmentViews:
                 APIAssignment(
                     id=assignment.id,
                     title=assignment.title,
+                    is_gradable=assignment.is_gradable,
                     created=assignment.created,
                     course=api_course,
                     annotation_metrics=metrics,

--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -40,7 +40,12 @@ class TestAssignmentViews:
         )
         assert response == {
             "assignments": [
-                {"id": a.id, "title": a.title, "created": a.created}
+                {
+                    "id": a.id,
+                    "title": a.title,
+                    "is_gradable": a.is_gradable,
+                    "created": a.created,
+                }
                 for a in assignments
             ],
             "pagination": sentinel.pagination,
@@ -70,6 +75,7 @@ class TestAssignmentViews:
         assert response == {
             "id": assignment.id,
             "title": assignment.title,
+            "is_gradable": assignment.is_gradable,
             "created": assignment.created,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
         }
@@ -98,6 +104,7 @@ class TestAssignmentViews:
             "id": assignment.id,
             "title": assignment.title,
             "created": assignment.created,
+            "is_gradable": assignment.is_gradable,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "groups": [],
             "auto_grading_config": {
@@ -127,6 +134,7 @@ class TestAssignmentViews:
             "id": assignment.id,
             "title": assignment.title,
             "created": assignment.created,
+            "is_gradable": assignment.is_gradable,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "groups": [
                 {"h_authority_provided_id": g.authority_provided_id, "name": g.lms_name}
@@ -154,6 +162,7 @@ class TestAssignmentViews:
             "id": assignment.id,
             "title": assignment.title,
             "created": assignment.created,
+            "is_gradable": assignment.is_gradable,
             "course": {"id": assignment.course.id, "title": assignment.course.lms_name},
             "sections": [
                 {"h_authority_provided_id": g.authority_provided_id, "name": g.lms_name}
@@ -211,6 +220,7 @@ class TestAssignmentViews:
                 {
                     "id": assignment.id,
                     "title": assignment.title,
+                    "is_gradable": assignment.is_gradable,
                     "created": assignment.created,
                     "course": {
                         "id": course.id,
@@ -225,6 +235,7 @@ class TestAssignmentViews:
                 {
                     "id": assignment_with_no_annos.id,
                     "title": assignment_with_no_annos.title,
+                    "is_gradable": assignment.is_gradable,
                     "created": assignment_with_no_annos.created,
                     "course": {
                         "id": course.id,


### PR DESCRIPTION
This is a potential fix for:

- https://github.com/hypothesis/product-backlog/issues/1608


This will allow  the FE to base the decision to show the "sync grades" button both on the feature flag (part of the JSConfig dictionary) and the current assignment's `is_gradable` value.

@acelaya Can you double check if this approach makes sense? I reckon we need both the FF in JSConfig and this new value. If the FF is enabled we'd still shouldn't show the button to sync grades for non-gradable assignments.


Also see:

- https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1732217246293399 



### Testing 

- Check the new values is present on the JSON response and that that doesn't cause any issues

https://hypothesis.instructure.com/courses/319/assignments/3308