### PR TITLE
Fix linting after ruff rules update

### DIFF
--- a/tests/unit/lms/views/dashboard/api/assignment_test.py
+++ b/tests/unit/lms/views/dashboard/api/assignment_test.py
@@ -178,7 +178,6 @@ class TestAssignmentViews:
         h_api,
         db_session,
         dashboard_service,
-        user_service,
         assignments_metrics_response,
         assignment,
     ):


### PR DESCRIPTION
This changes was made in a brach not rebased with the latest rule selection in `main`.