### PR TITLE
Store canvas terms info on the database

### DIFF
--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -1,4 +1,7 @@
 import logging
+from datetime import datetime
+
+from dateutil import parser
 
 CLAIM_PREFIX = "https://purl.imsglobal.org/spec/lti/claim"
 
@@ -25,6 +28,13 @@ class LTIParams(dict):
     @property
     def v11(self):
         return self
+
+    def get_datetime(self, key: str) -> datetime | None:
+        """Get a datetime from the LTI parameters."""
+        try:
+            return parser.isoparse(self.get(key))
+        except (TypeError, ValueError):
+            return None
 
     @classmethod
     def from_request(cls, request):

--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -28,6 +28,7 @@ from lms.services.launch_verifier import (
     LTILaunchVerificationError,
     LTIOAuthError,
 )
+from lms.services.lms_term import LMSTermService
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_names_roles import LTINamesRolesService
 from lms.services.lti_registration import LTIRegistrationService
@@ -164,6 +165,9 @@ def includeme(config):  # noqa: PLR0915
     )
     config.register_service_factory(
         "lms.services.auto_grading.factory", iface=AutoGradingService
+    )
+    config.register_service_factory(
+        "lms.services.lms_term.factory", iface=LMSTermService
     )
 
     # Plugins are not the same as top level services but we want to register them as pyramid services too

--- a/lms/services/lms_term.py
+++ b/lms/services/lms_term.py
@@ -1,0 +1,48 @@
+from lms.models import LMSTerm, LTIParams
+from lms.services.upsert import bulk_upsert
+
+
+class LMSTermService:
+    def __init__(self, db):
+        self._db = db
+
+    def get_term(self, lti_params: LTIParams) -> LMSTerm | None:
+        term_starts_at = lti_params.get_datetime("custom_term_start")
+        term_ends_at = lti_params.get_datetime("custom_term_end")
+        term_id = lti_params.get("custom_term_id")
+        term_name = lti_params.get("custom_term_name")
+        guid = lti_params["tool_consumer_instance_guid"]
+
+        if not any([term_starts_at, term_ends_at]):
+            # We need to have at least one date to consider a term.
+            return None
+
+        if term_id:
+            # If we get an ID from the LMS we'll use it as the key.
+            # We'll scope it the installs GUID
+            key = f"{guid}:{term_id}"
+        else:
+            # Otherwise we'll use the name and dates as part of the key
+            key = f"{guid}:{term_name if term_name else '-'}:{term_starts_at if term_starts_at else '-'}:{term_ends_at if term_ends_at else '-'}"
+
+        values = [
+            {
+                "name": term_name,
+                "tool_consumer_instance_guid": guid,
+                "starts_at": term_starts_at,
+                "ends_at": term_ends_at,
+                "key": key,
+                "lms_id": term_id,
+            }
+        ]
+        return bulk_upsert(
+            self._db,
+            model_class=LMSTerm,
+            values=values,
+            index_elements=["key"],
+            update_columns=["updated", "name", "starts_at", "ends_at"],
+        ).first()
+
+
+def factory(_context, request):
+    return LMSTermService(db=request.db)

--- a/tests/unit/lms/services/course_test.py
+++ b/tests/unit/lms/services/course_test.py
@@ -193,6 +193,7 @@ class TestCourseService:
         custom_course_ends,
         course_ends_at,
         custom_canvas_api_id,
+        lms_term_service,
     ):
         lti_params["custom_course_starts"] = custom_course_starts
         lti_params["custom_course_ends"] = custom_course_ends
@@ -233,6 +234,7 @@ class TestCourseService:
                             "starts_at": course_starts_at,
                             "ends_at": course_ends_at,
                             "lms_api_course_id": custom_canvas_api_id,
+                            "lms_term_id": lms_term_service.get_term.return_value.id,
                         }
                     ],
                     index_elements=["h_authority_provided_id"],
@@ -243,6 +245,7 @@ class TestCourseService:
                         "starts_at",
                         "ends_at",
                         "lms_api_course_id",
+                        "lms_term_id",
                     ],
                 ),
                 call().one(),
@@ -500,11 +503,12 @@ class TestCourseService:
         return grouping_service
 
     @pytest.fixture
-    def svc(self, db_session, application_instance, grouping_service):
+    def svc(self, db_session, application_instance, grouping_service, lms_term_service):
         return CourseService(
             db=db_session,
             application_instance=application_instance,
             grouping_service=grouping_service,
+            lms_term_service=lms_term_service,
         )
 
     @pytest.fixture
@@ -533,13 +537,16 @@ class TestCourseService:
 
 
 class TestCourseServiceFactory:
-    def test_it(self, pyramid_request, grouping_service, CourseService):
+    def test_it(
+        self, pyramid_request, grouping_service, CourseService, lms_term_service
+    ):
         svc = course_service_factory(sentinel.context, pyramid_request)
 
         CourseService.assert_called_once_with(
             db=pyramid_request.db,
             application_instance=pyramid_request.lti_user.application_instance,
             grouping_service=grouping_service,
+            lms_term_service=lms_term_service,
         )
 
         assert svc == CourseService.return_value

