### PR TITLE
Roster info message

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -2,6 +2,8 @@ import {
   CautionIcon,
   ClockIcon,
   FileGenericIcon,
+  InfoIcon,
+  Link,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useMemo, useState } from 'preact/hooks';
@@ -426,6 +428,19 @@ export default function AssignmentActivity() {
           }
         }}
       />
+      {!students.isLoading && !students.data?.last_updated && (
+        <Link
+          variant="text-light"
+          classes="flex items-center gap-1"
+          href="https://web.hypothes.is/help/student-roster-displays-in-the-lms-reporting-dashboards/"
+          target="_blank"
+          data-testid="missing-roster-message"
+        >
+          <InfoIcon />
+          Full roster data for this assignment is not available. This only shows
+          students who have previously launched it.
+        </Link>
+      )}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/AssignmentActivity-test.js
@@ -727,8 +727,12 @@ describe('AssignmentActivity', () => {
 
         const wrapper = createComponent();
         const lastSyncDate = wrapper.find('[data-testid="last-roster-date"]');
+        const missingRosterMessage = wrapper.find(
+          '[data-testid="missing-roster-message"]',
+        );
 
         assert.equal(lastSyncDate.exists(), shouldDisplayLastSyncInfo);
+        assert.equal(missingRosterMessage.exists(), !shouldDisplayLastSyncInfo);
       });
     });
 


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/lms/pull/6899

Add a message under the students table when the list is generated from launches instead of a roster, so that teachers can better understand why some students may not be displayed in that case. 

![image](https://github.com/user-attachments/assets/e889cac8-080b-493b-afcb-58c716255489)
