### PR TITLE
Ignore error when fetching assignment roster

### DIFF
--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -243,6 +243,8 @@ class RosterService:
                 in err.response_body
                 # Canvas, assignment deleted in the LMS
                 or "Requested ResourceLink was not found" in err.response_body
+                or "Requested assignment not configured for external tool launches"
+                in err.response_body
             ):
                 LOG.error("Fetching assignment roster failed: %s", err.response_body)
                 # We ignore this type of error, just stop here.

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -394,6 +394,7 @@ class TestRosterService:
         [
             "Requested ResourceLink bound to unexpected external tool",
             "Requested ResourceLink was not found",
+            "Requested assignment not configured for external tool launches",
         ],
     )
     def test_fetch_assignment_roster_retries_with_lti_v11_id(


### PR DESCRIPTION
We can't do about it and it's only adding noise on the logs/sentry.

We'll still log a message about it in case we need to debug these:

"Requested assignment not configured for external tool launches"