### PR TITLE
Store LMS API id on LMSUser during launches

### DIFF
--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -75,6 +75,9 @@ class UserService:
     def upsert_lms_user(self, user: User, lti_params: LTIParams) -> LMSUser:
         """Upsert LMSUser based on a User object."""
         self._db.flush()  # Make sure User has hit the DB on the current transaction
+
+        # API ID, only Canvas for now
+        lms_api_user_id = lti_params.get("custom_canvas_user_id")
         lms_user = bulk_upsert(
             self._db,
             LMSUser,
@@ -86,6 +89,7 @@ class UserService:
                     "h_userid": user.h_userid,
                     "email": user.email,
                     "display_name": user.display_name,
+                    "lms_api_user_id": lms_api_user_id,
                 }
             ],
             index_elements=["h_userid"],
@@ -100,6 +104,7 @@ class UserService:
                         text('"lms_user"."lti_v13_user_id"'),
                     ),
                 ),
+                "lms_api_user_id",
             ],
         ).one()
         bulk_upsert(

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -65,6 +65,8 @@ class TestUserService:
 
     def test_upsert_lms_user(self, service, lti_user, pyramid_request, db_session):
         user = service.upsert_user(lti_user)
+        pyramid_request.lti_params["custom_canvas_user_id"] = "lms_api_user_id"
+
         lms_user = service.upsert_lms_user(user, pyramid_request.lti_params)
 
         lms_user = db_session.scalars(
@@ -75,6 +77,7 @@ class TestUserService:
         assert lms_user.email == user.email
         assert lms_user.updated == user.updated
         assert lms_user.lti_v13_user_id == pyramid_request.lti_params.v13.get("sub")
+        assert lms_user.lms_api_user_id == "lms_api_user_id"
 
     def test_upsert_lms_user_doesnt_clear_lti_v13_user_id(
         self, service, lti_user, pyramid_request, db_session


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6880


### Testing

Launch a LTI1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/3308

- Check the value in the DB

```
 select * from lms_user where lms_api_user_id is not null;
-[ RECORD 1 ]---------------+----------------------------------------------------
id                          | 2051
tool_consumer_instance_guid | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms
lti_user_id                 | 969fc294ee26e3f1d0c9714af3351dc4eacfd6df
h_userid                    | acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is
email                       | eng+canvasteacher@hypothes.is
display_name                | DISPLAY NAME TEACHER
created                     | 2024-11-28 14:07:58.223625
updated                     | 2024-11-29 10:51:29.29357
lti_v13_user_id             | 3f25366d-ab34-4307-be21-3ea444559e82
lms_api_user_id             | 36
```

- Clear the value `update lms_user set lms_api_user_id=null;`


- Launch an LTI1.1 assignment: https://hypothesis.instructure.com/courses/125/assignments/873

- The value is also set 

```
select * from lms_user where lms_api_user_id is not null;
-[ RECORD 1 ]---------------+----------------------------------------------------
id                          | 2051
tool_consumer_instance_guid | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms
lti_user_id                 | 969fc294ee26e3f1d0c9714af3351dc4eacfd6df
h_userid                    | acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is
email                       | eng+canvasteacher@hypothes.is
display_name                | DISPLAY NAME TEACHER
created                     | 2024-11-28 14:07:58.223625
updated                     | 2024-11-29 11:04:30.813082
lti_v13_user_id             | 3f25366d-ab34-4307-be21-3ea444559e82
lms_api_user_id             | 36

```

