### PR TITLE
Store course start and end when available

### DIFF
--- a/lms/models/lms_course.py
+++ b/lms/models/lms_course.py
@@ -51,7 +51,7 @@ class LMSCourse(CreatedUpdatedMixin, Base):
     """The start date of the course. Only for when we get this information directly from the LMS"""
 
     ends_at: Mapped[datetime | None] = mapped_column()
-    """The end date of the course. Only for when we get this information direclty from the LMS"""
+    """The end date of the course. Only for when we get this information directly from the LMS"""
 
 
 class LMSCourseApplicationInstance(CreatedUpdatedMixin, Base):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1617


Use the value from the custom variables in canvas this indicates the course deviates from the term of the course.

We have been requesting these variables as part of the default custom variables in the config json for a while so we'll get a data for a few schools.

We'll look into applying the same patter in other LMSes.



### Testing


- Apply the migration

`tox -e dev --run-command 'alembic upgrade head'`


- Launch an assignment that doesn't send the course dates

https://hypothesis.instructure.com/courses/125/assignments/873

- Check the DB, no dates for this course, in `make sql`


```
select * from lms_course where lti_context_id = 'f3cd019017839c4630358662a05540f2f6ec5f93';


-[ RECORD 1 ]---------------+----------------------------------------------------
id                          | 1056
tool_consumer_instance_guid | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms
lti_context_id              | f3cd019017839c4630358662a05540f2f6ec5f93
h_authority_provided_id     | 653e9620a656a954c684942f6443fa3e3410c03a
copied_from_id              | 
name                        | Developer Test Course with Sections Enabled
created                     | 2025-01-07 10:57:47.775449
updated                     | 2025-01-07 10:57:47.775449
lti_context_memberships_url | 
starts_at                   | 
ends_at                    
```


- Launch an assignment that does have the required variable configured

https://hypothesis.instructure.com/courses/319/assignments/3308


- Check the DB for this course, it will have the dates now:


```
select * from lms_course where lti_context_id = '6ed5aff92b5257ab607ec9c629844ea8586fde68';


-[ RECORD 1 ]---------------+-----------------------------------------------------------------------
id                          | 1057
tool_consumer_instance_guid | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms
lti_context_id              | 6ed5aff92b5257ab607ec9c629844ea8586fde68
h_authority_provided_id     | 3394ac098caa5997ed3d87023befb9f7e9ea4a38
copied_from_id              | 
name                        | LTI 1.3 Testing
created                     | 2025-01-07 11:13:07.186753
updated                     | 2025-01-07 11:13:07.186753
lti_context_memberships_url | https://hypothesis.instructure.com/api/lti/courses/319/names_and_roles
starts_at                   | 2025-01-02 07:00:00
ends_at                     | 2026-01-01 07:00:00
```

