### PR TITLE
Fix report queries with a date type cast

### DIFF
--- a/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
+++ b/lms/data_tasks/report/create_from_scratch/02_entities/03_events/01_create_view.sql
@@ -23,7 +23,7 @@ CREATE MATERIALIZED VIEW report.events AS (
 
         translated_events AS (
             SELECT
-                report.multi_truncate('week', timestamp) AS timestamp_week,
+                report.multi_truncate('week', timestamp::date) AS timestamp_week,
                 user_map.organization_id,
                 event_type.type::report.event_type AS event_type,
                 user_map.user_id

--- a/lms/data_tasks/report/create_from_scratch/05_activity_counts/02_groups/03_group_activity/01_create_view.jinja2.sql
+++ b/lms/data_tasks/report/create_from_scratch/05_activity_counts/02_groups/03_group_activity/01_create_view.jinja2.sql
@@ -6,7 +6,7 @@ CREATE MATERIALIZED VIEW report.group_activity AS (
     WITH
         launch_counts AS (
             SELECT
-                report.multi_truncate('week', timestamp) AS timestamp_week,
+                report.multi_truncate('week', timestamp::date) AS timestamp_week,
                 group_id,
                 COUNT(1) AS launch_count
             FROM report.group_map


### PR DESCRIPTION
Fixes: [sentry issue](https://hypothesis.sentry.io/issues/6151425460/?alert_rule_id=4849653&alert_type=issue&notification_uuid=a9fa7651-769d-449e-bfe6-6f1c17fb37b3&project=259908&referrer=slack)


The multi_truncate function takes a date but we were passing a timestamp instead. Cast the type accordingly.


Issue introduced in: https://github.com/hypothesis/lms/pull/6910/


### Testing

- Run 


```
tox -e dev --run-command "python bin/run_data_task.py -c conf/development.ini -t report/create_from_scratch"
```

in H first

- Run the same command in LMS now.


It success in this branch. Fails on `main`.




