### PR TITLE
Expose roster information on the user metrics endpoint

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -113,6 +113,19 @@ class APIAssignments(TypedDict):
     pagination: NotRequired[Pagination]
 
 
+class RosterEntry(APIStudent):
+    active: bool
+    "Whether or not this student is active in the course/assignment or roster."
+
+
+class APIRoster(TypedDict):
+    students: list[RosterEntry]
+
+    last_updated: datetime | None
+    """When was this roster last updated.
+    None indicates we don't have roster data, we rely on launches to determine the list of students."""
+
+
 class APIStudents(TypedDict):
     students: list[APIStudent]
 

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -194,6 +194,9 @@ export type Student = {
   h_userid: string;
   lms_id: string;
   display_name: string | null;
+
+  /** Whether this student is active in the course/assignment or roster */
+  active: boolean;
 };
 
 export type AutoGradingGrade = {

--- a/lms/static/scripts/frontend_apps/api-types.ts
+++ b/lms/static/scripts/frontend_apps/api-types.ts
@@ -218,6 +218,14 @@ export type StudentWithMetrics = Student & {
  */
 export type StudentsMetricsResponse = {
   students: StudentWithMetrics[];
+
+  /**
+   * Indicates the last time the students roster was updated.
+   *
+   * `null` indicates we don't have roster data and the list is based on
+   * assignment launches.
+   */
+  last_updated: ISODateTime | null;
 };
 
 type AssignmentWithCourse = Assignment & {

--- a/lms/static/scripts/frontend_apps/components/RelativeTime.tsx
+++ b/lms/static/scripts/frontend_apps/components/RelativeTime.tsx
@@ -8,17 +8,29 @@ import { useEffect, useMemo, useState } from 'preact/hooks';
 export type RelativeTimeProps = {
   /** The reference date-time, in ISO format */
   dateTime: string;
+
+  /**
+   * Whether a `title` attribute with the absolute date should be added.
+   * Defaults to `true`.
+   */
+  withTitle?: boolean;
 };
 
 /**
  * Displays a date as a time relative to `now`, making sure it is updated at
  * appropriate intervals
  */
-export default function RelativeTime({ dateTime }: RelativeTimeProps) {
+export default function RelativeTime({
+  dateTime,
+  withTitle = true,
+}: RelativeTimeProps) {
   const [now, setNow] = useState(() => new Date());
   const absoluteDate = useMemo(
-    () => formatDateTime(dateTime, { includeWeekday: true }),
-    [dateTime],
+    () =>
+      withTitle
+        ? formatDateTime(dateTime, { includeWeekday: true })
+        : undefined,
+    [dateTime, withTitle],
   );
   const relativeDate = useMemo(
     () => formatRelativeDate(new Date(dateTime), now),

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -1,4 +1,10 @@
-import { ClockIcon } from '@hypothesis/frontend-shared';
+import {
+  CautionIcon,
+  ClockIcon,
+  FileGenericIcon,
+  InfoIcon,
+  Link,
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useMemo, useState } from 'preact/hooks';
 import { useLocation, useParams, useSearch } from 'wouter-preact';
@@ -17,7 +23,6 @@ import { courseURL } from '../../utils/dashboard/navigation';
 import { rootViewTitle } from '../../utils/dashboard/root-view-title';
 import { useDocumentTitle } from '../../utils/hooks';
 import { type QueryParams, replaceURLParams } from '../../utils/url';
-import RelativeTime from '../RelativeTime';
 import type {
   DashboardActivityFiltersProps,
   SegmentsType,
@@ -26,6 +31,7 @@ import DashboardActivityFilters from './DashboardActivityFilters';
 import DashboardBreadcrumbs from './DashboardBreadcrumbs';
 import FormattedDate from './FormattedDate';
 import GradeIndicator from './GradeIndicator';
+import LastSyncIndicator from './LastSyncIndicator';
 import type { OrderableActivityTableColumn } from './OrderableActivityTable';
 import OrderableActivityTable from './OrderableActivityTable';
 import StudentStatusBadge from './StudentStatusBadge';
@@ -203,6 +209,7 @@ export default function AssignmentActivity() {
                 },
               },
       ),
+      last_updated: students.data?.last_updated ?? null,
     });
   }, [students]);
 
@@ -275,20 +282,26 @@ export default function AssignmentActivity() {
                 },
               ]}
             />
