### PR TITLE
Include last .gitignore changes from the cookiecutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+/build
 coverage
 node_modules
 yarn-error.log
@@ -11,6 +11,7 @@ supervisord.pid
 .DS_Store
 .devdata*
 .eslintcache
+*.tsbuildinfo
 .certificates
 tests/bdd/steps/_compiled_feature_steps.py
 


### PR DESCRIPTION
See:

- Add *.tsbuildinfo files to .gitignore

https://github.com/hypothesis/cookiecutters/commit/819732a9422e241bfe58afea1d3b6cc29a3ab727

- Only gitignore build directory at root of repository

https://github.com/hypothesis/cookiecutters/commit/9494fe534c5cde15f1dfe19d5b2f189fcc91ef40