### PR TITLE
Bugfix, clearing LMSUser.lti_v13_user_id on LTI1.1 launches

### DIFF
--- a/lms/services/upsert.py
+++ b/lms/services/upsert.py
@@ -10,7 +10,7 @@ def bulk_upsert(
     model_class,
     values: list[dict],
     index_elements: list[str],
-    update_columns: list[str],
+    update_columns: list[str | tuple],
 ):
     """
     Create or update the specified values in a table.
@@ -50,7 +50,16 @@ def bulk_upsert(
         # The columns to use to find matching rows.
         index_elements=index_elements,
         # The columns to update.
-        set_={element: getattr(base.excluded, element) for element in update_columns},
+        set_={
+            # For tuples include the two elements as the key and value of the dict
+            # For strings use value: excluded.value by default
+            (element[0] if isinstance(element, tuple) else element): (
+                element[1]
+                if isinstance(element, tuple)
+                else getattr(base.excluded, element)
+            )
+            for element in update_columns
+        },
     ).returning(*index_elements_columns)
 
     result = db.execute(stmt)

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from sqlalchemy import select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import Select
 
@@ -89,7 +89,18 @@ class UserService:
                 }
             ],
             index_elements=["h_userid"],
-            update_columns=["updated", "display_name", "email", "lti_v13_user_id"],
+            update_columns=[
+                "updated",
+                "display_name",
+                "email",
+                (
+                    "lti_v13_user_id",
+                    func.coalesce(
+                        text('"excluded"."lti_v13_user_id"'),
+                        text('"lms_user"."lti_v13_user_id"'),
+                    ),
+                ),
+            ],
         ).one()
         bulk_upsert(
             self._db,


### PR DESCRIPTION
bulk_upsert will update the table columns in `update_elements` with the
value passed in updated.

In the case of lti_v13_user_id  that means that the value will be set on
LTI1.3  and removed (set to None) on LTI1.1 launches.

To fix this we change the value set from the raw value to
coalesce(value, LMSUser.lti_v13_user_id)


### Testing 

#### Replicate the bug on `main`

- Remove all of these IDs

```
update lms_user set lti_v13_user_id = null;
```

- Launch an LTI1.3 assignment:  https://hypothesis.instructure.com/courses/319/assignments/3336


- Check the value is now stored in the DB:

```select * from lms_user where lti_v13_user_id is not null;```


- Launch a LTI1.1 assignment: https://hypothesis.instructure.com/courses/125/assignments/873


- Check the DB again:

```select * from lms_user where lti_v13_user_id is not null;```

No results this time!

##### Switch to this branch `lms-user-api-id-bug`

- Repeat the process, this time the value is not cleared while doing the LTI1.1 launch.




