### PR TITLE
Handle `None` required replies

### DIFF
--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -104,8 +104,8 @@ class AutoGradingService:
                 else:
                     grade = 0
             case ("all_or_nothing", "separate"):
-                assert auto_grading_config.required_replies is not None, (
-                    "'separate' auto grade config with empty replies"
+                auto_grading_config.required_replies = (
+                    auto_grading_config.required_replies or 0
                 )
                 if (
                     annotation_metrics["annotations"]
@@ -121,8 +121,8 @@ class AutoGradingService:
                 grade = combined_count / auto_grading_config.required_annotations
 
             case ("scaled", "separate"):
-                assert auto_grading_config.required_replies is not None, (
-                    "'separate' auto grade config with empty replies"
+                auto_grading_config.required_replies = (
+                    auto_grading_config.required_replies or 0
                 )
                 # Let's make sure we do not count annotations or replies above the requirement, otherwise, a person
                 # with 6 replies and 0 annotations on an assignment which requires 3 of each would get a 100% grade,

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -115,6 +115,8 @@ class TestAutoGradingService:
             ("all_or_nothing", "cumulative", 15, None, 10, 6, 1),
             ("all_or_nothing", "separate", 10, 5, 10, 4, 0),
             ("all_or_nothing", "separate", 10, 5, 10, 5, 1),
+            ("all_or_nothing", "separate", 10, 0, 9, 4, 0),
+            ("all_or_nothing", "separate", 10, None, 9, 4, 0),
             ("scaled", "cumulative", 15, None, 5, 5, 0.67),
             ("scaled", "cumulative", 15, None, 10, 10, 1),
             ("scaled", "separate", 10, 5, 8, 2, 0.67),
@@ -122,6 +124,8 @@ class TestAutoGradingService:
             # In scaled+separate cases, extra annos/replies should be ignored
             ("scaled", "separate", 3, 2, 0, 3, 0.4),
             ("scaled", "separate", 5, 5, 12, 2, 0.7),
+            ("scaled", "separate", 5, 0, 5, 2, 1),
+            ("scaled", "separate", 5, None, 5, 2, 1),
         ],
     )
     def test_calculate_grade(


### PR DESCRIPTION
The code alreayd handles 0 required replies correctly, but it was deliberately ignoring the None value.

Assign a 0 to the None value to complete the calculation