### PR TITLE
Fix issue while trying to fetch multiple groups rosters

### DIFF
--- a/lms/views/dashboard/pagination.py
+++ b/lms/views/dashboard/pagination.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from types import NoneType
-from typing import TypeVar
+from typing import Any, TypeVar
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from marshmallow import ValidationError, fields, post_load, validate
@@ -39,7 +39,7 @@ def _get_next_url(current_url, cursor_value) -> str:
 
 
 def get_page(
-    request, items_query: Select[tuple[T]], cursor_columns: list
+    request, items_query: Select[tuple[T, *tuple[Any]]], cursor_columns: list
 ) -> tuple[list[T], Pagination]:
     """Return the first page and pagination metadata from a query."""
 

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -42,7 +42,7 @@ class TestUserViews:
         )
         get_page.assert_called_once_with(
             pyramid_request,
-            user_service.get_users.return_value,
+            user_service.get_users.return_value.add_columns.return_value,
             [User.display_name, User.id],
         )
         assert response == {
@@ -92,21 +92,17 @@ class TestUserViews:
             pyramid_request.parsed_params["segment_authority_provided_ids"] = [
                 g.authority_provided_id for g in segments
             ]
-            user_service.get_users.return_value = (
-                select(User)
-                .where(
-                    User.id.in_(
-                        [
-                            u.id
-                            for u in [
-                                student,
-                                student_no_annos,
-                                student_no_annos_no_name,
-                            ]
+            user_service.get_users.return_value = select(User).where(
+                User.id.in_(
+                    [
+                        u.id
+                        for u in [
+                            student,
+                            student_no_annos,
+                            student_no_annos_no_name,
                         ]
-                    )
+                    ]
                 )
-                .add_columns(True)
             )
         else:
             db_session.flush()


### PR DESCRIPTION
While working on exposing the segments dashboard I notice a bug, selecting multiple segments in `main` fails.

This PR fixes that bug only, keeping exposing the segment rosters in a separate PR.


## Testing

- On `main` open the dashboard on an assignments with groups, filter by groups. You'll get an error.


https://hypothesis.instructure.com/courses/319/assignments/3336


- Repeat the process on this branch. No error.


