### PR TITLE
Functional test for the DeepLinking fields API

### DIFF
--- a/lms/validation/authentication/_bearer_token.py
+++ b/lms/validation/authentication/_bearer_token.py
@@ -41,7 +41,7 @@ class BearerTokenSchema(PyramidRequestSchema):
 
     def __init__(self, request):
         super().__init__(request)
-        self._jwt_service = request.find_service(iface=JWTService)
+        self._jwt_service: JWTService = request.find_service(iface=JWTService)
         self._lti_user_service = request.find_service(iface=LTIUserService)
         self._secret = request.registry.settings["jwt_secret"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_SETTINGS = {
     "jwt_secret": "test_secret",
     "google_client_id": "fake_client_id",
     "google_developer_key": "fake_developer_key",
-    "lms_secret": "TEST_LMS_SECRET",
+    "lms_secret": "test_secret",
     "aes_secret": b"TSeQ7E3dzbHgu5ydX2xCrKJiXTmfJbOe",
     "jinja2.filters": {
         "static_path": "pyramid_jinja2.filters:static_path_filter",

--- a/tests/factories/lti_user.py
+++ b/tests/factories/lti_user.py
@@ -4,6 +4,12 @@ from lms.models.lti_user import LTI, LTIUser
 from tests.factories.application_instance import ApplicationInstance
 from tests.factories.attributes import TOOL_CONSUMER_INSTANCE_GUID, USER_ID
 
+_LTI = make_factory(
+    LTI,
+    course_id=Faker("hexify", text="^" * 40),
+    product_family="UNKNOWN",
+)
+
 LTIUser = make_factory(
     LTIUser,
     user_id=USER_ID,
@@ -13,6 +19,6 @@ LTIUser = make_factory(
     effective_lti_roles=[],
     tool_consumer_instance_guid=TOOL_CONSUMER_INSTANCE_GUID,
     display_name=Faker("name"),
-    lti=LTI(course_id=Faker("hexify", text="^" * 40), product_family="UNKNOWN"),
+    lti=SubFactory(_LTI),
     application_instance=SubFactory(ApplicationInstance),
 )


### PR DESCRIPTION
Just covering the LTI1.1 version on this commit.


This happens to be the first API functional test (other than LTI launches) in the code base.

This test breaks on the reverted commit https://github.com/hypothesis/lms/pull/6832 showing extra data showing on the payload.