### PR TITLE
Hide `SyncGradesButton` for auto-grading non-gradable assignments

### DIFF
--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -187,6 +187,7 @@ export type Assignment = {
   title: string;
   /** Date in which the assignment was created, in ISO format */
   created: ISODateTime;
+  is_gradable: boolean;
 };
 
 export type Student = {

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -95,6 +95,7 @@ export default function AssignmentActivity() {
     replaceURLParams(routes.assignment, { assignment_id: assignmentId }),
   );
   const isAutoGradingAssignment = !!assignment.data?.auto_grading_config;
+  const isGradable = !!assignment.data?.is_gradable;
   const segments = useMemo((): DashboardActivityFiltersProps['segments'] => {
     const { data } = assignment;
     if (
@@ -161,12 +162,17 @@ export default function AssignmentActivity() {
 
   const syncURL = useMemo(
     () =>
-      isAutoGradingAssignment
+      isAutoGradingAssignment && isGradable
         ? replaceURLParams(routes.assignment_grades_sync, {
             assignment_id: assignmentId,
           })
         : null,
-    [assignmentId, isAutoGradingAssignment, routes.assignment_grades_sync],
+    [
+      assignmentId,
+      isAutoGradingAssignment,
+      isGradable,
+      routes.assignment_grades_sync,
+    ],
   );
   const [lastSyncParams, setLastSyncParams] = useState<QueryParams>({});
   const lastSync = usePolledAPIFetch<GradingSync>({
@@ -345,7 +351,7 @@ export default function AssignmentActivity() {
             }
           />
         )}
-        {isAutoGradingAssignment && auto_grading_sync_enabled && (
+        {isAutoGradingAssignment && auto_grading_sync_enabled && isGradable && (
           <SyncGradesButton
             studentsToSync={studentsToSync}
             lastSync={lastSync}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -56,6 +56,7 @@ describe('AssignmentActivity', () => {
       id: 12,
       title: 'The course',
     },
+    is_gradable: true,
   };
 
   let fakeUseAPIFetch;
@@ -497,34 +498,58 @@ describe('AssignmentActivity', () => {
       {
         syncEnabled: true,
         isAutoGradingAssignment: true,
-        shouldShowButton: true,
+        isGradable: true,
       },
       {
         syncEnabled: false,
         isAutoGradingAssignment: true,
-        shouldShowButton: false,
+        isGradable: true,
       },
       {
         syncEnabled: true,
         isAutoGradingAssignment: false,
-        shouldShowButton: false,
+        isGradable: true,
       },
       {
         syncEnabled: false,
         isAutoGradingAssignment: false,
-        shouldShowButton: false,
+        isGradable: true,
       },
-    ].forEach(({ isAutoGradingAssignment, syncEnabled, shouldShowButton }) => {
-      it('shows sync button when both sync and auto-grading are enabled', () => {
+      {
+        syncEnabled: false,
+        isAutoGradingAssignment: true,
+        isGradable: false,
+      },
+      {
+        syncEnabled: false,
+        isAutoGradingAssignment: false,
+        isGradable: true,
+      },
+      {
+        syncEnabled: true,
+        isAutoGradingAssignment: false,
+        isGradable: false,
+      },
+      {
+        syncEnabled: false,
+        isAutoGradingAssignment: false,
+        isGradable: false,
+      },
+    ].forEach(({ isAutoGradingAssignment, syncEnabled, isGradable }) => {
+      it('shows sync button when sync and auto-grading are enabled, and the assignment is gradable', () => {
         setUpFakeUseAPIFetch({
           ...activeAssignment,
+          is_gradable: isGradable,
           auto_grading_config: isAutoGradingAssignment ? {} : null,
         });
         fakeConfig.dashboard.auto_grading_sync_enabled = syncEnabled;
 
         const wrapper = createComponent();
 
-        assert.equal(wrapper.exists('SyncGradesButton'), shouldShowButton);
+        assert.equal(
+          wrapper.exists('SyncGradesButton'),
+          isAutoGradingAssignment && syncEnabled && isGradable,
+        );
       });
     });
 


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lms/pull/6867

Make sure the `SyncGradesButton` is not displayed for auto-grading assignments if they are not gradable.

We still display calculated grades in the dashboard, but we don't allow syncing, as that would fail if the BE indicates the assignment is not gradable.

> [!IMPORTANT]  
> The second commit in this PR is only meant to [fix an unrelated test](https://github.com/hypothesis/lms/actions/runs/12008780157/job/33472140156?pr=6869) which started to fail now.
> 
> I could not find the exact root cause, but I was able to tell it was related with the fact that multiple tests are using and modifying the global `history` object, and it seems to not be properly reset.

### Testing steps

Creating an auto-grading assignment which is not gradable is not easy. The simplest way to test this is faking this by applying this diff.

```diff
diff --git a/lms/views/dashboard/api/assignment.py b/lms/views/dashboard/api/assignment.py
index 32e3e3f65..1cc9a0bc2 100644
--- a/lms/views/dashboard/api/assignment.py
+++ b/lms/views/dashboard/api/assignment.py
@@ -107,7 +107,7 @@ class AssignmentViews:
             id=assignment.id,
             title=assignment.title,
             created=assignment.created,
-            is_gradable=assignment.is_gradable,
+            is_gradable=False,
             course=APICourse(
                 id=assignment.course.id,
                 title=assignment.course.lms_name,
```

Then go to https://hypothesis.instructure.com/courses/319/assignments/7296, and open the dashboard.

You should see the autograding info, like the calculated grade, but the sync button should not be visible.