### PR TITLE
Retry Canvas submission on timeout

### DIFF
--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -254,6 +254,7 @@ export default function BasicLTILaunchApp() {
           authToken,
           path: '/api/lti/submissions',
           data: submissionParams,
+          maxRetries: 2,
         });
       } catch (e) {
         // If reporting the submission failed, show a modal error dialog above

--- a/lms/static/scripts/frontend_apps/components/test/BasicLTILaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLTILaunchApp-test.js
@@ -453,6 +453,7 @@ describe('BasicLTILaunchApp', () => {
       const apiCall = fakeApiCall.getCall(0);
       assert.deepEqual(apiCall.args[0], {
         authToken: 'dummyAuthToken',
+        maxRetries: 2,
         path: '/api/lti/submissions',
         data: {
           submitted_at: undefined,
@@ -596,6 +597,7 @@ describe('BasicLTILaunchApp', () => {
               const apiCall = fakeApiCall.getCall(0);
               assert.deepEqual(apiCall.args[0], {
                 authToken: 'dummyAuthToken',
+                maxRetries: 2,
                 path: '/api/lti/submissions',
                 data: {
                   submitted_at: undefined,
@@ -638,6 +640,7 @@ describe('BasicLTILaunchApp', () => {
               const apiCall = fakeApiCall.getCall(0);
               assert.deepEqual(apiCall.args[0], {
                 authToken: 'dummyAuthToken',
+                maxRetries: 2,
                 path: '/api/lti/submissions',
                 data: {
                   submitted_at: '2022-04-28T13:25:34Z',

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -84,6 +84,10 @@ function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function isRetryableResponse(status: number, data: any): boolean {
+  return status === 409 || (data && data.retryable);
+}
+
 /**
  * Make an API call to the LMS app backend.
  */
@@ -127,7 +131,10 @@ export async function apiCall<Result = unknown>(
   const resultJSON = await result.json();
 
   if (result.status >= 400 && result.status < 600) {
-    if (result.status === 409 && retryCount < maxRetries) {
+    if (
+      isRetryableResponse(result.status, resultJSON) &&
+      retryCount < maxRetries
+    ) {
       await delay(retryDelay);
       return apiCall({ ...options, retryCount: retryCount + 1 });
     }

--- a/lms/static/scripts/frontend_apps/utils/api.ts
+++ b/lms/static/scripts/frontend_apps/utils/api.ts
@@ -114,6 +114,9 @@ export async function apiCall<Result = unknown>(
   const headers: Record<string, string> = {
     Authorization: authToken,
   };
+  if (retryCount > 0) {
+    headers['Retry-Count'] = `${retryCount}`;
+  }
 
   if (data !== undefined) {
     body = JSON.stringify(data);
@@ -136,7 +139,10 @@ export async function apiCall<Result = unknown>(
       retryCount < maxRetries
     ) {
       await delay(retryDelay);
-      return apiCall({ ...options, retryCount: retryCount + 1 });
+      return apiCall({
+        ...options,
+        retryCount: retryCount + 1,
+      });
     }
 
     // Refresh expired access tokens for external APIs, if required. Only one

--- a/lms/views/api/exceptions.py
+++ b/lms/views/api/exceptions.py
@@ -295,6 +295,10 @@ class ErrorBody:
                     )
                 body["refresh"] = {"method": "POST", "path": path}
 
+        # Expose whether or not the exception is retryable to the frontend.
+        if getattr(request.exception, "retryable", False):
+            body["retryable"] = True
+
         return body
 
 

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -14,6 +14,7 @@ from lms.validation import (
     APIRecordResultSchema,
     APIRecordSpeedgraderSchema,
 )
+from lms.views.helpers import log_retries_callback
 
 LOG = logging.getLogger(__name__)
 
@@ -150,6 +151,7 @@ class GradingViews:
         self.request.registry.notify(
             LTIEvent.from_request(request=self.request, type_=LTIEvent.Type.SUBMISSION)
         )
+        self.request.add_finished_callback(log_retries_callback)
         return {}
 
 

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -117,6 +117,11 @@ class GradingViews:
             )
 
         except ExternalRequestError as err:
+            if err.is_timeout:
+                # We'll inform the frontend that this is a retryable error for timeouts.
+                err.retryable = True
+                raise
+
             if (
                 err.status_code == 422
                 # This is LTI1.3 only. In LTI1.1 canvas behaves differently and allows this type of submissions.

--- a/lms/views/helpers/__init__.py
+++ b/lms/views/helpers/__init__.py
@@ -1,3 +1,4 @@
+from lms.views.helpers._logging import log_retries_callback
 from lms.views.helpers._via import via_url, via_video_url
 
-__all__ = ["via_url", "via_video_url"]
+__all__ = ["log_retries_callback", "via_url", "via_video_url"]

--- a/lms/views/helpers/_logging.py
+++ b/lms/views/helpers/_logging.py
@@ -1,0 +1,17 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def log_retries_callback(request):
+    """Log a message when a retried requests succeeds."""
+    if (
+        request.headers.get("Retry-Count")
+        and request.response.status_code >= 200
+        and request.response.status_code < 300
+    ):
+        LOG.debug(
+            "Request to %s succeeded after %s retries",
+            request.path_info,
+            request.headers["Retry-Count"],
+        )

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -246,6 +246,11 @@ class TestErrorBody:
     def test_json(self, pyramid_request, error_body, expected):
         assert error_body.__json__(pyramid_request) == expected
 
+    def test_json_retryable_exception(self, pyramid_request):
+        pyramid_request.exception.retryable = True
+
+        assert ErrorBody().__json__(pyramid_request) == {"retryable": True}
+
     @pytest.mark.usefixtures("with_refreshable_exception")
     def test_json_includes_refresh_info_if_the_exception_is_refreshable(
         self, pyramid_request, oauth2_token_service

--- a/tests/unit/lms/views/helpers/_logging_test.py
+++ b/tests/unit/lms/views/helpers/_logging_test.py
@@ -1,0 +1,20 @@
+import logging
+
+from lms.views.helpers import log_retries_callback
+
+
+def test_log_retries_callback(pyramid_request, caplog):
+    caplog.set_level(logging.DEBUG)
+    pyramid_request.headers["Retry-Count"] = "1"
+
+    log_retries_callback(pyramid_request)
+
+    assert "succeeded after 1 retries" in "".join(caplog.messages)
+
+
+def test_log_retries_callback_doesnt_log_not_retry(pyramid_request, caplog):
+    caplog.set_level(logging.DEBUG)
+
+    log_retries_callback(pyramid_request)
+
+    assert not caplog.messages


### PR DESCRIPTION
Canvas submissions are sent when the first annotations is made during a "session" on a gradable assignment.

We have some error handling and display error dialogs accordingly but due to the indirect nature of the action is tricky to handle transactional errors like timeouts.

This commits adds a "flag" on the response of API calls to our own frontend marking the request as "retryable" allowing the FE to retry them.


### Testing


- Apply a diff like

```
diff --git a/lms/views/api/grading.py b/lms/views/api/grading.py
index 7b072a36d..430d0f0cc 100644
--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -103,6 +103,9 @@ class GradingViews:
         # absence of a submission from an ungraded submission. Non-Canvas LMSes in
         # theory require a grade).
 
+        if not self.request.headers.get("Retry-Count"):
+            raise ExternalRequestError(retryable=True)
+
         lis_result_sourcedid = self.parsed_params["lis_result_sourcedid"]
         try:
             # If we already have a score, then we've already recorded this info
```

to simulate a retry-success scenario. 


- Go to https://hypothesis.instructure.com/courses/319/assignments/3336 logged in as a **student**

- Check the devtools, make an annotation.


- You'll see to API request to `submissions` and a log line like:


```2025-02-19 11:14:15,976 DEBUG [lms.views.helpers._logging:13][MainThread] Request to /api/lti/submissions succeeded after 1 retries```

 on the server logs.

