### PR TITLE
Check multiple VS SKUS for the student pay license check

### DIFF
--- a/lms/services/vitalsource/_client.py
+++ b/lms/services/vitalsource/_client.py
@@ -119,7 +119,12 @@ class VitalSourceClient:
             auth=_VSUserAuth(self, user_reference),
         )
 
-        LOG.debug("Result of license call for %s: %s", user_reference, result)
+        LOG.debug(
+            "Result of license call for sku:%s user:%s: %s",
+            book_id,
+            user_reference,
+            result,
+        )
 
         # The result is a list of active licenses that match the given book
         # ID/SKU.

--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -11,7 +11,7 @@ from lms.services.vitalsource.model import VSBookLocation
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    H_SKU = "HYPOTHESISLMSAPP"
+    H_SKUS = ["HYPOTHESISLMSAPP", "HYPOTHESISLMSAPPR180"]
     """
     SKU of the H app in the VitalSource store.
     Student pay schools will check students have a license for this SKU
@@ -215,7 +215,10 @@ class VitalSourceService:
             # Do the actual license check, only for students
             user_reference = self.get_user_reference(lti_params)
             assert self._sso_client
-            if not self._sso_client.get_user_book_license(user_reference, self.H_SKU):
+            for sku in self.H_SKUS:
+                if self._sso_client.get_user_book_license(user_reference, sku):
+                    return None
+            else:
                 return ErrorCode.VITALSOURCE_STUDENT_PAY_NO_LICENSE
 
         return None


### PR DESCRIPTION
The existing SKU was for a perpetual license but recently a new SKU for a limited duration.

While no new licenses are granted for the old sku existing students might only have that one.

This change adds a check for the new SKU if the old one is not found.


More context and details about the different skus on:

https://hypothes-is.slack.com/archives/C2BLQDKHA/p1737069466987259



### Testing

- We can't reproduce the exact scenario (fallback from the old SKU to the new one)  but we can test the general mechanisms.

- Use a student account eg: `eng+canvasstudent@hypothes.is`. We only do VS license checks for students.

- Open this assignment which is configured to use VS student pay

https://hypothesis.instructure.com/courses/638/assignments/6493


- You'll get the following on the console:

```
2025-01-21 17:42:22,732 DEBUG [lms.services.vitalsource._client:122][MainThread] R `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packagesesult of license call for sku:HYPOTHESISLMSAPP user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': {'license': [{'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sk.py:2825: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.u': 'HYPOTHESISLMSAPP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of': '', '@term': '', '@code-use': 'code-api' `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages, '@kind': 'Online Resource', '@type': 'online', '@expiration': 'Wed, 15 May 2024 13:11:14 GMT'}, {'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sku': 'HYPOTHESISLMSesult of license call for sku:HYPOTHESISLMSAPP user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': {'license': [{'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sku': 'HYPOTHESISLMSAPP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of'APP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of': '', '@term': '', '@code-use': 'code-api', '@kind': 'Online 'Wed, 15 May 2024 13:11:14 GMT'}, {'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sku': 'HYPOTHESISLMSAPP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of': '', '@term': '', '@code-use': 'code-api', '@kind': 'Online Resource', '@type':  Resource', '@type': 'download', '@expiration': 'Wed, 15 May 2024 13:11:14 GMT'}]}}
```

checking for one license and getting a successful response.

- Let apply a diff like:

```diff --git a/lms/services/vitalsource/service.py b/lms/services/vitalsource/service.py
index 3a0fbfcf4..f438fc7a0 100644
--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -11,7 +11,7 @@ from lms.services.vitalsource.model import VSBookLocation
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    H_SKUS = ["HYPOTHESISLMSAPP", "HYPOTHESISLMSAPPR180"]
+    H_SKUS = ["NOPE", "HYPOTHESISLMSAPP", "HYPOTHESISLMSAPPR180"]
     """
     SKU of the H app in the VitalSource store.
     Student pay schools will check students have a license for this SKU
```

and try again.


- This time we get a "no-license" result and then the same result as before


```
[lms.services.vitalsource._client:122][MainThread] Result of license call for sku:NOPE user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': None}
web (stderr)

[lms.services.vitalsource._client:122][MainThread] Result of license call for sku:HYPOTHESISLMSAPP user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': {'license': [{'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sku': 'HYPOTHESISLMSAPP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of': '', '@term': '', '@code-use': 'code-api', '@kind': 'Online Resource', '@type': 'online', '@expiration': 'Wed, 15 May 2024 13:11:14 GMT'}, {'@imprint': 'Hypothesis', '@publisher': 'Hypothesis', '@name': 'The Hypothesis LMS App', '@sku': 'HYPOTHESISLMSAPP', '@isbn': 'HYPOTHESISLMSAPP', '@part_of': '', '@term': '', '@code-use': 'code-api', '@kind': 'Online Resource', '@type': 'download', '@expiration': 'Wed, 15 May 2024 13:11:14 GMT'}]}}
```


- Finally let's try the case where we don't get access after checking all SKUS, with a diff like:


```diff --git a/lms/services/vitalsource/service.py b/lms/services/vitalsource/service.py
index 3a0fbfcf4..be74af582 100644
--- a/lms/services/vitalsource/service.py
+++ b/lms/services/vitalsource/service.py
@@ -11,7 +11,7 @@ from lms.services.vitalsource.model import VSBookLocation
 class VitalSourceService:
     """A high-level interface for dealing with VitalSource."""
 
-    H_SKUS = ["HYPOTHESISLMSAPP", "HYPOTHESISLMSAPPR180"]
+    H_SKUS = ["NOPE", "ABSOLUTELY NOT"]
     """
     SKU of the H app in the VitalSource store.
     Student pay schools will check students have a license for this SKU
(END)
```


- [Refresh the assignment](https://hypothesis.instructure.com/courses/638/assignments/6493).

- We get the expected two calls to the API with no licenses back:

```
[lms.services.vitalsource._client:122][MainThread] Result of license call for sku:NOPE user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': None}

[lms.services.vitalsource._client:122][MainThread] Result of license call for sku:ABSOLUTELY NOT user:2b04173b-1f12-42ea-aa87-5dd0b6ef2473: {'licenses': None}
```

- We get a modal about not having the license 

```Hypothesis isn't able to find your license from VitalSource```

