### PR TITLE
Don't clear lti_v11_lis_result_sourcedid when updating

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, func, select, text
 from sqlalchemy.orm import Session
 
 from lms.models import (
@@ -244,7 +244,18 @@ class AssignmentService:
                 model_class=LMSUserAssignmentMembership,
                 values=values,
                 index_elements=["lms_user_id", "assignment_id", "lti_role_id"],
-                update_columns=["updated", "lti_v11_lis_result_sourcedid"],
+                update_columns=[
+                    "updated",
+                    (
+                        "lti_v11_lis_result_sourcedid",
+                        func.coalesce(
+                            text('"excluded"."lti_v11_lis_result_sourcedid"'),
+                            text(
+                                '"lms_user_assignment_membership"."lti_v11_lis_result_sourcedid"'
+                            ),
+                        ),
+                    ),
+                ],
             )
         )
 


### PR DESCRIPTION
If we already have a value for lti_v11_lis_result_sourcedid in the DB don't overwrite it with a null value.

It's not entirely clear in which situations we'll get a None value after having already one in the DB but we have seen this happening in the wild.

Slack thread with more details:

https://hypothes-is.slack.com/archives/C2BLQDKHA/p1738852258730769?thread_ts=1738849292.643179&cid=C2BLQDKHA


## Testing 

Unfortunately I don't know how to replicate the LMS sending a null value here. I reckon the unit test does a good job here thought.