### PR TITLE
Return actual value for roster last_updated

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -187,7 +187,9 @@ class DashboardService:
                 "dashboard", "rosters"
             )
         )
-        roster_last_updated = self._roster_service.assignment_roster_exists(assignment)
+        roster_last_updated = self._roster_service.assignment_roster_last_updated(
+            assignment
+        )
 
         if rosters_enabled and roster_last_updated:
             # If rostering is enabled and we do have the data, use it

--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -199,6 +199,8 @@ class DashboardService:
             )
 
         else:
+            # If we are not going to return data from the roster, don't return the last updated date
+            roster_last_updated = None
             # Always fallback to fetch users that have launched the assignment at some point
             query = self._user_service.get_users_for_assignment(
                 role_scope=RoleScope.COURSE,

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from logging import getLogger
 
 from sqlalchemy import Select, func, select, text, update
@@ -64,14 +65,17 @@ class RosterService:
 
         return select(LMSUser).where(LMSUser.id.in_(roster_query))
 
-    def assignment_roster_exists(self, assignment: Assignment) -> bool:
-        """Check if we have roster data for the given assignment."""
-        return bool(
-            self._db.scalar(
-                select(AssignmentRoster)
-                .where(AssignmentRoster.assignment_id == assignment.id)
-                .limit(1)
-            )
+    def assignment_roster_exists(self, assignment: Assignment) -> datetime | None:
+        """
+        Check if we have roster data for the given assignment.
+
+        In case we have roster data, return the last updated timestamp, None otherwise.
+        """
+        return self._db.scalar(
+            select(AssignmentRoster.updated)
+            .where(AssignmentRoster.assignment_id == assignment.id)
+            .order_by(AssignmentRoster.updated.desc())
+            .limit(1)
         )
 
     def get_assignment_roster(

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -65,12 +65,8 @@ class RosterService:
 
         return select(LMSUser).where(LMSUser.id.in_(roster_query))
 
-    def assignment_roster_exists(self, assignment: Assignment) -> datetime | None:
-        """
-        Check if we have roster data for the given assignment.
-
-        In case we have roster data, return the last updated timestamp, None otherwise.
-        """
+    def assignment_roster_last_updated(self, assignment: Assignment) -> datetime | None:
+        """Return the roster's last updated timestamp for given assignment, or None if we don't have roster data."""
         return self._db.scalar(
             select(AssignmentRoster.updated)
             .where(AssignmentRoster.assignment_id == assignment.id)

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -233,7 +233,7 @@ class TestDashboardService:
             course=factories.Course(application_instance=application_instance)
         )
         if not roster_available:
-            roster_service.assignment_roster_exists.return_value = None
+            roster_service.assignment_roster_last_updated.return_value = None
 
         last_updated, roster = svc.get_assignment_roster(assignment, sentinel.h_userids)
 
@@ -256,7 +256,10 @@ class TestDashboardService:
                 role_type=RoleType.LEARNER,
                 h_userids=sentinel.h_userids,
             )
-            assert last_updated == roster_service.assignment_roster_exists.return_value
+            assert (
+                last_updated
+                == roster_service.assignment_roster_last_updated.return_value
+            )
             assert (
                 roster
                 == roster_service.get_assignment_roster.return_value.order_by.return_value

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import Mock, sentinel
 
 import pytest
@@ -13,7 +14,7 @@ from tests import factories
 class TestRosterService:
     @pytest.mark.parametrize(
         "create_roster,expected",
-        [(True, True), (False, False)],
+        [(True, datetime(2021, 1, 1)), (False, None)],
     )
     def test_assignment_roster_exists(
         self, svc, assignment, db_session, create_roster, expected
@@ -23,6 +24,7 @@ class TestRosterService:
 
         if create_roster:
             factories.AssignmentRoster(
+                updated=datetime(2021, 1, 1),
                 lms_user=lms_user,
                 assignment=assignment,
                 lti_role=lti_role,

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -16,7 +16,7 @@ class TestRosterService:
         "create_roster,expected",
         [(True, datetime(2021, 1, 1)), (False, None)],
     )
-    def test_assignment_roster_exists(
+    def test_assignment_roster_last_updated(
         self, svc, assignment, db_session, create_roster, expected
     ):
         lms_user = factories.LMSUser()
@@ -32,7 +32,7 @@ class TestRosterService:
             )
         db_session.flush()
 
-        assert svc.assignment_roster_exists(assignment) == expected
+        assert svc.assignment_roster_last_updated(assignment) == expected
 
     @pytest.mark.parametrize("with_role_scope", [True, False])
     @pytest.mark.parametrize("with_role_type", [True, False])

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -111,6 +111,7 @@ class TestUserViews:
         else:
             db_session.flush()
             dashboard_service.get_assignment_roster.return_value = (
+                None,
                 select(User)
                 .where(
                     User.id.in_(
@@ -124,7 +125,7 @@ class TestUserViews:
                         ]
                     )
                 )
-                .add_columns(True)
+                .add_columns(True),
             )
 
         db_session.flush()
@@ -217,6 +218,7 @@ class TestUserViews:
 
         db_session.flush()
         dashboard_service.get_assignment_roster.return_value = (
+            None,
             select(User)
             .where(
                 User.id.in_(
@@ -226,7 +228,7 @@ class TestUserViews:
                     ]
                 )
             )
-            .add_columns(True)
+            .add_columns(True),
         )
         dashboard_service.get_request_assignment.return_value = assignment
         h_api.get_annotation_counts.return_value = annotation_counts_response


### PR DESCRIPTION
We have been returning `None` for all entries until now. 

Actually return the value on the DB for roster entries and `None` for the ones based on launches.


# Testing

- Open a LT1.1 assignment for which you have at least one student launch. Open the dashboard for it.

https://hypothesis.instructure.com/courses/125/assignments/873

You'll see the 

```Full roster data for this assignment is not available. This only shows students who have previously launched it.```

message.


- Make sure you have the application instance setting enabled:


http://localhost:8001/admin/instances/102/settings 


`Enable roster data`.

- Open a LTI1.3 assignment



https://hypothesis.instructure.com/courses/319/assignments/3336

- Make sure you have a roster for it, on `make shell`:

```
from lms.tasks.roster import schedule_fetching_rosters
schedule_fetching_rosters.delay()
```

- Open the dashboard, you'll get the roster updated date on the top right corner.


- Repeat with the AI setting disabled:
 
http://localhost:8001/admin/instances/102/settings 


The top right notice will be gone and you will fallback to launches data.