### PR TITLE
Migration to backfill LMSCourse.lms_api_course_id from existing grouping rows

### DIFF
--- a/lms/migrations/versions/9be518500f7d_backfill_lmscourse_api_lms_course_id.py
+++ b/lms/migrations/versions/9be518500f7d_backfill_lmscourse_api_lms_course_id.py
@@ -1,0 +1,42 @@
+"""Backfill LMSCourse.api_lms_course_id."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9be518500f7d"
+down_revision = "cf20e70211f9"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+        WITH backfill as (
+            -- Deduplicate "grouping" courses on authority_provided_id
+            SELECT DISTINCT ON (authority_provided_id)
+                authority_provided_id,
+                extra->'canvas'->>'custom_canvas_course_id' as api_id
+            FROM "grouping"
+            -- Pick only courses, not sections or groups
+            WHERE grouping.type ='course'
+            -- Pick only courses with an API ID
+            AND extra->'canvas'->>'custom_canvas_course_id' IS NOT NULL
+            -- Pick the most recent "grouping" there are duplicates
+            ORDER BY authority_provided_id, "grouping".updated desc
+        )
+        UPDATE lms_course
+        SET
+            lms_api_course_id = backfill.api_id
+        FROM backfill
+        WHERE
+        lms_course.h_authority_provided_id = backfill.authority_provided_id
+        -- We are already inserting rows in lms_course in the python code, leave those alone
+        AND lms_course.lms_api_course_id IS NULL
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
For:

- https://github.com/hypothesis/lms/issues/6880

While this data was in the database as part of Grouping.extra we "promoted" it to its own column on LMSCourse to make it easier to query and index.

While we only have this now for canvas now the new column names is a generic one now


See: https://github.com/hypothesis/lms/pull/6944



### Testing 

- Launch a couple of assignment from different courses

https://hypothesis.instructure.com/courses/319/assignments/3308
https://hypothesis.instructure.com/courses/125/assignments/875


- Remove the ID set [by the previous PR](https://github.com/hypothesis/lms/pull/6944)

in `make sql`

```
update lms_course set lms_api_course_id = null;

UPDATE 2
```


- Run the migration to backfill the values back:

```tox -e dev --run-command 'alembic upgrade head'```


- Check the values have been indeed set again:

in `make sql`:


```
select name, lms_api_course_id from lms_course where lms_api_course_id is not null;


                    name                     | lms_api_course_id 
---------------------------------------------+-------------------
 LTI 1.3 Testing                             | 319
 Developer Test Course with Sections Enabled | 125
(2 rows)
```
