### PR TITLE
Use the default worker for linting on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
-    runs-on: ubuntu-latest-32-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Python


### PR DESCRIPTION
This changes was made on the cookiecutter template but not actually applied to the main file