### PR TITLE
Follow pagination links on the LTI names and roles API responses

### DIFF
--- a/tests/unit/lms/services/lti_names_roles_test.py
+++ b/tests/unit/lms/services/lti_names_roles_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import sentinel
+from unittest.mock import Mock, call, sentinel
 
 import pytest
 
@@ -7,6 +7,8 @@ from lms.services.lti_names_roles import LTINamesRolesService, factory
 
 class TestLTINameRolesServices:
     def test_get_context_memberships(self, svc, ltia_http_service, lti_registration):
+        ltia_http_service.request.return_value.links = {}
+
         memberships = svc.get_context_memberships(
             lti_registration, sentinel.service_url
         )
@@ -19,16 +21,62 @@ class TestLTINameRolesServices:
             headers={
                 "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
             },
-            params={},
+            params={"limit": 100},
         )
         assert (
             memberships
             == ltia_http_service.request.return_value.json.return_value["members"]
         )
 
+    def test_get_context_memberships_multiple_pages(
+        self, svc, ltia_http_service, lti_registration
+    ):
+        ltia_http_service.request.side_effect = [
+            Mock(
+                links={"next": {"url": sentinel.next_url}},
+                json=Mock(return_value={"members": [sentinel.member_1]}),
+            ),
+            Mock(
+                links={},
+                json=Mock(return_value={"members": [sentinel.member_2]}),
+            ),
+        ]
+
+        memberships = svc.get_context_memberships(
+            lti_registration, sentinel.service_url
+        )
+
+        ltia_http_service.request.assert_has_calls(
+            [
+                call(
+                    lti_registration,
+                    "GET",
+                    sentinel.service_url,
+                    scopes=LTINamesRolesService.LTIA_SCOPES,
+                    headers={
+                        "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
+                    },
+                    params={"limit": 100},
+                ),
+                call(
+                    lti_registration,
+                    "GET",
+                    sentinel.next_url,
+                    scopes=LTINamesRolesService.LTIA_SCOPES,
+                    headers={
+                        "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
+                    },
+                    params={"limit": 100},
+                ),
+            ]
+        )
+        assert memberships == [sentinel.member_1, sentinel.member_2]
+
     def test_get_context_memberships_with_resource_link_id(
         self, svc, ltia_http_service, lti_registration
     ):
+        ltia_http_service.request.return_value.links = {}
+
         memberships = svc.get_context_memberships(
             lti_registration, sentinel.service_url, sentinel.resource_link_id
         )
@@ -41,7 +89,7 @@ class TestLTINameRolesServices:
             headers={
                 "Accept": "application/vnd.ims.lti-nrps.v2.membershipcontainer+json"
             },
-            params={"rlid": sentinel.resource_link_id},
+            params={"rlid": sentinel.resource_link_id, "limit": 100},
         )
         assert (
             memberships


### PR DESCRIPTION
Pagination was missing on the original name and roles service implementation and never added when used for rostering. 


### Testing

- Apply a diff like:

```diff --git a/lms/services/lti_names_roles.py b/lms/services/lti_names_roles.py
index 55a539ef0..7a50d40c1 100644
--- a/lms/services/lti_names_roles.py
+++ b/lms/services/lti_names_roles.py
@@ -41,7 +41,7 @@ class LTINamesRolesService:
         service_url: str,
         resource_link_id: str | None = None,
         max_pages: int = 10,
-        limit: int = 100,
+        limit: int = 5,
     ) -> list[Member]:
         """
         Get the roster for a course or assignment.
```

- Remove local rosters, in `make sql`:


```truncate course_roster, task_done CASCADE;```


- Launch any LTI1.3 assignment


https://hypothesis.instructure.com/courses/319/assignments/3308


- Schedule roster fetching, in `make shell`

```
from lms.tasks.roster import schedule_fetching_rosters  
schedule_fetching_rosters.delay() 
```

- In the console you'll see the new pagination logging:

```
worker (stderr)      | [2025-01-31 12:13:53,539: INFO/ForkPoolWorker-2] lms.tasks.roster.fetch_course_roster[6cf3caa7-03db-46f6-8533-8204a61fd9dd] Fetching next page of members https://hypothesis.instructure.com/api/lti/courses/319/names_and_roles?page=2&per_page=5
worker (stderr)      | [2025-01-31 12:13:53,758: INFO/ForkPoolWorker-2] lms.tasks.roster.fetch_course_roster[6cf3caa7-03db-46f6-8533-8204a61fd9dd] Fetching next page of members https://hypothesis.instructure.com/api/lti/courses/319/names_and_roles?page=3&per_page=5
worker (stderr)      | [2025-01-31 12:13:53,963: INFO/ForkPoolWorker-2] lms.tasks.roster.fetch_course_roster[6cf3caa7-03db-46f6-8533-8204a61fd9dd] Fetching next page of members https://hypothesis.instructure.com/api/lti/courses/319/names_and_roles?page=4&per_page=5
worker (stderr)      | [2025-01-31 12:13:54,182: INFO/ForkPoolWorker-2] lms.tasks.roster.fetch_course_roster[6cf3caa7-03db-46f6-8533-8204a61fd9dd] Fetching next page of members https://hypothesis.instructure.com/api/lti/courses/319/names_and_roles?page=5&per_page=5
```