### PR TITLE
Store the API ID for canvas courses on LMSCourse

### DIFF
--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -163,11 +163,19 @@ class TestCourseService:
 
     @pytest.mark.parametrize(
         "custom_course_starts, course_starts_at",
-        [(None, None), ("2022-01-01T00:00:00Z", datetime(2022, 1, 1, tzinfo=UTC))],
+        [
+            (None, None),
+            ("NOT A DATE", None),
+            ("2022-01-01T00:00:00Z", datetime(2022, 1, 1, tzinfo=UTC)),
+        ],
     )
     @pytest.mark.parametrize(
         "custom_course_ends, course_ends_at",
-        [(None, None), ("2022-01-01T00:00:00Z", datetime(2022, 1, 1, tzinfo=UTC))],
+        [
+            (None, None),
+            ("NOT A DATE", None),
+            ("2022-01-01T00:00:00Z", datetime(2022, 1, 1, tzinfo=UTC)),
+        ],
     )
     @pytest.mark.parametrize(
         "custom_canvas_api_id",

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -169,6 +169,10 @@ class TestCourseService:
         "custom_course_ends, course_ends_at",
         [(None, None), ("2022-01-01T00:00:00Z", datetime(2022, 1, 1, tzinfo=UTC))],
     )
+    @pytest.mark.parametrize(
+        "custom_canvas_api_id",
+        [None, "API ID"],
+    )
     def test_upsert_course(
         self,
         svc,
@@ -180,9 +184,11 @@ class TestCourseService:
         course_starts_at,
         custom_course_ends,
         course_ends_at,
+        custom_canvas_api_id,
     ):
         lti_params["custom_course_starts"] = custom_course_starts
         lti_params["custom_course_ends"] = custom_course_ends
+        lti_params["custom_canvas_course_id"] = custom_canvas_api_id
 
         course = svc.upsert_course(
             lti_params=lti_params,
@@ -218,6 +224,7 @@ class TestCourseService:
                             "lti_context_memberships_url": None,
                             "starts_at": course_starts_at,
                             "ends_at": course_ends_at,
+                            "lms_api_course_id": custom_canvas_api_id,
                         }
                     ],
                     index_elements=["h_authority_provided_id"],
@@ -227,6 +234,7 @@ class TestCourseService:
                         "lti_context_memberships_url",
                         "starts_at",
                         "ends_at",
+                        "lms_api_course_id",
                     ],
                 ),
                 call().one(),


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6880


Course have a LTI identifier that it's send on every launch but also have a API only ID that's needed to talk to the proprietary API of each LMS.

We do store the canvas version of this ID in a json dict in Grouping.extra but this train of PR promotes it to its own column.


### Testing

- Apply the migration
tox -e dev --run-command 'alembic upgrade head'

- Log into canvas (`eng+canvasteacher@hypothes.is`) and launch:

https://hypothesis.instructure.com/courses/125/assignments/875


- Check the correct value (125) is present on lms_course now, in `make sql`:


```
select * from lms_course where lms_api_course_id = '125';


-[ RECORD 1 ]---------------+----------------------------------------------------
id                          | 1056
tool_consumer_instance_guid | VCSy8DAKCFIQYaItpSGyXhOXIlk5A6NWduVVG1u3:canvas-lms
lti_context_id              | f3cd019017839c4630358662a05540f2f6ec5f93
h_authority_provided_id     | 653e9620a656a954c684942f6443fa3e3410c03a
copied_from_id              | 
name                        | Developer Test Course with Sections Enabled
created                     | 2025-01-07 10:57:47.775449
updated                     | 2025-01-08 13:01:36.984534
lti_context_memberships_url | 
starts_at                   | 
ends_at                     | 
lms_api_course_id           | 125
```

