### PR TITLE
Make each of the schedule_* roster functions celery tasks

### DIFF
--- a/lms/tasks/roster.py
+++ b/lms/tasks/roster.py
@@ -22,7 +22,7 @@ LAUNCHED_WINDOW = timedelta(hours=24)
 """How recent we need to have seen a launch from a course/assignment before we stop fetching rosters for it."""
 
 ROSTER_REFRESH_WINDOW = timedelta(hours=24 * 3)
-"""How frequenly should we fetch roster for the same course/assignment/segment"""
+"""How frequently should we fetch roster for the same course/assignment/segment"""
 
 ROSTER_LIMIT = 50
 """How many rosters should we fetch per execution of the schedule task."""
@@ -35,6 +35,7 @@ def schedule_fetching_rosters() -> None:
     schedule_fetching_segment_rosters()
 
 
+@app.task()
 def schedule_fetching_course_rosters() -> None:
     """Schedule fetching course rosters based on their last lunches and the most recent roster fetch."""
 
@@ -95,6 +96,7 @@ def schedule_fetching_course_rosters() -> None:
                 )
 
 
+@app.task()
 def schedule_fetching_assignment_rosters() -> None:
     """Schedule fetching assignment rosters based on their last lunches and the most recent roster fetch."""
 
@@ -159,6 +161,7 @@ def schedule_fetching_assignment_rosters() -> None:
                 )
 
 
+@app.task()
 def schedule_fetching_segment_rosters() -> None:
     """Schedule fetching segment rosters based on their last lunches and the most recent roster fetch."""
 


### PR DESCRIPTION
While we don't call these as celery tasks in production it's handy to have the possibility to do so in local testing.


### Testing

- In `make shell`, schedule the full roster fetching, as before:

```
from lms.tasks import roster
roster.schedule_fetching_rosters.delay()
```

but now you can also do it for only assignments for example:


```
roster.schedule_fetching_assignment_rosters.delay()
```