### PR TITLE
Return the actual value for RosterEntry.active

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -178,7 +178,7 @@ class DashboardService:
 
     def get_assignment_roster(
         self, assignment: Assignment, h_userids: list[str] | None = None
-    ) -> Select[tuple[LMSUser]]:
+    ) -> Select[tuple[LMSUser, bool]]:
         rosters_enabled = (
             assignment.course
             and assignment.course.application_instance.settings.get(
@@ -203,7 +203,8 @@ class DashboardService:
                 role_type=RoleType.LEARNER,
                 assignment_id=assignment.id,
                 h_userids=h_userids,
-            )
+                # For launch data we always add the "active" column as true for compatibility with the roster query.
+            ).add_columns(True)
 
         # Always return the results, no matter the source, sorted
         return query.order_by(LMSUser.display_name, LMSUser.id)

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -147,11 +147,12 @@ class UserViews:
             h_userids=request_h_userids,
         )
         # Iterate over all the students we have in the DB
-        for user in self.request.db.scalars(users_query).all():
+        for roster_data in self.request.db.execute(users_query).all():
+            user, active = roster_data
             if s := stats_by_user.get(user.h_userid):
                 # We seen this student in H, get all the data from there
                 api_student = RosterEntry(
-                    active=True,
+                    active=active,
                     h_userid=user.h_userid,
                     lms_id=user.user_id,
                     display_name=s["display_name"],
@@ -165,7 +166,7 @@ class UserViews:
                 # We haven't seen this user H,
                 # use LMS DB's data and set 0s for all annotation related fields.
                 api_student = RosterEntry(
-                    active=True,
+                    active=active,
                     h_userid=user.h_userid,
                     lms_id=user.user_id,
                     display_name=user.display_name,

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -234,7 +234,7 @@ class TestDashboardService:
         )
         assert (
             roster
-            == user_service.get_users_for_assignment.return_value.order_by.return_value
+            == user_service.get_users_for_assignment.return_value.add_columns.return_value.order_by.return_value
         )
 
     def test_get_assignment_roster_with(

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -92,23 +92,39 @@ class TestUserViews:
             pyramid_request.parsed_params["segment_authority_provided_ids"] = [
                 g.authority_provided_id for g in segments
             ]
-            user_service.get_users.return_value = select(User).where(
-                User.id.in_(
-                    [
-                        u.id
-                        for u in [student, student_no_annos, student_no_annos_no_name]
-                    ]
+            user_service.get_users.return_value = (
+                select(User)
+                .where(
+                    User.id.in_(
+                        [
+                            u.id
+                            for u in [
+                                student,
+                                student_no_annos,
+                                student_no_annos_no_name,
+                            ]
+                        ]
+                    )
                 )
+                .add_columns(True)
             )
         else:
             db_session.flush()
-            dashboard_service.get_assignment_roster.return_value = select(User).where(
-                User.id.in_(
-                    [
-                        u.id
-                        for u in [student, student_no_annos, student_no_annos_no_name]
-                    ]
+            dashboard_service.get_assignment_roster.return_value = (
+                select(User)
+                .where(
+                    User.id.in_(
+                        [
+                            u.id
+                            for u in [
+                                student,
+                                student_no_annos,
+                                student_no_annos_no_name,
+                            ]
+                        ]
+                    )
                 )
+                .add_columns(True)
             )
 
         db_session.flush()
@@ -200,10 +216,17 @@ class TestUserViews:
             auto_grading_service.get_last_grades.return_value = {}
 
         db_session.flush()
-        dashboard_service.get_assignment_roster.return_value = select(User).where(
-            User.id.in_(
-                [u.id for u in [student, student_no_annos, student_no_annos_no_name]]
+        dashboard_service.get_assignment_roster.return_value = (
+            select(User)
+            .where(
+                User.id.in_(
+                    [
+                        u.id
+                        for u in [student, student_no_annos, student_no_annos_no_name]
+                    ]
+                )
             )
+            .add_columns(True)
         )
         dashboard_service.get_request_assignment.return_value = assignment
         h_api.get_annotation_counts.return_value = annotation_counts_response


### PR DESCRIPTION
We have been returning `True` for all entries until now. Actually return the value on the DB for roster entries and `True` for the ones based on launches.


# Testing

- Open a LT1.1 assignment for which you have at least one student launch. Open the dashboard for it.

https://hypothesis.instructure.com/courses/125/assignments/873

You get the list of students. No "drop" badges.


- Open a LTI1.3 assignment


https://hypothesis.instructure.com/courses/319/assignments/3336

- Make sure you have a roster for it, on `make shell`:

```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```

- Open the dashboard, you'll get the list of students, no badges.

- On `make sql`, set everyone as inactive:

```
update assignment_roster set active=false;
```

- Refresh the dashboard, everyone gets a `DROP` badge!




