### PR TITLE
Schedule fetching canvas groups rosters

### DIFF
--- a/tests/unit/lms/tasks/roster_test.py
+++ b/tests/unit/lms/tasks/roster_test.py
@@ -7,9 +7,11 @@ from freezegun import freeze_time
 from lms.tasks.roster import (
     fetch_assignment_roster,
     fetch_course_roster,
+    fetch_segment_roster,
     schedule_fetching_assignment_rosters,
     schedule_fetching_course_rosters,
     schedule_fetching_rosters,
+    schedule_fetching_segment_rosters,
 )
 from tests import factories
 
@@ -31,13 +33,25 @@ class TestRosterTasks:
 
         roster_service.fetch_assignment_roster.assert_called_once_with(assignment)
 
+    def test_fetch_segment_roster(self, roster_service, db_session):
+        lms_segment = factories.LMSSegment()
+        db_session.flush()
+
+        fetch_segment_roster(lms_segment_id=lms_segment.id)
+
+        roster_service.fetch_canvas_group_roster.assert_called_once_with(lms_segment)
+
     def test_schedule_fetching_rosters(
-        self, schedule_fetching_assignment_rosters, schedule_fetching_course_rosters
+        self,
+        schedule_fetching_assignment_rosters,
+        schedule_fetching_course_rosters,
+        schedule_fetching_segment_rosters,
     ):
         schedule_fetching_rosters()
 
         schedule_fetching_course_rosters.assert_called_once_with()
         schedule_fetching_assignment_rosters.assert_called_once_with()
+        schedule_fetching_segment_rosters.assert_called_once_with()
 
     @freeze_time("2024-08-28")
     @pytest.mark.usefixtures(
@@ -75,6 +89,24 @@ class TestRosterTasks:
 
         fetch_assignment_roster.delay.assert_called_once_with(
             assignment_id=assignment_with_recent_launch.id
+        )
+
+    @freeze_time("2024-08-28")
+    @pytest.mark.usefixtures(
+        "lms_segment_with_no_launch",
+        "lms_segment_with_no_recent_launch",
+        "lms_segment_with_recent_launch_and_task_done_row",
+        "lms_segment_with_launch_and_recent_roster",
+    )
+    def test_schedule_fetching_segment_rosters(
+        self, lms_segment_with_recent_launch, db_session, fetch_segment_roster
+    ):
+        db_session.flush()
+
+        schedule_fetching_segment_rosters()
+
+        fetch_segment_roster.delay.assert_called_once_with(
+            lms_segment_id=lms_segment_with_recent_launch.id
         )
 
     @pytest.fixture
@@ -214,12 +246,65 @@ class TestRosterTasks:
         return assignment
 
     @pytest.fixture
+    def lms_segment_with_no_launch(self, lms_course_with_no_launch):
+        return factories.LMSSegment(
+            lms_course=lms_course_with_no_launch, type="canvas_group"
+        )
+
+    @pytest.fixture
+    def lms_segment_with_no_recent_launch(self, lms_course_with_no_recent_launch):
+        return factories.LMSSegment(
+            lms_course=lms_course_with_no_recent_launch, type="canvas_group"
+        )
+
+    @pytest.fixture
+    def lms_segment_with_recent_launch(self, lms_course_with_recent_launch):
+        return factories.LMSSegment(
+            lms_course=lms_course_with_recent_launch, type="canvas_group"
+        )
+
+    @pytest.fixture
+    def lms_segment_with_recent_launch_and_task_done_row(
+        self, lms_course_with_recent_launch, db_session
+    ):
+        lms_segment = factories.LMSSegment(
+            lms_course=lms_course_with_recent_launch, type="canvas_group"
+        )
+        db_session.flush()  # Make sure we have an ID for the course
+        factories.TaskDone(key=f"roster::segment::scheduled::{lms_segment.id}")
+
+        return lms_segment
+
+    @pytest.fixture
+    def lms_segment_with_launch_and_recent_roster(self, lms_course_with_recent_launch):
+        lms_segment = factories.LMSSegment(
+            lms_course=lms_course_with_recent_launch, type="canvas_group"
+        )
+        factories.LMSSegmentRoster(
+            lms_segment=lms_segment,
+            lms_user=factories.LMSUser(),
+            lti_role=factories.LTIRole(),
+            active=True,
+            updated=datetime(2024, 8, 25),
+        )
+
+        return lms_segment
+
+    @pytest.fixture
     def fetch_course_roster(self, patch):
         return patch("lms.tasks.roster.fetch_course_roster")
 
     @pytest.fixture
     def fetch_assignment_roster(self, patch):
         return patch("lms.tasks.roster.fetch_assignment_roster")
+
+    @pytest.fixture
+    def fetch_segment_roster(self, patch):
+        return patch("lms.tasks.roster.fetch_segment_roster")
+
+    @pytest.fixture
+    def schedule_fetching_segment_rosters(self, patch):
+        return patch("lms.tasks.roster.schedule_fetching_segment_rosters")
 
     @pytest.fixture
     def schedule_fetching_assignment_rosters(self, patch):


### PR DESCRIPTION
Use the same logic as for assignments and courses.


For:

- https://github.com/hypothesis/lms/issues/6902




### Testing 

- Truncate any segment rosters you might have.

```
truncate lms_segment_roster ;
TRUNCATE TABLE
```



- Launch an LTI1.3 groups assignment


https://hypothesis.instructure.com/courses/319/assignments/3336


- On `make shell`, schedule fetching rosters

```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```

segment roster fetching is scheduled:


```
worker (stderr)      | [2024-12-09 10:09:17,408: INFO/ForkPoolWorker-1] lms.tasks.roster.fetch_segment_roster[3da79f05-6966-4626-a447-1ba2c3a9898c] Task lms.tasks.roster.fetch_segment_roster[3da79f05-6966-4626-a447-1ba2c3a9898c] succeeded in 0.6005973350256681s: None
worker (stderr)      | [2024-12-09 10:09:17,531: INFO/ForkPoolWorker-2] lms.tasks.roster.fetch_segment_roster[b947bcf5-1c92-4557-84f0-385c1a0ca838] Task lms.tasks.roster.fetch_segment_roster[b947bcf5-1c92-4557-84f0-385c1a0ca838] succeeded in 0.7232479890226386s: None
```


- We have now roster data for those segments on the DB:

```
select name, lms_user_id from lms_segment_roster join lms_segment on lms_segment.id = lms_segment_id;
  name   | lms_user_id 
---------+-------------
 Group 2 |        2054
 Group 2 |        2055
 Group 2 |        2056
 Group 1 |        2050
(4 rows)
```


- Schedule it again:


```schedule_fetching_rosters.delay()```


No segment roster fetch is scheduled now.


- Remove task_done rows


```
truncate task_done ; 
```

- Schedule the fetch again, nothing happens yet


- Change the date of the existing roster:


```
 update lms_segment_roster set updated = now() - '1 month'::interval;
```

- Schedule again, this time both rosters are re-fetched


- Lets now remove the task done and mark the roster as old:

```
truncate task_done ;
update lms_segment_roster set updated = now() - '1 month'::interval;
```

- We'll also mark the launch event on the course as old:


```
 update event set timestamp = now() - '1 month'::interval where id in (select event.id from event join grouping on course_id = grouping.id where lms_name = 'LTI 1.3 Testing' order by timestamp desc limit 1);
```


- Scheduling the fetching again doesn't trigger a segment roster fetch this time.