### PR TITLE
Remove auto grading feature flags

### DIFF
--- a/lms/js_config_types.py
+++ b/lms/js_config_types.py
@@ -159,9 +159,3 @@ class DashboardConfig(TypedDict):
     """Organization data for dashboard access scoped to one organization. For staff members only."""
 
     routes: DashboardRoutes
-
-    auto_grading_sync_enabled: bool
-    """Whether or nor the option to sync grades back to the LMS is enabled."""
-
-    assignment_segments_filter_enabled: bool
-    """Whether the segments filter dropdown should be displayed in the assignment view or not"""

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -55,10 +55,7 @@ class ApplicationSettings(JSONSettings):
         ),
         JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
         JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
-        JSONSetting("hypothesis", "auto_grading_enabled", asbool),
-        JSONSetting("hypothesis", "auto_grading_sync_enabled", asbool),
         JSONSetting("dashboard", "rosters", asbool),
-        JSONSetting("dashboard", "assignment_segments_filter_enabled", asbool),
     )
 
 

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -288,14 +288,6 @@ class JSConfig:
                             "api.dashboard.assignments.grading.sync"
                         ),
                     ),
-                    auto_grading_sync_enabled=self._lti_user
-                    and self._application_instance.settings.get(
-                        "hypothesis", "auto_grading_sync_enabled", False
-                    ),
-                    assignment_segments_filter_enabled=not self._lti_user
-                    or self._application_instance.settings.get(
-                        "dashboard", "assignment_segments_filter_enabled", False
-                    ),
                 ),
             }
         )
@@ -381,9 +373,9 @@ class JSConfig:
                     "formAction": form_action,
                     "formFields": form_fields,
                     "promptForTitle": prompt_for_title,
-                    "autoGradingEnabled": self._application_instance.settings.get(
-                        "hypothesis", "auto_grading_enabled", False
-                    ),
+                    # Enable auto grading everywhere except in Sakai
+                    "autoGradingEnabled": self._application_instance.tool_consumer_info_product_family_code
+                    != "sakai",
                     # The "content item selection" that we submit to Canvas's
                     # content_item_return_url is actually an LTI launch URL with
                     # the selected document URL or file_id as a query parameter. To

