### PR TITLE
Configure new canvas instances to send term IDs

### DIFF
--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -84,6 +84,7 @@ def config_json(request):
             "custom_context_id_history": "$Context.id.history",
             "custom_course_starts": "$Canvas.course.startAt",
             "custom_course_ends": "$Canvas.course.endAt",
+            "custom_term_id": "$Canvas.term.id",
             "custom_term_name": "$Canvas.term.name",
             "custom_term_start": "$Canvas.term.startAt",
             "custom_term_end": "$Canvas.term.endAt",

--- a/tests/unit/lms/views/canvas/config_test.py
+++ b/tests/unit/lms/views/canvas/config_test.py
@@ -53,6 +53,7 @@ class TestConfigJSON:
                 "custom_context_id_history": "$Context.id.history",
                 "custom_course_starts": "$Canvas.course.startAt",
                 "custom_course_ends": "$Canvas.course.endAt",
+                "custom_term_id": "$Canvas.term.id",
                 "custom_term_name": "$Canvas.term.name",
                 "custom_term_start": "$Canvas.term.startAt",
                 "custom_term_end": "$Canvas.term.endAt",


### PR DESCRIPTION
Configure new canvas instances to include the missing term ID variable on launches.

This endpoint is used while configuring new LTI1.3 installs. Instead copy pasting or manually entering the LTI configuration Canvas can fetch it from this endpoint.

Include the new variable so new install have it moving forward. 

This value is not yet read anywhere in the code base.