-            {lastSync.data && (
-              <div
-                className="flex gap-x-1 items-center text-color-text-light"
-                data-testid="last-sync-date"
-              >
-                <ClockIcon />
-                Grades last synced:{' '}
-                {lastSync.data.finish_date ? (
-                  <RelativeTime dateTime={lastSync.data.finish_date} />
-                ) : (
-                  'syncing…'
-                )}
-              </div>
-            )}
+            <div className="flex gap-0.5">
+              {lastSync.data && (
+                <LastSyncIndicator
+                  icon={
+                    lastSync.data.status === 'failed' ? CautionIcon : ClockIcon
+                  }
+                  taskName="Grades"
+                  dateTime={lastSync.data.finish_date}
+                  data-testid="last-sync-date"
+                />
+              )}
+              {students.data?.last_updated && (
+                <LastSyncIndicator
+                  icon={FileGenericIcon}
+                  taskName="Roster"
+                  dateTime={students.data.last_updated}
+                  data-testid="last-roster-date"
+                />
+              )}
+            </div>
           </div>
         )}
         <div className="flex justify-between items-center">
@@ -415,6 +428,19 @@ export default function AssignmentActivity() {
           }
         }}
       />
+      {!students.isLoading && !students.data?.last_updated && (
+        <Link
+          variant="text-light"
+          classes="flex items-center gap-1"
+          href="https://web.hypothes.is/help/student-roster-displays-in-the-lms-reporting-dashboards/"
+          target="_blank"
+          data-testid="missing-roster-message"
+        >
+          <InfoIcon />
+          Full roster data for this assignment is not available. This only shows
+          students who have previously launched it.
+        </Link>
+      )}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -28,6 +28,7 @@ import FormattedDate from './FormattedDate';
 import GradeIndicator from './GradeIndicator';
 import type { OrderableActivityTableColumn } from './OrderableActivityTable';
 import OrderableActivityTable from './OrderableActivityTable';
