### PR TITLE
Simplify get_users_for_course to take LMSCourse instead of Grouping.id

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -259,7 +259,7 @@ class DashboardService:
             query = self._user_service.get_users_for_course(
                 role_scope=RoleScope.COURSE,
                 role_type=RoleType.LEARNER,
-                course_id=lms_course.course.id,
+                lms_course=lms_course,
                 h_userids=h_userids,
                 # For launch data we always add the "active" column as true for compatibility with the roster query.
             ).add_columns(true())

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -191,7 +191,7 @@ class UserService:
         self,
         role_scope: RoleScope,
         role_type: RoleType,
-        course_id: int,
+        lms_course: LMSCourse,
         h_userids: list[str] | None = None,
     ) -> Select[tuple[LMSUser]]:
         """Get the users that belong to one course."""
@@ -203,13 +203,8 @@ class UserService:
                 LMSCourseMembership.lms_user_id == LMSUser.id,
             )
             .join(LMSCourse, LMSCourse.id == LMSCourseMembership.lms_course_id)
-            # course_id is the PK on Grouping, we need to join with LMSCourse by authority_provided_id
-            .join(
-                Grouping,
-                Grouping.authority_provided_id == LMSCourse.h_authority_provided_id,
-            )
             .where(
-                Grouping.id == course_id,
+                LMSCourseMembership.lms_course_id == lms_course.id,
                 LMSCourseMembership.lti_role_id.in_(
                     select(LTIRole.id).where(
                         LTIRole.scope == role_scope, LTIRole.type == role_type

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -332,7 +332,7 @@ class TestDashboardService:
             user_service.get_users_for_course.assert_called_once_with(
                 role_scope=RoleScope.COURSE,
                 role_type=RoleType.LEARNER,
-                course_id=lms_course.course.id,
+                lms_course=lms_course,
                 h_userids=sentinel.h_userids,
             )
             assert not last_updated

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -164,7 +164,7 @@ class TestUserService:
         query = service.get_users_for_course(
             role_scope=RoleScope.COURSE,
             role_type=RoleType.LEARNER,
-            course_id=course.id,
+            lms_course=course.lms_course,
             h_userids=[student_in_assignment.h_userid] if with_h_userids else None,
         )
 


### PR DESCRIPTION
This simplifies the query and makes for a more clear method signature.