--- a/tests/unit/lms/services/lms_term_test.py
+++ b/tests/unit/lms/services/lms_term_test.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+from unittest.mock import sentinel
+
+import pytest
+
+from lms.services.lms_term import LMSTermService, factory
+
+
+class TestLMSTermService:
+    def test_get_term_not_enought_data(self, svc, pyramid_request):
+        assert not svc.get_term(pyramid_request.lti_params)
+
+    def test_get_term(self, svc, pyramid_request):
+        term_starts = datetime(2020, 1, 1)
+        term_ends = datetime(2020, 6, 1)
+        term_name = "NICE TERM"
+        lti_params = pyramid_request.lti_params
+        lti_params["custom_term_start"] = term_starts.isoformat()
+        lti_params["custom_term_end"] = term_ends.isoformat()
+        lti_params["custom_term_name"] = term_name
+
+        term = svc.get_term(pyramid_request.lti_params)
+
+        assert term.starts_at == term_starts
+        assert term.ends_at == term_ends
+        assert term.name == term_name
+        assert (
+            term.tool_consumer_instance_guid
+            == lti_params["tool_consumer_instance_guid"]
+        )
+
+    @pytest.mark.parametrize(
+        "name,start,end,term_id,expected",
+        [
+            (
+                "NICE TERM",
+                "2020-01-01 00:00:00",
+                "2020-06-01 00:00:00",
+                None,
+                "TEST_TOOL_CONSUMER_INSTANCE_GUID:NICE TERM:2020-01-01 00:00:00:2020-06-01 00:00:00",
+            ),
+            (
+                "NICE TERM",
+                None,
+                "2020-06-01 00:00:00",
+                None,
+                "TEST_TOOL_CONSUMER_INSTANCE_GUID:NICE TERM:-:2020-06-01 00:00:00",
+            ),
+            (
+                "NICE TERM",
+                "2020-01-01 00:00:00",
+                None,
+                None,
+                "TEST_TOOL_CONSUMER_INSTANCE_GUID:NICE TERM:2020-01-01 00:00:00:-",
+            ),
+            (
+                "NICE TERM",
+                "2020-01-01 00:00:00",
+                "2020-06-01 00:00:00",
+                "TERM_ID",
+                "TEST_TOOL_CONSUMER_INSTANCE_GUID:TERM_ID",
+            ),
+        ],
+    )
+    def test_get_term_key(
+        self, svc, pyramid_request, name, start, end, term_id, expected
+    ):
+        lti_params = pyramid_request.lti_params
+        lti_params["custom_term_start"] = start
+        lti_params["custom_term_end"] = end
+        lti_params["custom_term_name"] = name
+        lti_params["custom_term_id"] = term_id
+
+        term = svc.get_term(pyramid_request.lti_params)
+
+        assert term.key == expected
+
+    @pytest.fixture()
+    def svc(self, pyramid_request):
+        return LMSTermService(db=pyramid_request.db)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, LMSTermService):
+        service = factory(sentinel.context, pyramid_request)
+
+        LMSTermService.assert_called_once_with(db=pyramid_request.db)
+        assert service == LMSTermService.return_value
+
+    @pytest.fixture
+    def LMSTermService(self, patch):
+        return patch("lms.services.lms_term.LMSTermService")

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -37,6 +37,7 @@ from lms.services.jstor import JSTORService
 from lms.services.jwt import JWTService
 from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
 from lms.services.launch_verifier import LaunchVerifier
+from lms.services.lms_term import LMSTermService
 from lms.services.lti_grading import LTIGradingService
 from lms.services.lti_h import LTIHService
 from lms.services.lti_names_roles import LTINamesRolesService
@@ -89,6 +90,7 @@ __all__ = (
     "jwt_service",
     "jwt_oauth2_token_service",
     "launch_verifier",
+    "lms_term_service",
     "lti_grading_service",
     "lti_h_service",
     "lti_names_roles_service",
@@ -354,6 +356,11 @@ def lti_names_roles_service(mock_service):
 @pytest.fixture
 def lti_registration_service(mock_service):
     return mock_service(LTIRegistrationService)
+
+
+@pytest.fixture
+def lms_term_service(mock_service):
+    return mock_service(LMSTermService)
 
 
 @pytest.fixture


### PR DESCRIPTION
We'll start storing this data based on launches that contain the lastest Canvas configuration, which includes variables about terms.

This will allow us to build a backlog of courses with start and end dates.

We recently did a similar job to store course dates, which in Canvas means courses that don't belong to a term. In combination this commit this should give us coverage of all LTI1.3 courses for schools that have the most recent configuration.

See: https://github.com/hypothesis/lms/pull/6941

--- 


## Testing


- Apply the migration 



```
tox -e dev --run-command 'alembic upgrade head' 
  
dev run-test-pre: PYTHONHASHSEED='4055832553'
dev run-test-pre: commands[0] | pip-sync-faster requirements/dev.txt --pip-args --disable-pip-version-check
dev run-test: commands[0] | alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 9be518500f7d -> a8fd48c30957, Create the lms_term table.
```


- Launch an assignment that won't send term information:

https://hypothesis.instructure.com/courses/125/assignments/1833

- Everything looks good, nothing gets created on the DB.

- Launch an assignment that does send term information

https://hypothesis.instructure.com/courses/319/assignments/3308


- Check the DB for the new data:

```
select lms_course.name, lms_term.name, lms_term.starts_at, lms_term.ends_at from lms_term join lms_course on lms_term.id = lms_term_id;
      name       |     name     | starts_at |       ends_at       
-----------------+--------------+-----------+---------------------
 LTI 1.3 Testing | Default Term |           | 2027-04-30 06:00:00
(1 row)
```