--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -76,11 +76,7 @@ function SyncErrorMessage({ grades }: { grades: StudentGradingSync[] }) {
  */
 export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
-  const {
-    routes,
-    auto_grading_sync_enabled,
-    assignment_segments_filter_enabled,
-  } = dashboard;
+  const { routes, user } = dashboard;
   const { assignmentId, organizationPublicId } = useParams<{
     assignmentId: string;
     organizationPublicId?: string;
@@ -98,12 +94,7 @@ export default function AssignmentActivity() {
   const isGradable = !!assignment.data?.is_gradable;
   const segments = useMemo((): DashboardActivityFiltersProps['segments'] => {
     const { data } = assignment;
-    if (
-      !data ||
-      // Display the segments filter only for auto-grading assignments, or
-      // assignments where the feature was explicitly enabled
-      (!assignment_segments_filter_enabled && !isAutoGradingAssignment)
-    ) {
+    if (!data) {
       return undefined;
     }
 
@@ -126,13 +117,7 @@ export default function AssignmentActivity() {
       selectedIds: segmentIds,
       onChange: segmentIds => updateFilters({ segmentIds }),
     };
-  }, [
-    assignment,
-    assignment_segments_filter_enabled,
-    isAutoGradingAssignment,
-    segmentIds,
-    updateFilters,
-  ]);
+  }, [assignment, segmentIds, updateFilters]);
 
   const students = useAPIFetch<StudentsMetricsResponse>(
     routes.students_metrics,
@@ -351,7 +336,7 @@ export default function AssignmentActivity() {
             }
           />
         )}
-        {isAutoGradingAssignment && auto_grading_sync_enabled && isGradable && (
+        {isAutoGradingAssignment && !user.is_staff && isGradable && (
           <SyncGradesButton
             studentsToSync={studentsToSync}
             lastSync={lastSync}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -109,8 +109,9 @@ describe('AssignmentActivity', () => {
           students_metrics: '/api/students/metrics',
           assignment_grades_sync: '/api/assignments/:assignment_id/grades/sync',
         },
-        auto_grading_sync_enabled: true,
-        assignment_segments_filter_enabled: false,
+        user: {
+          is_staff: false,
+        },
       },
     };
 
@@ -496,59 +497,59 @@ describe('AssignmentActivity', () => {
 
     [
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: true,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: true,
         isGradable: true,
       },
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: true,
         isGradable: false,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: false,
         isGradable: false,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: false,
       },
-    ].forEach(({ isAutoGradingAssignment, syncEnabled, isGradable }) => {
-      it('shows sync button when sync and auto-grading are enabled, and the assignment is gradable', () => {
+    ].forEach(({ isAutoGradingAssignment, isStaff, isGradable }) => {
+      it('shows sync button when user is not staff, and the assignment is auto-grading and gradable', () => {
         setUpFakeUseAPIFetch({
           ...activeAssignment,
           is_gradable: isGradable,
           auto_grading_config: isAutoGradingAssignment ? {} : null,
         });
-        fakeConfig.dashboard.auto_grading_sync_enabled = syncEnabled;
+        fakeConfig.dashboard.user.is_staff = isStaff;
 
         const wrapper = createComponent();
 
         assert.equal(
           wrapper.exists('SyncGradesButton'),
-          isAutoGradingAssignment && syncEnabled && isGradable,
+          isAutoGradingAssignment && !isStaff && isGradable,
         );
       });
     });
@@ -606,7 +607,7 @@ describe('AssignmentActivity', () => {
           },
           studentsData,
         );
-        fakeConfig.dashboard.auto_grading_sync_enabled = true;
+        fakeConfig.dashboard.user.is_staff = false;
 
         const wrapper = createComponent();
 
@@ -622,7 +623,7 @@ describe('AssignmentActivity', () => {
         ...activeAssignment,
         auto_grading_config: {},
       });
-      fakeConfig.dashboard.auto_grading_sync_enabled = true;
+      fakeConfig.dashboard.user.is_staff = false;
 
       const wrapper = createComponent();
       act(() => wrapper.find('SyncGradesButton').props().onSyncScheduled());
@@ -776,13 +777,6 @@ describe('AssignmentActivity', () => {
   });
 
   context('when assignment has segments', () => {
-    it('sets no segments when auto-grading is not enabled', () => {
-      const wrapper = createComponent();
-      const filters = wrapper.find('DashboardActivityFilters');
-
-      assert.isUndefined(filters.prop('segments'));
-    });
-
     [
       {
         assignmentExtra: { sections: [{}, {}] },
@@ -833,12 +827,6 @@ describe('AssignmentActivity', () => {
       const filters = wrapper.find('DashboardActivityFilters');
 
       assert.isDefined(filters.prop('onClearSelection'));
-    });
-  });
-
-  context('when assignment_segments_filter_enabled is true', () => {
-    beforeEach(() => {
-      fakeConfig.dashboard.assignment_segments_filter_enabled = true;
     });
 
     [{ sections: [{}, {}] }, { groups: [{}, {}, {}] }].forEach(

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -290,17 +290,6 @@ export type DashboardConfig = {
   routes: DashboardRoutes;
   user: DashboardUser;
 
-  /** Whether syncing grades is enabled for auto-grading assignments or not */
-  auto_grading_sync_enabled: boolean;
-
-  /**
-   * Whether the segments filter should be displayed for non-auto-grading
-   * assignments or not.
-   * For auto-grading assignments we'll ignore this and always display the
-   * segments filter.
-   */
-  assignment_segments_filter_enabled: boolean;
-
   /**
    * Organization-related information.
    *

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -114,12 +114,9 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
-                            {{ settings_checkbox("Enable auto-grading", "hypothesis", "auto_grading_enabled", default=False) }}
-                            {{ settings_checkbox("Enable auto-grading grade sync", "hypothesis", "auto_grading_sync_enabled", default=False) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Dashboard settings</legend>
-                            {{ settings_checkbox("Enable segments filter in assignment view", "dashboard", "assignment_segments_filter_enabled", default=False) }}
                             {{ settings_checkbox("Enable roster data", "dashboard", "rosters", default=False) }}
                         </fieldset>
                         <fieldset class="box">


### PR DESCRIPTION
Leave the main autoGradingEnabled configuration option but base it values on whether or not the install belongs to a Sakai school


### Testing

##### Sakai has autograding disabled 

Log in into sakai with `Sakai Administrator` on https://hypothesis-dev.longsight.com/

- Switch to `main`

-  Truncate assignments to force a reconfiguration

`truncate assignment cascade`

- Launch `localhost - autograding`, select a document, the option for auto grading is there.


- Switch to `remove-auto-grading-ff-fe`, try again, the auto grading option is not longer available.