+import StudentStatusBadge from './StudentStatusBadge';
 import SyncGradesButton from './SyncGradesButton';
 
 type StudentsTableRow = {
@@ -47,6 +48,9 @@ type StudentsTableRow = {
    * If the assignment is not auto-grading, this will be ´undefined`.
    */
   last_grade?: number | null;
+
+  /** Whether this student is active in the course/assignment or roster */
+  active: boolean;
 };
 
 /**
@@ -135,7 +139,8 @@ export default function AssignmentActivity() {
 
     return students.data.students
       .filter(
-        ({ auto_grading_grade }) =>
+        ({ auto_grading_grade, active }) =>
+          active &&
           !!auto_grading_grade &&
           auto_grading_grade.current_grade !== auto_grading_grade.last_grade,
       )
@@ -366,15 +371,25 @@ export default function AssignmentActivity() {
               );
             case 'display_name':
               return (
-                stats.display_name ?? (
-                  <span className="flex flex-col gap-1.5">
-                    <span className="italic">Unknown</span>
-                    <span className="text-xs text-grey-7">
-                      This student launched the assignment but didn{"'"}t
-                      annotate yet
+                <div className="flex items-center justify-between gap-x-2">
+                  {stats.display_name ?? (
+                    <span className="flex flex-col gap-1.5">
+                      <span className="italic">Unknown</span>
+                      <span className="text-xs text-grey-7">
+                        This student launched the assignment but didn{"'"}t
+                        annotate yet
+                      </span>
                     </span>
-                  </span>
-                )
+                  )}
+                  {!stats.active && (
+                    <div
+                      className="-my-0.5"
+                      title="This student is no longer in this assignment"
+                    >
+                      <StudentStatusBadge type="drop" />
+                    </div>
+                  )}
+                </div>
               );
             case 'current_grade':
               return (

--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
@@ -12,6 +12,8 @@ import type {
   StudentGradingSyncStatus,
 } from '../../api-types';
 import GradeStatusChip from './GradeStatusChip';
+import type { StudentStatusType } from './StudentStatusBadge';
+import StudentStatusBadge from './StudentStatusBadge';
 
 type AnnotationCountProps = {
   children: ComponentChildren;
@@ -57,27 +59,6 @@ function SectionTitle({ children }: { children: ComponentChildren }) {
   );
 }
 
-type BadgeType = 'new' | 'error' | 'syncing';
-
-function Badge({ type }: { type: BadgeType }) {
-  return (
-    <div
-      className={classnames(
-        'px-1 py-0.5 rounded cursor-auto font-bold uppercase text-[0.65rem]',
-        {
-          'bg-grey-7 text-white': type === 'new',
-          'bg-grade-error-light text-grade-error': type === 'error',
-          'bg-grey-2 text-grey-7': type === 'syncing',
-        },
-      )}
-    >
-      {type === 'new' && 'New'}
-      {type === 'error' && 'Error'}
-      {type === 'syncing' && 'Syncing'}
-    </div>
-  );
-}
-
 export type GradeIndicatorProps = {
   grade: number;
   lastGrade?: number | null;
@@ -114,7 +95,7 @@ export default function GradeIndicator({
   // Checking typeof lastGrade to avoid number zero to be treated as false
   const hasLastGrade = typeof lastGrade === 'number';
   const gradeHasChanged = lastGrade !== grade;
-  const badgeType = ((): BadgeType | undefined => {
+  const badgeType = ((): StudentStatusType | undefined => {
     if (status === 'in_progress') {
       return 'syncing';
     }
@@ -142,7 +123,7 @@ export default function GradeIndicator({
         >
           <GradeStatusChip grade={grade} />
         </button>
-        {badgeType && <Badge type={badgeType} />}
+        {badgeType && <StudentStatusBadge type={badgeType} />}
       </div>
       <div aria-live="polite" aria-relevant="additions">
         {popoverVisible && (

--- a/lms/static/scripts/frontend_apps/components/dashboard/LastSyncIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/LastSyncIndicator.tsx
@@ -1,0 +1,48 @@
+import type { IconComponent } from '@hypothesis/frontend-shared';
+import { formatDateTime } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { useMemo } from 'preact/hooks';
+
+import type { ISODateTime } from '../../api-types';
+import RelativeTime from '../RelativeTime';
+
+export type LastSyncIndicatorProps = {
+  icon: IconComponent;
+  taskName: string;
+  dateTime: ISODateTime | null;
+};
+
+/**
+ * Represents the last time a task that syncs periodically happened
+ */
+export default function LastSyncIndicator({
+  icon: Icon,
+  taskName,
+  dateTime,
+}: LastSyncIndicatorProps) {
+  const absoluteDate = useMemo(
+    () =>
+      dateTime ? formatDateTime(dateTime, { includeWeekday: true }) : undefined,
+    [dateTime],
+  );
+
+  return (
+    <div
+      className={classnames(
+        'flex gap-x-1 items-center p-1.5',
+        'bg-grey-2 text-color-text-light cursor-default',
+        'first:rounded-l last:rounded-r',
+      )}
+      title={absoluteDate && `${taskName} last synced on ${absoluteDate}`}
+      data-testid="container"
+    >
+      <Icon />
+      <span className="font-bold">{taskName}:</span>
+      {dateTime ? (
+        <RelativeTime dateTime={dateTime} withTitle={false} />
+      ) : (
+        <span data-testid="syncing">syncing…</span>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentStatusBadge.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentStatusBadge.tsx
@@ -1,0 +1,39 @@
+import classnames from 'classnames';
+
+/**
+ * Grade syncing:
+ *  - `new`: A new grade exists that has not been synced.
+ *  - `error`: Last attempt on syncing a grade failed.
+ *  - `syncing`: Syncing grades is in progress for a particular student.
+ * Assignment participation:
+ *  - `drop`: The student dropped the assignment.
+ */
+export type StudentStatusType = 'new' | 'error' | 'syncing' | 'drop';
+
+/**
+ * Badge displaying different student-related statuses around assignment
+ * participation or grade syncing
+ */
+export default function StudentStatusBadge({
+  type,
+}: {
+  type: StudentStatusType;
+}) {
+  return (
+    <div
+      className={classnames(
+        'px-1 py-0.5 rounded cursor-auto font-bold uppercase text-[0.65rem]',
+        {
+          'bg-grey-7 text-white': type === 'new' || type === 'drop',
+          'bg-grade-error-light text-grade-error': type === 'error',
+          'bg-grey-2 text-grey-7': type === 'syncing',
+        },
+      )}
+    >
+      {type === 'new' && 'New'}
+      {type === 'error' && 'Error'}
+      {type === 'syncing' && 'Syncing'}
+      {type === 'drop' && 'Drop'}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -23,6 +23,7 @@ describe('AssignmentActivity', () => {
         current_grade: 0.5,
         last_grade: null,
       },
+      active: true,
     },
     {
       display_name: 'a',
@@ -35,6 +36,7 @@ describe('AssignmentActivity', () => {
         current_grade: 0.8,
         last_grade: 0.61,
       },
+      active: true,
     },
     {
       display_name: 'c',
@@ -47,6 +49,7 @@ describe('AssignmentActivity', () => {
         current_grade: 0.4,
         last_grade: null,
       },
+      active: false,
     },
   ];
   const activeAssignment = {
@@ -122,6 +125,8 @@ describe('AssignmentActivity', () => {
       // Do not mock FormattedDate, for consistency when checking
       // rendered values in different columns
       './FormattedDate': true,
+      // Let badges render normally so that we can assert on their text
+      './StudentStatusBadge': true,
     });
     $imports.$mock({
       '../../utils/api': {
@@ -222,7 +227,7 @@ describe('AssignmentActivity', () => {
       expectedValue: '',
       studentStats: { last_activity: null },
     },
-    // Render display_name when it's null
+    // Render fallback when display_name is null
     {
       fieldName: 'display_name',
       expectedValue:
@@ -230,6 +235,27 @@ describe('AssignmentActivity', () => {
       studentStats: {
         id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
         display_name: null,
+        active: true,
+      },
+    },
+    // Render fallback when display_name is null and user is not active
+    {
+      fieldName: 'display_name',
+      expectedValue:
+        "UnknownThis student launched the assignment but didn't annotate yetDrop",
+      studentStats: {
+        id: 'e4ca30ee27eda1169d00b83f2a86e3494ffd9b12',
+        display_name: null,
+        active: false,
+      },
+    },
+    // Render inactive user's display name
+    {
+      fieldName: 'display_name',
+      expectedValue: 'Jane DoeDrop',
+      studentStats: {
+        display_name: 'Jane Doe',
+        active: false,
       },
     },
   ].forEach(({ fieldName, expectedValue, studentStats }) => {
@@ -239,6 +265,7 @@ describe('AssignmentActivity', () => {
         last_activity: '2024-01-01T10:35:18',
         annotations: 37,
         replies: 25,
+        active: true,
       };
       const wrapper = createComponent();
 
@@ -567,6 +594,7 @@ describe('AssignmentActivity', () => {
               auto_grading_grade: {
                 current_grade: 0.5,
               },
+              active: true,
             },
             // Included, because last grade and current grade are different
             {
@@ -576,11 +604,13 @@ describe('AssignmentActivity', () => {
                 current_grade: 0.87,
                 last_grade: 0.7,
               },
+              active: true,
             },
             // Ignored, because auto_grading_grade is not set
             {
               display_name: 'c',
               h_userid: 'baz',
+              active: true,
             },
             // Ignored, because last and current grades are the same
             {
@@ -590,6 +620,16 @@ describe('AssignmentActivity', () => {
                 current_grade: 0.64,
                 last_grade: 0.64,
               },
+              active: true,
+            },
+            // Ignored, because it's not active
+            {
+              display_name: 'e',
+              h_userid: 'foo',
+              auto_grading_grade: {
+                current_grade: 0.5,
+              },
+              active: false,
             },
           ],
         },

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeIndicator-test.js
@@ -216,7 +216,7 @@ describe('GradeIndicator', () => {
   ].forEach(({ lastGrade, shouldShowBadge, shouldShowPrevGrade }) => {
     it('shows the "new" badge if last grade is not set or is different than current grade', () => {
       const wrapper = createComponent({ lastGrade });
-      const badge = wrapper.find('Badge[type="new"]');
+      const badge = wrapper.find('StudentStatusBadge[type="new"]');
 
       assert.equal(badge.exists(), shouldShowBadge);
       if (shouldShowBadge) {
@@ -244,7 +244,7 @@ describe('GradeIndicator', () => {
   ].forEach(({ status, expectedBadge, expectedBadgeText }) => {
     it('shows the corresponding badge based on status', () => {
       const wrapper = createComponent({ status });
-      const badge = wrapper.find(`Badge[type="${expectedBadge}"]`);
+      const badge = wrapper.find(`StudentStatusBadge[type="${expectedBadge}"]`);
 
       assert.isTrue(badge.exists());
       assert.equal(badge.text(), expectedBadgeText);

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/LastSyncIndicator-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/LastSyncIndicator-test.js
@@ -1,0 +1,39 @@
+import { FileCodeIcon, formatDateTime } from '@hypothesis/frontend-shared';
+import { mount } from 'enzyme';
+
+import LastSyncIndicator from '../LastSyncIndicator';
+
+describe('LastSyncIndicator', () => {
+  function createComponent(dateTime) {
+    return mount(
+      <LastSyncIndicator
+        icon={FileCodeIcon}
+        taskName="task"
+        dateTime={dateTime}
+      />,
+    ).find('[data-testid="container"]');
+  }
+
+  [
+    { dateTime: null, expectedTitle: undefined },
+    {
+      dateTime: '2024-10-02T14:24:15.677924+00:00',
+      expectedTitle: `task last synced on ${formatDateTime('2024-10-02T14:24:15.677924+00:00', { includeWeekday: true })}`,
+    },
+  ].forEach(({ dateTime, expectedTitle }) => {
+    it('has title when dateTime is not null', () => {
+      const wrapper = createComponent(dateTime);
+      assert.equal(wrapper.prop('title'), expectedTitle);
+    });
+
+    it('shows syncing message when date time is null', () => {
+      const wrapper = createComponent(dateTime);
+      assert.equal(wrapper.exists('[data-testid="syncing"]'), !dateTime);
+    });
+
+    it('shows relative time when dateTime is not null', () => {
+      const wrapper = createComponent(dateTime);
+      assert.equal(wrapper.exists('RelativeTime'), !!dateTime);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/StudentStatusBadge-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/StudentStatusBadge-test.js
@@ -1,0 +1,17 @@
+import { mount } from 'enzyme';
+
+import StudentStatusBadge from '../StudentStatusBadge';
+
+describe('StudentStatusBadge', () => {
+  [
+    { type: 'new', expectedText: 'New' },
+    { type: 'error', expectedText: 'Error' },
+    { type: 'syncing', expectedText: 'Syncing' },
+    { type: 'drop', expectedText: 'Drop' },
+  ].forEach(({ type, expectedText }) => {
+    it('shows right text based on type', () => {
+      const badge = mount(<StudentStatusBadge type={type} />);
+      assert.equal(badge.text(), expectedText);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/components/test/RelativeTime-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/RelativeTime-test.js
@@ -32,17 +32,19 @@ describe('RelativeTime', () => {
     $imports.$restore();
   });
 
-  function createComponent() {
-    return mount(<RelativeTime dateTime={dateTime} />);
+  function createComponent(props = {}) {
+    return mount(<RelativeTime dateTime={dateTime} {...props} />);
   }
 
-  it('sets initial time values', () => {
-    const wrapper = createComponent();
-    const time = wrapper.find('time');
+  [{ withTitle: true }, { withTitle: false }].forEach(({ withTitle }) => {
+    it('sets initial time values', () => {
+      const wrapper = createComponent({ withTitle });
+      const time = wrapper.find('time');
 
-    assert.equal(time.prop('title'), 'absolute date');
-    assert.equal(time.prop('dateTime'), dateTime);
-    assert.equal(wrapper.text(), 'relative date');
+      assert.equal(time.prop('title'), withTitle ? 'absolute date' : undefined);
+      assert.equal(time.prop('dateTime'), dateTime);
+      assert.equal(wrapper.text(), 'relative date');
+    });
   });
 
   it('is updated after time passes', () => {

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -6,9 +6,11 @@ from pyramid.view import view_config
 
 from lms.js_config_types import (
     AnnotationMetrics,
+    APIRoster,
     APIStudent,
     APIStudents,
     AutoGradingGrade,
+    RosterEntry,
 )
 from lms.models import Assignment, RoleScope, RoleType, User
 from lms.security import Permissions
@@ -108,7 +110,7 @@ class UserViews:
         permission=Permissions.DASHBOARD_VIEW,
         schema=UsersMetricsSchema,
     )
-    def students_metrics(self) -> APIStudents:
+    def students_metrics(self) -> APIRoster:
         """Fetch the stats for one particular assignment."""
         assignment = self.dashboard_service.get_request_assignment(
             self.request, self.request.parsed_params["assignment_id"]
@@ -137,7 +139,7 @@ class UserViews:
         )
         # Organize the H stats by userid for quick access
         stats_by_user = {s["userid"]: s for s in stats}
-        students: list[APIStudent] = []
+        students: list[RosterEntry] = []
 
         users_query = self._students_query(
             assignment_ids=[assignment.id],
@@ -148,7 +150,8 @@ class UserViews:
         for user in self.request.db.scalars(users_query).all():
             if s := stats_by_user.get(user.h_userid):
                 # We seen this student in H, get all the data from there
-                api_student = APIStudent(
+                api_student = RosterEntry(
+                    active=True,
                     h_userid=user.h_userid,
                     lms_id=user.user_id,
                     display_name=s["display_name"],
@@ -161,7 +164,8 @@ class UserViews:
             else:
                 # We haven't seen this user H,
                 # use LMS DB's data and set 0s for all annotation related fields.
-                api_student = APIStudent(
+                api_student = RosterEntry(
+                    active=True,
                     h_userid=user.h_userid,
                     lms_id=user.user_id,
                     display_name=user.display_name,
@@ -174,11 +178,13 @@ class UserViews:
         if assignment.auto_grading_config:
             students = self._add_auto_grading_data(assignment, students)
 
-        return {"students": students}
+        # We are not exposing the roster info here yet, just making the API changes to better coordinate with the frontend
+        # For now we mark every roster entry as active and we don't include any last_activity.
+        return APIRoster(students=students, last_updated=None)
 
     def _add_auto_grading_data(
-        self, assignment: Assignment, api_students: list[APIStudent]
-    ) -> list[APIStudent]:
+        self, assignment: Assignment, api_students: list[RosterEntry]
+    ) -> list[RosterEntry]:
         """Augment APIStudent with auto-grading data."""
         last_sync_grades = self.auto_grading_service.get_last_grades(assignment)
 

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -130,6 +130,7 @@ class TestUserViews:
         expected = {
             "students": [
                 {
+                    "active": True,
                     "h_userid": student.h_userid,
                     "lms_id": student.user_id,
                     "display_name": student.display_name,
@@ -140,6 +141,7 @@ class TestUserViews:
                     },
                 },
                 {
+                    "active": True,
                     "h_userid": student_no_annos.h_userid,
                     "lms_id": student_no_annos.user_id,
                     "display_name": student_no_annos.display_name,
@@ -150,6 +152,7 @@ class TestUserViews:
                     },
                 },
                 {
+                    "active": True,
                     "h_userid": student_no_annos_no_name.h_userid,
                     "lms_id": student_no_annos_no_name.user_id,
                     "display_name": None,
@@ -159,7 +162,8 @@ class TestUserViews:
                         "last_activity": None,
                     },
                 },
-            ]
+            ],
+            "last_updated": None,
         }
         assert response == expected
 
@@ -221,6 +225,7 @@ class TestUserViews:
         expected = {
             "students": [
                 {
+                    "active": True,
                     "h_userid": student.h_userid,
                     "lms_id": student.user_id,
                     "display_name": student.display_name,
@@ -231,6 +236,7 @@ class TestUserViews:
                     },
                 },
                 {
+                    "active": True,
                     "h_userid": student_no_annos.h_userid,
                     "lms_id": student_no_annos.user_id,
                     "display_name": student_no_annos.display_name,
@@ -241,6 +247,7 @@ class TestUserViews:
                     },
                 },
                 {
+                    "active": True,
                     "h_userid": student_no_annos_no_name.h_userid,
                     "lms_id": student_no_annos_no_name.user_id,
                     "display_name": None,
@@ -250,7 +257,8 @@ class TestUserViews:
                         "last_activity": None,
                     },
                 },
-            ]
+            ],
+            "last_updated": None,
         }
         calls = []
 
@@ -266,7 +274,10 @@ class TestUserViews:
                 else None,
             }
             calls.append(
-                call(assignment.auto_grading_config, api_student["annotation_metrics"])
+                call(
+                    assignment.auto_grading_config,
+                    api_student["annotation_metrics"],
+                )
             )
 
         auto_grading_service.calculate_grade.assert_has_calls(calls)


### PR DESCRIPTION
Proposed changes to the API structure to accommodate roster meta-information on the metrics endpoint.

That endpoint currently return a list of students, update it to return an APIRoster object which does contain the same APIStudent entries augmented with:

active: bool, for each student.
last_udpaetd: datetime, for the whole roster.


Once we agree on a API format we could:

- In one PR change the API in the BE and the FE to expect the new structure
- In successive BE PRs, start sending the right data in the new fields.
- FE changes to present the new information.



More context:

- Proposed figma designs: https://www.figma.com/design/ctCnzwkAyYArSNBYEshiCm/Hypothesis---LMS-Assignment-Grading?node-id=2148-277&node-type=frame&t=LT23EqykFa2dtAsf-0
-  Slack thread: https://hypothes-is.slack.com/archives/C2C2U40LW/p1732097953530889
