### PR TITLE
Ignore any non-token related API errors while fetching rosters

### DIFF
--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -604,6 +604,12 @@ class RosterService:
                 lms_course,
                 with_refresh_token=False,
             )
+        except CanvasAPIError:
+            LOG.info(
+                "Failed to fetch sections for course %s, API error",
+                lms_course.id,
+            )
+            return []
 
     def _refresh_canvas_token(
         self, canvas_service: CanvasAPIClient, oauth2_token_service

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -615,6 +615,19 @@ class TestRosterService:
         assert "error refreshing token" in caplog.records[0].message
 
     @pytest.mark.usefixtures("instructor_in_course", "canvas_section")
+    def test_fetch_canvas_sections_roster_failed_canvas_api_error(
+        self, svc, lms_course, canvas_api_client, db_session, caplog
+    ):
+        db_session.flush()
+
+        canvas_api_client.course_sections.side_effect = CanvasAPIError(refreshable=True)
+        canvas_api_client.get_refreshed_token.side_effect = CanvasAPIError
+
+        svc.fetch_canvas_sections_roster(lms_course)
+
+        assert "API error" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("instructor_in_course", "canvas_section")
     def test_fetch_canvas_sections_roster_with_invalid_token(
         self, svc, lms_course, canvas_api_client, db_session, caplog
     ):


### PR DESCRIPTION
Avoid noise on the logs when fetching rosters by ignoring any non-token related API errors.