### PR TITLE
Add extra logging around the Canvas API call groups endpoint

### DIFF
--- a/lms/services/canvas_api/factory.py
+++ b/lms/services/canvas_api/factory.py
@@ -55,4 +55,5 @@ def canvas_api_client_factory(
         folders_enabled=application_instance.settings.get(
             "canvas", "folders_enabled", default=False
         ),
+        application_instance=application_instance,
     )

--- a/tests/unit/lms/services/canvas_api/client_test.py
+++ b/tests/unit/lms/services/canvas_api/client_test.py
@@ -691,7 +691,10 @@ class TestCanvasAPIClientIntegrated:
 
 
 @pytest.fixture
-def canvas_api_client(authenticated_client, file_service):
+def canvas_api_client(authenticated_client, file_service, application_instance):
     return CanvasAPIClient(
-        authenticated_client, file_service, pages_client=sentinel.pages_client
+        authenticated_client,
+        file_service,
+        pages_client=sentinel.pages_client,
+        application_instance=application_instance,
     )

--- a/tests/unit/lms/services/canvas_api/factory_test.py
+++ b/tests/unit/lms/services/canvas_api/factory_test.py
@@ -39,6 +39,7 @@ class TestCanvasAPIClientFactory:
             file_service=file_service,
             pages_client=CanvasPagesClient.return_value,
             folders_enabled=folders_enabled,
+            application_instance=application_instance,
         )
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,
@@ -79,6 +80,7 @@ class TestCanvasAPIClientFactory:
             file_service=file_service_factory.return_value,
             pages_client=CanvasPagesClient.return_value,
             folders_enabled=False,
+            application_instance=application_instance,
         )
         AuthenticatedClient.assert_called_once_with(
             basic_client=BasicClient.return_value,


### PR DESCRIPTION
We suspect different permissions and roles configuration at schools affect the resulting payload.

Log the API call results to confirm this.


More context about the issue we are finding at: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1737729175299909


### Testing

- Launch a groups assignment https://hypothesis.instructure.com/courses/125/assignments/1833

- Click the "Speed grader" button on the top right corner.

- Check the new logging line on the server


```
Canvas API. Course groups. 'include_users'=True. 'application_instance_id'=8
```