### PR TITLE
Add TEST_USER as a possible role type

### DIFF
--- a/lms/models/lti_role.py
+++ b/lms/models/lti_role.py
@@ -20,6 +20,7 @@ class RoleType(StrEnum):
     LEARNER = "learner"
     ADMIN = "admin"
     NONE = "none"
+    TEST_USER = "test_user"
 
 
 @unique
@@ -168,6 +169,7 @@ class _RoleParser:
         "SysSupport": RoleType.ADMIN,
         "TeachingAssistant": RoleType.INSTRUCTOR,
         "User": RoleType.LEARNER,
+        "TestUser": RoleType.TEST_USER,
     }
 
     @classmethod

--- a/tests/unit/lms/models/lti_role_test.py
+++ b/tests/unit/lms/models/lti_role_test.py
@@ -193,7 +193,7 @@ class TestLTIRole:
             ),
             (
                 "http://purl.imsglobal.org/vocab/lti/system/person#TestUser",
-                RoleType.LEARNER,
+                RoleType.TEST_USER,
                 RoleScope.SYSTEM,
             ),
         ],


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1595

This role is always found in combination with other role so this change shouldn't have
an immediate impact on the system.

From the spec:

https://www.imsglobal.org/spec/lti/v1p3#lti-vocabulary-for-system-roles

This is a marker role to be used in conjunction with a "real" role.
It indicates this user is created by the platform for testing different user scenarios.