### PR TITLE
Migration to add lms_api_course_id to LMSCourse

### DIFF
--- a/lms/migrations/versions/cf20e70211f9_add_api_to_lmscourse.py
+++ b/lms/migrations/versions/cf20e70211f9_add_api_to_lmscourse.py
@@ -1,0 +1,17 @@
+"""Add API ID to LMSCourse."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "cf20e70211f9"
+down_revision = "0aa54a98ad39"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lms_course", sa.Column("lms_api_course_id", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("lms_course", "lms_api_course_id")


### PR DESCRIPTION
Migration to add a column for the API id for courses.

Auto generated from:

- https://github.com/hypothesis/lms/pull/6943

More context and testing instructions: 

- https://github.com/hypothesis/lms/pull/6944
