### PR TITLE
Always use the error template for unexpected exceptions

### DIFF
--- a/lms/views/exceptions.py
+++ b/lms/views/exceptions.py
@@ -105,6 +105,11 @@ class ExceptionViews:
 
     @exception_view_config(context=Exception)
     def error(self):
+        # Always use the error template.
+        # Depending on when the exception has happened,
+        # the renderer might be set to a different one
+        self.request.override_renderer = "lms:templates/error.html.jinja2"
+
         LOG.exception("Unexpected error %s", type(self.exception))
         return self.error_response(
             500,


### PR DESCRIPTION
Depending on when the exception has happened,
the renderer might be set to a different one.

Use the override to always use the basic error template.


Relevant conversation: https://hypothes-is.slack.com/archives/C2C2U40LW/p1738361139273649

This is very similar to https://github.com/hypothesis/lms/pull/6997 but for any type of error


## Testing

- First in `main`

- Apply a diff like:

```diff 
--git a/lms/services/ltia_http.py b/lms/services/ltia_http.py
index f4fd27a78..c118bb4df 100644
--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -93,6 +93,9 @@ class LTIAHTTPService:
 
         try:
             token_data = response.json()
+            1 / 0
         except JSONDecodeError as err:  # pragma: no cover
             LOG.error("Non-json response: %s", response.text)
             raise SerializableError(
```


- Launch a gradable D2L assignment as any instructor

https://aunltd.brightspacedemo.com/d2l/le/content/6782/viewContent/3348/View?ou=6782


- You'll get an error like:


![Screenshot from 2025-02-04 13-58-17](https://github.com/user-attachments/assets/1acb88c0-2d82-4f08-a74a-c2c6ae2578e4)



- Switch to this branch, refresh the assignment:

![Screenshot from 2025-02-04 15-37-38](https://github.com/user-attachments/assets/28893576-5f4a-4d0e-b3f2-81952dcb9028)


You'll get now an error message, not much details here but we do log the exception and it should appear on sentry. The user doesn't get the confusing 404 error.
