### PR TITLE
Fix coverage on CI when multiple Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-python${{ matrix.python-version}}
           path: .coverage.*
           include-hidden-files: true
   Coverage:
@@ -137,7 +137,8 @@ jobs:
       - name: Download coverage files
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-python*
+          merge-multiple: true
       - run: python -m pip install 'tox<4'
       - run: tox -e coverage
   Functests:


### PR DESCRIPTION
Ported from the cookiecutter template, see:

https://github.com/hypothesis/cookiecutters/commit/659029705ec2d185c1ae1f9cb7155f3a80634e5b