### PR TITLE
Increase the timeout for the report refresh workflow

### DIFF
--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       App: ${{ github.event.repository.name }}
       Env: 'prod'
-      Timeout: 3600
+      Timeout: 5400
       Region: 'all'
       Command: 'newrelic-admin run-program python bin/run_data_task.py --config-file conf/production.ini --task report/refresh'
     secrets: inherit


### PR DESCRIPTION
We have been around 1h in the last few runs. Increase the time out to 1h and 30 minutes for now.