### PR TITLE
Expose segment rosters on the dashboards

### DIFF
--- a/lms/services/segment.py
+++ b/lms/services/segment.py
@@ -17,6 +17,14 @@ class SegmentService:
         self._db = db
         self._group_set_service = group_set_service
 
+    def get_segment(self, authority_provided_id: str) -> LMSSegment | None:
+        """Get a segment by its authority_provided_id."""
+        return (
+            self._db.query(LMSSegment)
+            .filter_by(h_authority_provided_id=authority_provided_id)
+            .one_or_none()
+        )
+
     def upsert_segments(
         self,
         course: LMSCourse,

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -218,6 +218,21 @@ class UserViews:
         h_userids: list[str] | None = None,
     ) -> tuple[datetime | None, Select[tuple[LMSUser | User, bool]]]:
         course_ids = self.request.parsed_params.get("course_ids")
+
+        # Roster for specific segments
+        if segment_authority_provided_ids:
+            # Fetch all the segments to be sure the current user has access to them.
+            segments = [
+                self.dashboard_service.get_request_segment(
+                    self.request, authority_provided_id
+                )
+                for authority_provided_id in segment_authority_provided_ids
+            ]
+
+            return self.dashboard_service.get_segments_roster(
+                segments=segments, h_userids=h_userids
+            )
+
         # Single assigment fetch
         if (
             assignment_ids

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -38,7 +38,7 @@ from tests.factories.lms_course import (
     LMSCourseMembership,
 )
 from tests.factories.lms_group_set import LMSGroupSet
-from tests.factories.lms_segment import LMSSegment
+from tests.factories.lms_segment import LMSSegment, LMSSegmentMembership
 from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride

--- a/tests/factories/lms_segment.py
+++ b/tests/factories/lms_segment.py
@@ -12,3 +12,7 @@ LMSSegment = factory.make_factory(
     name=Faker("word"),
     h_authority_provided_id=Faker("hexify", text="^" * 40),
 )
+
+LMSSegmentMembership = factory.make_factory(
+    models.LMSSegmentMembership, FACTORY_CLASS=SQLAlchemyModelFactory
+)

--- a/tests/unit/lms/services/segment_test.py
+++ b/tests/unit/lms/services/segment_test.py
@@ -55,6 +55,12 @@ class TestSegmentService:
             lms_user=lms_user, segments=segments, lti_roles=roles
         )
 
+    def test_get_segment(self, svc, db_session):
+        segment = factories.LMSSegment()
+        db_session.flush()
+
+        assert svc.get_segment(segment.h_authority_provided_id) == segment
+
     @pytest.fixture
     def svc(self, db_session, group_set_service):
         return SegmentService(db=db_session, group_set_service=group_set_service)


### PR DESCRIPTION
Segment rosters are used a bit differently than assignments ones.

We allow filtering by **multiple** rosters and we'll display a list of those students with the metrics. For assignments we only allow to select one assignment at the time.

This adds a bit of extra complexity as we need to query the roster as a combination of rosters. Over time we'll likely move to "multi select" filters in more places in the dashboards but for now just using it on the place the UI allows for that type of query.



### Testing

- Launch a LTI1.3 assignment using groups:

https://hypothesis.instructure.com/courses/319/assignments/3336



- Fetch the roster for those, in `make shell`:

```
from lms.tasks.roster import schedule_fetching_rosters 
schedule_fetching_rosters.delay()
```

- Open the dashboard for the assignment

- Select both groups independently on the segment filter/dropdown.

- The users shown matches the groups definiiont here:

![Screenshot from 2025-01-13 17-35-19](https://github.com/user-attachments/assets/56c8c91f-e869-4827-872b-b0f1e4c5964e)


- Select both groups at the same time. You get a combination of students in both groups. 

