### PR TITLE
Catch OAuth2Error while refreshing token for section roster

### DIFF
--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -625,7 +625,7 @@ class RosterService:
         try:
             refresh_token = oauth2_token_service.get().refresh_token
             canvas_service.get_refreshed_token(refresh_token)
-        except (ConcurrentTokenRefreshError, CanvasAPIError):
+        except (ConcurrentTokenRefreshError, CanvasAPIError, OAuth2TokenError):
             return False
 
         return True


### PR DESCRIPTION
OAuth2Error was missing in the except block while refreshing the token for section roster. This PR adds the missing exception to the except block, together with: ConcurrentTokenRefreshError and CanvasAPIError.