### PR TITLE
Increase the number of roster fetched in each task execution

### DIFF
--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -22,7 +22,7 @@ LAUNCHED_WINDOW = timedelta(hours=24)
 ROSTER_REFRESH_WINDOW = timedelta(hours=24 * 7)
 """How frequenly should we fetch roster for the same course/assignment"""
 
-ROSTER_LIMIT = 5
+ROSTER_LIMIT = 50
 """How many roster should we fetch per executing of the schedule task."""
 
 


### PR DESCRIPTION
Now that we are starting to actually use the roster data fetch them more aggressively.

The task that fetches roster is currently scheduled to run every 15 minutes, change the number of rosters fetched from 5 to 50.