### PR TITLE
Deduplicate students from Canvas sections API response

### DIFF
--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -447,12 +447,16 @@ class RosterService:
                 )
                 continue
 
-            for student in api_section.get("students", []) or []:
-                db_student = db_course_users_by_lms_api_id.get(str(student["id"]))
+            # We use a set here to avoid any pontential duplicates in the API response.
+            student_ids = {
+                str(student["id"]) for student in api_section.get("students", [])
+            }
+            for student_id in student_ids:
+                db_student = db_course_users_by_lms_api_id.get(student_id)
                 if not db_student:
                     LOG.debug(
                         "Skiping roster entry for student ID:%s. Not found the DB",
-                        student["id"],
+                        student_id,
                     )
                     continue
 

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -536,11 +536,13 @@ class TestRosterService:
                 "students": [
                     # Student that matches student_in_course, the student in the DB
                     {"id": student_in_course.lms_api_user_id},
+                    # Duplicate student, should be ignored
+                    {"id": student_in_course.lms_api_user_id},
                     # Student that doesn't match any student in the DB
                     {"id": "SOME OTHER USER"},
                 ],
             },
-            # Section we haven't seend before in teh DB
+            # Section we haven't seen before in the DB
             {"id": "SOME OTHER SECTION"},
         ]
 


### PR DESCRIPTION
These are causing:

```
CardinalityViolation: ON CONFLICT DO UPDATE command cannot affect row a second time
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
```


See:


https://hypothesis.sentry.io/issues/6238959334/?environment=prod&project=259908&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=2


I've not been able to reproduce this with real data, but the new test cases do fail with the same exception on `main` so this looks like the right fix.