### PR TITLE
Ignore API exceptions while listing files for course copy

### DIFF
--- a/lms/product/plugin/course_copy.py
+++ b/lms/product/plugin/course_copy.py
@@ -8,7 +8,7 @@ from lms.services.group_set import GroupSetService
 
 
 class CourseCopyFilesHelper:
-    """Helper class to abstract common behaviour around LMS file / course copy."""
+    """Helper class to abstract common behavior around LMS file / course copy."""
 
     def __init__(self, file_service: FileService):
         self._file_service = file_service
@@ -38,7 +38,7 @@ class CourseCopyFilesHelper:
             # We might not have access to use the API for that endpoint.
             # That will depend on our role and the course's permissions settings.
             # We will continue anyway, maybe the files of the new course are already in the DB
-            # after an instructor launched corrected the issue.
+            # after an instructor launch corrected the issue.
             pass
 
         # We get the original file record from the DB


### PR DESCRIPTION
In cases where for example students don't have access to list files this allows the course copy process to continue using the information in our DB.

If the course copy ultimately fails we'll raise an exception for that particular situation.


### How is course copy for canvas file supposed to work?

1. At some point an instructor configures a file assignment in the original course.
2. We store all the files in that course in the DB, including the one selected for the assignment
3. The course gets copied in the LMS
4. A new instructor launches the new course
5. We realize the assignment is configured with a file ID that's not in the new course
6. We fetch all the files in the new course.
7. We match, based on the info we have now on the DB, the old file to the new file (for example based on name).
8. We store a map of new file to old file to avoid repeating this process.


However, step 6 will not be possible for students in courses where students don't have access to list files.

This commit  ignores failures during that step and continues trying to find a map between files. That is possible if an instructor has launched any assignment before the student.

If for some reason we can't find a map between files (ie no instructor has launched prior to the student) we'll still generate the same error dialog we were displaying before.



## Testing 


Testing course copy is a bit more convoluted that other features as it requires multiple courses and users. 

#### Let's first replicate the issue in `main`.


- Truncate your assignments table
 
`docker compose exec postgres psql -U postgres -c "truncate assignment cascade;"`

this is what we store the mapping info from old file id to new file id.


- List the files in the original course. In real conditions this would happen when the instructor  created the original assignments.

Use `eng+canvasteacher@hypothes.is` as the instructor for this step.

In any of the original course assignments, for example:


https://hypothesis.instructure.com/courses/125/assignments/7412/edit?name=Assignment%20creation%20-%20test%20&due_at=&points_possible=0&post_to_sis=false

go to `External Tool Options`->`Find`

select `Hypothesis
localhost (make devdata) with Sections Enabled`

and pick "Canvas File" in our filepicker. Just listing the files there will suffice, they are stored on the DB at that point.


- Switch to a different instructor, `eng+coursecopyteacher` this is the instructor in the new course that's not part of the original one.



- Launch an assignment on the new course, for example:


https://hypothesis.instructure.com/courses/733/assignments/8850

- The assignment launches correctly and we get a record of the map between files in the DB:


```
select title, extra from assignment order by updated desc limit 1;
                      title                       |                              extra                              
--------------------------------------------------+-----------------------------------------------------------------
 localhost (make devdata) Canvas Files Assignment | {"group_set_id": null, "canvas_file_mappings": {"802": "6712"}}
(1 row)
```


- Login now as a student `eng+coursecopystudent`


- Launch the same assignment you launched as the instructor


https://hypothesis.instructure.com/courses/733/assignments/8850


this is successful, we are relying on the the mapping created th by the teacher.


- Launch a different canvas files assignment as the student

https://hypothesis.instructure.com/courses/733/assignments/8853


This now fails, we try to list the files as the student and we fail.


- Switch to this branch `course-copy-ignore-exception`

- Launch the same assignment again  

https://hypothesis.instructure.com/courses/733/assignments/8853


It's successful this time.


