### PR TITLE
Pick org_defined_id from the right location

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -183,23 +183,10 @@ _V11_TO_V13 = (
     # To make upgrades seamless we prefer the LTI1.1 version when available
     #
     # http://www.imsglobal.org/spec/lti/v1p3/migr#lti-1-1-migration-claim
-    (
-        "user_id",
-        [f"{CLAIM_PREFIX}/lti1p1", "user_id"],
-    ),
-    (
-        "resource_link_id",
-        [f"{CLAIM_PREFIX}/lti1p1", "resource_link_id"],
-    ),
+    ("user_id", [f"{CLAIM_PREFIX}/lti1p1", "user_id"]),
+    ("resource_link_id", [f"{CLAIM_PREFIX}/lti1p1", "resource_link_id"]),
     # LMS dependant variables that are not part of the "custom" claim
-    (
-        "org_defined_id",
-        [
-            "https://purl.imsglobal.org/spec/lti/claim/launch_presentation",
-            "http://www.brightspace.com",
-            "org_defined_id",
-        ],
-    ),
+    ("org_defined_id", ["http://www.brightspace.com", "org_defined_id"]),
 )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -92,9 +92,10 @@ def lti_v13_params():
             "canvas_api_domain": "hypothesis.instructure.com",
         },
         "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
-            "http://www.brightspace.com": {
-                "org_defined_id": "ORG_DEFINED_ID",
-            }
+            "locale": "en-us"
+        },
+        "http://www.brightspace.com": {
+            "org_defined_id": "ORG_DEFINED_ID",
         },
     }
 


### PR DESCRIPTION
Use "http://www.brightspace.com" -> "org_defined_id" instead of nesting that on "https://purl.imsglobal.org/spec/lti/claim/launch_presentation"


Fixes the issue discussed over: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1733264076402659


Has this ever worked? Was some initial school sending it on the wrong location?

In any case the only two install in the database that use this parameters are the ones with the issue discussed on slack so we don't have to worry about breaking anything on the old location.


## Testing

- Launch https://hypothes-is.slack.com/archives/C2BLQDKHA/p1733264076402659

Check the payload for the lti_launches endpoint, it only a `id_token` parameter which is JWT.

Inspect it and check the relevant section:


```
  "http://www.brightspace.com": {
    "tenant_id": "6de670d5-5f9b-44ba-9028-c424414b6d0f",
    "org_defined_id": null,
    "user_id": 362,
    "username": "Marcos.Prieto",
    "content_topic_id": 2132,
    "Context.id.history": "",
    "ResourceLink.id.history": "",
    "link_id": 210
  },
```

- Our D2L instance send a `None` value for `org_defined_id`, we can test that we are looking at the right location using another value with a diff like:

```diff
 --git a/lms/models/lti_params.py b/lms/models/lti_params.py
index 5a4d27f0c..768f69b1d 100644
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -186,7 +186,7 @@ _V11_TO_V13 = (
     ("user_id", [f"{CLAIM_PREFIX}/lti1p1", "user_id"]),
     ("resource_link_id", [f"{CLAIM_PREFIX}/lti1p1", "resource_link_id"]),
     # LMS dependant variables that are not part of the "custom" claim
-    ("org_defined_id", ["http://www.brightspace.com", "org_defined_id"]),
+    ("org_defined_id", ["http://www.brightspace.com", "username"]),
 )


diff --git a/lms/views/lti/basic_launch.py b/lms/views/lti/basic_launch.py
index e9fa00d22..9dc328310 100644
--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -57,6 +57,7 @@ class BasicLaunchViews:
             request.user, request.lti_params
         )
         self.course = self._record_course()
+        print(request.lti_params["org_defined_id"])

```

- Launch again and you'll see the username on the console.



