### PR TITLE
Fix only first page being loaded in PaginatedMultiSelect

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
@@ -100,7 +100,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
       containerClasses="!w-auto min-w-44"
       buttonContent={buttonContent}
       data-testid={`${entity}-select`}
-      onListboxScroll={e => {
+      onPopoverScroll={e => {
         const element = e.target as HTMLUListElement;
         const newScrollPosition = element.scrollTop;
         const isScrollingDown =

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/PaginatedMultiSelect-test.js
@@ -76,7 +76,7 @@ describe('PaginatedMultiSelect', () => {
     }
 
     function scrollTo(select, { scrollHeight, scrollTop = 100 }) {
-      select.props().onListboxScroll({
+      select.props().onPopoverScroll({
         target: {
           clientHeight: 50,
           scrollTop,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.12.0",
+    "@hypothesis/frontend-shared": "^8.16.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,15 +1996,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.12.0":
-  version: 8.12.0
-  resolution: "@hypothesis/frontend-shared@npm:8.12.0"
+"@hypothesis/frontend-shared@npm:^8.16.1":
+  version: 8.16.1
+  resolution: "@hypothesis/frontend-shared@npm:8.16.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 900be36b83fa0b73f1705ac6b774414b0ca8a6c779d0e3d96390212c2cb317071d5d8bbf1c771b11ff9e1e040c89972e8a716c3f5d0a0188b5ef6943eaab3c37
+  checksum: 9c1037d4e8f10ad8423e244a75d1f5c1000433b0f519fc87c43dff51cf570d6dc702838dc188cd63c5a3f7a821e0d95ef2114eb2788fded2d30813a915228628
   languageName: node
   linkType: hard
 
@@ -7297,7 +7297,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@babel/preset-typescript": ^7.26.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.12.0
+    "@hypothesis/frontend-shared": ^8.16.1
     "@hypothesis/frontend-testing": ^1.3.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.1


### PR DESCRIPTION
> Part of https://github.com/hypothesis/support/issues/178
> Depends on https://github.com/hypothesis/frontend-shared/pull/1864

Use the fixes introduced in https://github.com/hypothesis/frontend-shared/pull/1864 to ensure all pages are loaded in `PaginatedMultiSelect` as you scroll down.

### Test steps

1. Go to https://hypothesis.instructure.com/courses/319/assignments and log in as instructor
2. Launch a "bunch" of localhost assignments from there, to build a relatively long list.
3. Go to http://localhost:8001/dashboard/courses/1. You should see all assignments you lunched listed there, and they should also show in the "Assignments" dropdown.
4. Apply this diff, which does two things: a) reduce the items per page returned by paginated API calls and b) reduce the size of Select popovers, so that scroll appears even with very few items on it.
    ```diff
    diff --git a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
    index 384219a3a..f5613e0b0 100644
    --- a/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
    +++ b/lms/static/scripts/frontend_apps/components/dashboard/PaginatedMultiSelect.tsx
    @@ -98,6 +98,7 @@ export default function PaginatedMultiSelect<TResult, TSelect>({
           onChange={onChange}
           aria-label={`Select ${entity}`}
           containerClasses="!w-auto min-w-44"
    +      popoverClasses="!max-h-24"
           buttonContent={buttonContent}
           data-testid={`${entity}-select`}
           onPopoverScroll={e => {
    diff --git a/lms/views/dashboard/pagination.py b/lms/views/dashboard/pagination.py
    index 38325e270..a865d88f8 100644
    --- a/lms/views/dashboard/pagination.py
    +++ b/lms/views/dashboard/pagination.py
    @@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
     T = TypeVar("T")
     
     
    -MAX_ITEMS_PER_PAGE = 100
    +MAX_ITEMS_PER_PAGE = 3
     """Maximum number of items to return in paginated endpoints"""
    ```
5. Open the assignments dropdown, which should only show three assignments. Scroll down and observe how new pages continue loading until all assignments are there.

In `main`, if you apply the same diff, you'll see how only the first page of assignments is loaded even if you scroll.

> [!WARNING] 
> There's an unrelated issue with students when loaded from the the roster, where we seem to be returning the first page on every request, even when a cursor is provided.
> This PR does not cover fixing that.