### PR TITLE
Add missing document types to report assignment type query

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/02_entities/04_assignments/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/02_entities/04_assignments/01_create_view.sql
@@ -19,8 +19,12 @@ CREATE MATERIALIZED VIEW report.assignments AS (
         CASE
             -- Content integrations
             WHEN STARTS_WITH(url, 'blackboard://') THEN 'Blackboard Files'
+            WHEN STARTS_WITH(url, 'moodle://file') THEN 'Moodle Files'
+            WHEN STARTS_WITH(url, 'moodle://page') THEN 'Moodle Pages'
             WHEN STARTS_WITH(url, 'd2l://') THEN 'D2L Files'
-            WHEN STARTS_WITH(url, 'canvas://') THEN 'Canvas Files'
+            WHEN STARTS_WITH(url, 'canvas://file') THEN 'Canvas Files'
+            WHEN STARTS_WITH(url, 'canvas://page') THEN 'Canvas Pages'
+            WHEN STARTS_WITH(url, 'canvas-studio://') THEN 'Canvas Studio'
             WHEN STARTS_WITH(url, 'vitalsource://') THEN 'VitalSource'
             WHEN STARTS_WITH(url, 'jstor://') THEN 'JSTOR'
             WHEN STARTS_WITH(url, 'https://drive.google.com') THEN 'Google Drive'


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1613


This will change the type of assignments created every day (while running the "report refresh" GH action).


To backfill the historic data we need to run "create_from_scratch". We'll do that when we also have the "start of the week" code in to avoid having to run it twice.