### PR TITLE
Switch H_USERID factory from a sequence to an UUID.

### DIFF
--- a/tests/factories/attributes.py
+++ b/tests/factories/attributes.py
@@ -1,6 +1,8 @@
 """Shared attributes used by test factories."""
 
-from factory import Faker, Sequence
+import uuid
+
+from factory import Faker, LazyAttribute
 
 OAUTH_CONSUMER_KEY = Faker("hexify", text="Hypothesis" + "^" * 32)
 SHARED_SECRET = Faker("hexify", text="^" * 64)
@@ -9,7 +11,7 @@ ACCESS_TOKEN = REFRESH_TOKEN = Faker("hexify", text="^" * 32)
 USER_ID = Faker("hexify", text="^" * 40)
 H_USERNAME = Faker("hexify", text="^" * 30)
 H_DISPLAY_NAME = Faker("name")
-H_USERID = Sequence(lambda n: f"acct:user_{n + 1}@example.com")
+H_USERID = LazyAttribute(lambda _: f"acct:user_{uuid.uuid4()}@example.com")
 
 RESOURCE_LINK_ID = Faker("hexify", text="^" * 32)
 TOOL_CONSUMER_INSTANCE_GUID = Faker("hexify", text="^" * 40)


### PR DESCRIPTION
We have seen some concurrency issues in CI test execution. This is an attempt to avoid collisions.


### Testing

In `make shell`


```

In [1]: factories.LMSUser().h_userid
Out[1]: 'acct:user_73fc8e29-c77f-45fc-9b47-ec29f6388d2c@example.com'

In [2]: factories.User().h_userid
Out[2]: 'acct:user_730f470b-aab4-4360-a0a3-0b8de2555979@example.com'
```
