### PR TITLE
Fix query to find assignment rosters that need fetching

### DIFF
--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -114,9 +114,8 @@ def schedule_fetching_assignment_rosters() -> None:
 
     # Only fetch rosters for assignments that have been recently launched
     recent_launches_clause = exists(
-        select(Event)
-        .join(Assignment, Event.assignment_id == Assignment.id)
-        .where(
+        select(Event).where(
+            Event.assignment_id == Assignment.id,
             Event.timestamp >= now - LAUNCHED_WINDOW,
         )
     )

--- a/tests/unit/lms/tasks/roster_test.py
+++ b/tests/unit/lms/tasks/roster_test.py
@@ -42,6 +42,7 @@ class TestRosterTasks:
     @freeze_time("2024-08-28")
     @pytest.mark.usefixtures(
         "lms_course_with_no_launch",
+        "lms_course_with_no_recent_launch",
         "lms_course_with_no_service_url",
         "lms_course_with_launch_and_recent_roster",
         "lms_course_with_recent_launch_and_task_done_row",
@@ -60,6 +61,7 @@ class TestRosterTasks:
     @freeze_time("2024-08-28")
     @pytest.mark.usefixtures(
         "assignment_with_no_launch",
+        "assignment_with_no_recent_launch",
         "assignment_with_no_lti_v13_id",
         "assignment_with_recent_launch_and_task_done_row",
         "assignment_with_launch_and_recent_roster",
@@ -94,11 +96,36 @@ class TestRosterTasks:
         )
 
     @pytest.fixture
+    def assignment_with_no_recent_launch(self, lms_course_with_recent_launch):
+        assignment = factories.Assignment(
+            lti_v13_resource_link_id="ID", course=lms_course_with_recent_launch.course
+        )
+        factories.Event(
+            assignment=assignment,
+            timestamp=datetime(2024, 1, 1),
+        )
+        return assignment
+
+    @pytest.fixture
     def lms_course_with_recent_launch(self):
         course = factories.Course()
         factories.Event(
             course=course,
             timestamp=datetime(2024, 8, 28),
+        )
+
+        return factories.LMSCourse(
+            lti_context_memberships_url="URL",
+            h_authority_provided_id=course.authority_provided_id,
+            course=course,
+        )
+
+    @pytest.fixture
+    def lms_course_with_no_recent_launch(self):
+        course = factories.Course()
+        factories.Event(
+            course=course,
+            timestamp=datetime(2024, 1, 1),
         )
 
         return factories.LMSCourse(


### PR DESCRIPTION
The existing query used a subquery that joined itself on assignments. That meant that that condition will return true if any event can be joined with an assignments, that's always true.

Avoid the join and use the parent query Assignment, making the subquery a correlated one to get the correct result.

This changes the SQL of this condition from something like:


`AND (EXISTS (SELECT event.id, event.timestamp, event.type_id, event.application_instance_id, event.course_id, event.assignment_id, event.grouping_id FROM event JOIN assignment ON event.assignment_id = assignment.id WHERE event.timestamp >= now() - '1 day '::interval))`

(with JOIN)

to

`
AND (EXISTS (SELECT event.id, event.timestamp, event.type_id, event.application_instance_id, event.course_id, event.assignment_id, event.grouping_id FROM event  WHERE event.timestamp >= now() - '1 day '::interval and assignment_id = assignment.id))
`

with a condition on the WHERE

The effect of the bug is that we'd be getting rosters for assignments that don't have recent launches. As we sort the results by assignment.created we'd still are getting the most recently created assignments.



