### PR TITLE
Basic functional test for DeepLinking launches

### DIFF
--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -41,7 +41,7 @@ class BearerTokenSchema(PyramidRequestSchema):
 
     def __init__(self, request):
         super().__init__(request)
-        self._jwt_service = request.find_service(iface=JWTService)
+        self._jwt_service: JWTService = request.find_service(iface=JWTService)
         self._lti_user_service = request.find_service(iface=LTIUserService)
         self._secret = request.registry.settings["jwt_secret"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ TEST_SETTINGS = {
     "h_api_url_private": "https://h.example.com/private/api/",
     "rpc_allowed_origins": ["http://localhost:5000"],
     "oauth2_state_secret": "test_oauth2_state_secret",
+    "onedrive_client_id": "test_one_drive_client_id",
     "session_cookie_secret": "notasecret",
     "via_secret": "not_a_secret",
     "blackboard_api_client_id": "test_blackboard_api_client_id",
@@ -34,6 +35,7 @@ TEST_SETTINGS = {
     "disable_key_rotation": False,
     "admin_users": [],
     "email_preferences_secret": "test_email_preferences_secret",
+    "youtube_api_key": "test_youtube_api_key",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_SETTINGS = {
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",
-    "lms_secret": "TEST_LMS_SECRET",
+    "lms_secret": "test_secret",
     "aes_secret": b"TSeQ7E3dzbHgu5ydX2xCrKJiXTmfJbOe",
     "jinja2.filters": {
         "static_path": "pyramid_jinja2.filters:static_path_filter",

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -4,6 +4,12 @@ from lms.models.lti_user import LTI, LTIUser
 from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID, USER_ID
 
+_LTI = make_factory(
+    LTI,
+    course_id=Faker("hexify", text="^" * 40),
+    product_family="UNKNOWN",
+)
+
 LTIUser = make_factory(
     LTIUser,
     user_id=USER_ID,
@@ -13,6 +19,6 @@ LTIUser = make_factory(
     effective_lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
-    lti=LTI(course_id=Faker("hexify", text="^" * 40), product_family="UNKNOWN"),
+    lti=SubFactory(_LTI),
     application_instance=SubFactory(ApplicationInstance),
 )

--- a/tests/functional/views/lti/deep_linking_test.py
+++ b/tests/functional/views/lti/deep_linking_test.py
@@ -1,0 +1,123 @@
+import time
+
+import oauthlib.common
+import oauthlib.oauth1
+import pytest
+from h_matchers import Any
+
+from lms.resources._js_config import JSConfig
+
+
+class TestDeepLinkingLaunch:
+    def test_basic_lti_launch_canvas_deep_linking_url(
+        self,
+        do_deep_link_launch,
+        lti_params,
+        application_instance,
+        get_client_config,
+        environ,
+    ):
+        response = do_deep_link_launch(post_params=lti_params, status=200)
+
+        js_config = get_client_config(response)
+        assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
+        assert js_config["filePicker"] == {
+            "autoGradingEnabled": True,
+            "blackboard": {"enabled": None},
+            "canvas": {
+                "enabled": None,
+                "foldersEnabled": None,
+                "listFiles": {
+                    "authUrl": "http://localhost/api/canvas/oauth/authorize",
+                    "path": "/api/canvas/courses/None/files",
+                },
+                "pagesEnabled": None,
+            },
+            "canvasStudio": {"enabled": False},
+            "d2l": {"enabled": False},
+            "deepLinkingAPI": {
+                "data": {
+                    "content_item_return_url": "https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request",
+                    "context_id": "con-182",
+                    "opaque_data_lti11": None,
+                },
+                "path": "/lti/1.1/deep_linking/form_fields",
+            },
+            "formAction": "https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request",
+            "formFields": {
+                "lti_message_type": "ContentItemSelection",
+                "lti_version": "LTI-1p0",
+            },
+            "google": {
+                "clientId": environ["GOOGLE_CLIENT_ID"],
+                "developerKey": environ["GOOGLE_DEVELOPER_KEY"],
+                "enabled": True,
+                "origin": application_instance.lms_url,
+            },
+            "jstor": {"enabled": False},
+            "ltiLaunchUrl": "http://localhost/lti_launches",
+            "microsoftOneDrive": {
+                "clientId": environ["ONEDRIVE_CLIENT_ID"],
+                "enabled": True,
+                "redirectURI": "http://localhost/onedrive/filepicker/redirect",
+            },
+            "moodle": {"enabled": None, "pagesEnabled": None},
+            "promptForTitle": True,
+            "vitalSource": {"enabled": False},
+            "youtube": {"enabled": Any()},
+        }
+
+
+@pytest.fixture
+def lti_params(application_instance, sign_lti_params):
+    params = {
+        "context_id": "con-182",
+        "context_label": "SI182",
+        "context_title": "Design of Personal Environments",
+        "context_type": "CourseSection",
+        "custom_context_memberships_url": "https://apps.imsglobal.org/lti/cert/tp/tp_membership.php/context/con-182/membership?b64=a2puNjk3b3E5YTQ3Z28wZDRnbW5xYzZyYjU%3D",
+        "custom_context_setting_url": "https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/lis/CourseSection/con-182/bindings/ims/cert/custom?b64=a2puNjk3b3E5YTQ3Z28wZDRnbW5xYzZyYjU%3D",
+        "custom_link_setting_url": "$LtiLink.custom.url",
+        "custom_system_setting_url": "https://apps.imsglobal.org/lti/cert/tp/tp_settings.php/ToolProxy/Hypothesis1b40eafba184a131307049e01e9c147d/custom?b64=a2puNjk3b3E5YTQ3Z28wZDRnbW5xYzZyYjU%3D",
+        "custom_tc_profile_url": "https://apps.imsglobal.org/lti/cert/tp/tp_tcprofile.php?b64=a2puNjk3b3E5YTQ3Z28wZDRnbW5xYzZyYjU%3D",
+        "launch_presentation_document_target": "iframe",
+        "launch_presentation_locale": "en_US",
+        "launch_presentation_return_url": "https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request",
+        "lis_course_section_sourcedid": "id-182",
+        "lis_person_contact_email_primary": "jane@school.edu",
+        "lis_person_name_family": "Lastname",
+        "lis_person_name_full": "Jane Q. Lastname",
+        "lis_person_name_given": "Jane",
+        "lis_person_sourcedid": "school.edu:jane",
+        "lti_message_type": "ContentItemSelectionRequest",
+        "lti_version": "LTI-1p0",
+        "oauth_callback": "about:blank",
+        "oauth_consumer_key": application_instance.consumer_key,
+        "oauth_nonce": "38d6db30e395417659d068164ca95169",
+        "oauth_signature_method": "HMAC-SHA1",
+        "oauth_timestamp": str(int(time.time())),
+        "oauth_version": "1.0",
+        "roles": "Instructor",
+        "tool_consumer_info_product_family_code": "imsglc",
+        "tool_consumer_info_version": "1.1",
+        "tool_consumer_instance_description": "IMS Testing Description",
+        "tool_consumer_instance_guid": application_instance.tool_consumer_instance_guid,
+        "tool_consumer_instance_name": "IMS Testing Instance",
+        "user_id": "123456",
+        "content_item_return_url": "https://apps.imsglobal.org/lti/cert/tp/tp_return.php/basic-lti-launch-request",
+    }
+
+    return sign_lti_params(params)
+
+
+@pytest.fixture
+def sign_lti_params(oauth_client):
+    def _sign(params):
+        params["oauth_signature"] = oauth_client.get_oauth_signature(
+            oauthlib.common.Request(
+                "http://localhost/content_item_selection", "POST", body=params
+            )
+        )
+        return params
+
+    return _sign


### PR DESCRIPTION
Add a basic functional test for the LTI1.1 deep linking launch.

This is similar to the existing basic LTI launch test so there's some fixtures that are moved around and refactored to be able to reuse them in both cases.

This only cover the launch side of DeepLinking and the intention is just to have a sanity check type of test. In a follow up PR I'll add test for the API side of deep linking.


