### PR TITLE
Remove usage of auto-grading feature flags

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -76,11 +76,7 @@ function SyncErrorMessage({ grades }: { grades: StudentGradingSync[] }) {
  */
 export default function AssignmentActivity() {
   const { dashboard } = useConfig(['dashboard']);
-  const {
-    routes,
-    auto_grading_sync_enabled,
-    assignment_segments_filter_enabled,
-  } = dashboard;
+  const { routes, user } = dashboard;
   const { assignmentId, organizationPublicId } = useParams<{
     assignmentId: string;
     organizationPublicId?: string;
@@ -98,12 +94,7 @@ export default function AssignmentActivity() {
   const isGradable = !!assignment.data?.is_gradable;
   const segments = useMemo((): DashboardActivityFiltersProps['segments'] => {
     const { data } = assignment;
-    if (
-      !data ||
-      // Display the segments filter only for auto-grading assignments, or
-      // assignments where the feature was explicitly enabled
-      (!assignment_segments_filter_enabled && !isAutoGradingAssignment)
-    ) {
+    if (!data) {
       return undefined;
     }
 
@@ -126,13 +117,7 @@ export default function AssignmentActivity() {
       selectedIds: segmentIds,
       onChange: segmentIds => updateFilters({ segmentIds }),
     };
-  }, [
-    assignment,
-    assignment_segments_filter_enabled,
-    isAutoGradingAssignment,
-    segmentIds,
-    updateFilters,
-  ]);
+  }, [assignment, segmentIds, updateFilters]);
 
   const students = useAPIFetch<StudentsMetricsResponse>(
     routes.students_metrics,
@@ -351,7 +336,7 @@ export default function AssignmentActivity() {
             }
           />
         )}
-        {isAutoGradingAssignment && auto_grading_sync_enabled && isGradable && (
+        {isAutoGradingAssignment && !user.is_staff && isGradable && (
           <SyncGradesButton
             studentsToSync={studentsToSync}
             lastSync={lastSync}

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -109,8 +109,9 @@ describe('AssignmentActivity', () => {
           students_metrics: '/api/students/metrics',
           assignment_grades_sync: '/api/assignments/:assignment_id/grades/sync',
         },
-        auto_grading_sync_enabled: true,
-        assignment_segments_filter_enabled: false,
+        user: {
+          is_staff: false,
+        },
       },
     };
 
@@ -496,59 +497,59 @@ describe('AssignmentActivity', () => {
 
     [
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: true,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: true,
         isGradable: true,
       },
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: true,
         isGradable: false,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: true,
       },
       {
-        syncEnabled: true,
+        isStaff: true,
         isAutoGradingAssignment: false,
         isGradable: false,
       },
       {
-        syncEnabled: false,
+        isStaff: false,
         isAutoGradingAssignment: false,
         isGradable: false,
       },
-    ].forEach(({ isAutoGradingAssignment, syncEnabled, isGradable }) => {
-      it('shows sync button when sync and auto-grading are enabled, and the assignment is gradable', () => {
+    ].forEach(({ isAutoGradingAssignment, isStaff, isGradable }) => {
+      it('shows sync button when user is not staff, and the assignment is auto-grading and gradable', () => {
         setUpFakeUseAPIFetch({
           ...activeAssignment,
           is_gradable: isGradable,
           auto_grading_config: isAutoGradingAssignment ? {} : null,
         });
-        fakeConfig.dashboard.auto_grading_sync_enabled = syncEnabled;
+        fakeConfig.dashboard.user.is_staff = isStaff;
 
         const wrapper = createComponent();
 
         assert.equal(
           wrapper.exists('SyncGradesButton'),
-          isAutoGradingAssignment && syncEnabled && isGradable,
+          isAutoGradingAssignment && !isStaff && isGradable,
         );
       });
     });
@@ -606,7 +607,7 @@ describe('AssignmentActivity', () => {
           },
           studentsData,
         );
-        fakeConfig.dashboard.auto_grading_sync_enabled = true;
+        fakeConfig.dashboard.user.is_staff = false;
 
         const wrapper = createComponent();
 
@@ -622,7 +623,7 @@ describe('AssignmentActivity', () => {
         ...activeAssignment,
         auto_grading_config: {},
       });
-      fakeConfig.dashboard.auto_grading_sync_enabled = true;
+      fakeConfig.dashboard.user.is_staff = false;
 
       const wrapper = createComponent();
       act(() => wrapper.find('SyncGradesButton').props().onSyncScheduled());
@@ -776,13 +777,6 @@ describe('AssignmentActivity', () => {
   });
 
   context('when assignment has segments', () => {
-    it('sets no segments when auto-grading is not enabled', () => {
-      const wrapper = createComponent();
-      const filters = wrapper.find('DashboardActivityFilters');
-
-      assert.isUndefined(filters.prop('segments'));
-    });
-
     [
       {
         assignmentExtra: { sections: [{}, {}] },
@@ -833,12 +827,6 @@ describe('AssignmentActivity', () => {
       const filters = wrapper.find('DashboardActivityFilters');
 
       assert.isDefined(filters.prop('onClearSelection'));
-    });
-  });
-
-  context('when assignment_segments_filter_enabled is true', () => {
-    beforeEach(() => {
-      fakeConfig.dashboard.assignment_segments_filter_enabled = true;
     });
 
     [{ sections: [{}, {}] }, { groups: [{}, {}, {}] }].forEach(

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -290,17 +290,6 @@ export type DashboardConfig = {
   routes: DashboardRoutes;
   user: DashboardUser;
 
-  /** Whether syncing grades is enabled for auto-grading assignments or not */
-  auto_grading_sync_enabled: boolean;
-
-  /**
-   * Whether the segments filter should be displayed for non-auto-grading
-   * assignments or not.
-   * For auto-grading assignments we'll ignore this and always display the
-   * segments filter.
-   */
-  assignment_segments_filter_enabled: boolean;
-
   /**
    * Organization-related information.
    *


### PR DESCRIPTION
Adjust FE to changes introduced in https://github.com/hypothesis/lms/pull/6873, removing the usage of auto-grading feature flags.

The changes imply:

- We now show the segments filter for any assignment, regardless the type.
- The sync button is now displayed for any gradable and auto-grading assignment, as long as the active user is not a hypothesis staff member.