### PR TITLE
Refactor the role filtering parameter to be a tuple

### DIFF
--- a/lms/services/dashboard.py
+++ b/lms/services/dashboard.py
@@ -219,8 +219,7 @@ class DashboardService:
             # If rostering is enabled and we do have the data, use it
             query = self._roster_service.get_assignment_roster(
                 assignment,
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=h_userids,
             )
 
@@ -229,8 +228,7 @@ class DashboardService:
             roster_last_updated = None
             # Always fallback to fetch users that have launched the assignment at some point
             query = self._user_service.get_users_for_assignment(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 assignment_id=assignment.id,
                 h_userids=h_userids,
                 # For launch data we always add the "active" column as true for compatibility with the roster query.
@@ -249,16 +247,14 @@ class DashboardService:
             # If rostering is enabled and we do have the data, use it
             query = self._roster_service.get_course_roster(
                 lms_course,
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=h_userids,
             )
 
         else:
             # Always fallback to fetch users that have launched the assignment at some point
             query = self._user_service.get_users_for_course(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 lms_course=lms_course,
                 h_userids=h_userids,
                 # For launch data we always add the "active" column as true for compatibility with the roster query.
@@ -280,16 +276,14 @@ class DashboardService:
             # If rostering is enabled and we do have the data, use it
             query = self._roster_service.get_segments_roster(
                 segments,
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=h_userids,
             )
 
         else:
             # Always fallback to fetch users that have launched the assignment at some point
             query = self._user_service.get_users_for_segments(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 segment_ids=[segment.id for segment in segments],
                 h_userids=h_userids,
                 # For launch data we always add the "active" column as true for compatibility with the roster query.

--- a/lms/views/dashboard/api/user.py
+++ b/lms/views/dashboard/api/user.py
@@ -264,8 +264,7 @@ class UserViews:
         # Full organization fetch
         if not course_ids and not assignment_ids and not segment_authority_provided_ids:
             return None, self.user_service.get_users_for_organization(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=h_userids,
                 # Users the current user has access to see
                 instructor_h_userid=self.request.user.h_userid
@@ -276,8 +275,7 @@ class UserViews:
             ).add_columns(true())
 
         return None, self.user_service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             course_ids=self.request.parsed_params.get("course_ids"),
             assignment_ids=assignment_ids,
             # Users the current user has access to see

--- a/tests/unit/lms/services/dashboard_test.py
+++ b/tests/unit/lms/services/dashboard_test.py
@@ -285,8 +285,7 @@ class TestDashboardService:
 
         if not roster_available:
             user_service.get_users_for_assignment.assert_called_once_with(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 assignment_id=assignment.id,
                 h_userids=sentinel.h_userids,
             )
@@ -298,8 +297,7 @@ class TestDashboardService:
         else:
             roster_service.get_assignment_roster.assert_called_once_with(
                 assignment,
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=sentinel.h_userids,
             )
             assert (
@@ -330,8 +328,7 @@ class TestDashboardService:
 
         if not roster_available:
             user_service.get_users_for_course.assert_called_once_with(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 lms_course=lms_course,
                 h_userids=sentinel.h_userids,
             )
@@ -343,8 +340,7 @@ class TestDashboardService:
         else:
             roster_service.get_course_roster.assert_called_once_with(
                 lms_course,
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=sentinel.h_userids,
             )
             assert (
@@ -367,8 +363,7 @@ class TestDashboardService:
 
         if not roster_available:
             user_service.get_users_for_segments.assert_called_once_with(
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 segment_ids=[segment.id],
                 h_userids=sentinel.h_userids,
             )
@@ -380,8 +375,7 @@ class TestDashboardService:
         else:
             roster_service.get_segments_roster.assert_called_once_with(
                 [segment],
-                role_scope=RoleScope.COURSE,
-                role_type=RoleType.LEARNER,
+                include_role=(RoleScope.COURSE, RoleType.LEARNER),
                 h_userids=sentinel.h_userids,
             )
             assert (

--- a/tests/unit/lms/services/roster_test.py
+++ b/tests/unit/lms/services/roster_test.py
@@ -121,8 +121,10 @@ class TestRosterService:
         result = db_session.execute(
             svc.get_course_roster(
                 lms_course,
-                role_scope=lti_role.scope if with_role_scope else None,
-                role_type=lti_role.type if with_role_type else None,
+                include_role=(
+                    lti_role.scope if with_role_scope else None,
+                    lti_role.type if with_role_type else None,
+                ),
                 h_userids=[lms_user.h_userid, inactive_lms_user.h_userid]
                 if with_h_userids
                 else None,
@@ -164,8 +166,10 @@ class TestRosterService:
         result = db_session.execute(
             svc.get_assignment_roster(
                 assignment,
-                role_scope=lti_role.scope if with_role_scope else None,
-                role_type=lti_role.type if with_role_type else None,
+                include_role=(
+                    lti_role.scope if with_role_scope else None,
+                    lti_role.type if with_role_type else None,
+                ),
                 h_userids=[lms_user.h_userid, inactive_lms_user.h_userid]
                 if with_h_userids
                 else None,
@@ -207,8 +211,10 @@ class TestRosterService:
         result = db_session.execute(
             svc.get_segments_roster(
                 [lms_segment],
-                role_scope=lti_role.scope if with_role_scope else None,
-                role_type=lti_role.type if with_role_type else None,
+                include_role=(
+                    lti_role.scope if with_role_scope else None,
+                    lti_role.type if with_role_type else None,
+                ),
                 h_userids=[lms_user.h_userid, inactive_lms_user.h_userid]
                 if with_h_userids
                 else None,

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -113,8 +113,7 @@ class TestUserService:
         factories.User(h_userid=student_in_assignment.h_userid)  # Duplicated student
 
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             admin_organization_ids=[organization.id],
         )
 
@@ -131,8 +130,7 @@ class TestUserService:
         organization,
     ):
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             h_userids=[student_in_assignment.h_userid],
             admin_organization_ids=[organization.id],
         )
@@ -146,8 +144,7 @@ class TestUserService:
         self, service, db_session, student_in_assignment, course, organization
     ):
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             course_ids=[course.id],
             admin_organization_ids=[organization.id],
         )
@@ -162,8 +159,7 @@ class TestUserService:
         self, service, db_session, student_in_assignment, course, with_h_userids
     ):
         query = service.get_users_for_course(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             lms_course=course.lms_course,
             h_userids=[student_in_assignment.h_userid] if with_h_userids else None,
         )
@@ -189,8 +185,7 @@ class TestUserService:
         db_session.flush()
 
         query = service.get_users_for_segments(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             segment_ids=[lms_segment.id],
             h_userids=[student.h_userid] if with_h_userids else None,
         )
@@ -207,8 +202,7 @@ class TestUserService:
         db_session.flush()
 
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             assignment_ids=[assignment.id],
             admin_organization_ids=[organization.id],
         )
@@ -222,8 +216,7 @@ class TestUserService:
         self, service, db_session, student_in_assignment, assignment, with_h_userids
     ):
         query = service.get_users_for_assignment(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             assignment_id=assignment.id,
             h_userids=[student_in_assignment.h_userid] if with_h_userids else None,
         )
@@ -247,8 +240,7 @@ class TestUserService:
         db_session.flush()
 
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             instructor_h_userid=teacher_in_assigment.h_userid,
         )
 
@@ -267,8 +259,7 @@ class TestUserService:
         with_h_userids,
     ):
         query = service.get_users_for_organization(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             instructor_h_userid=teacher_in_assigment.h_userid,
             h_userids=[student_in_assignment.h_userid] if with_h_userids else None,
         )
@@ -296,8 +287,7 @@ class TestUserService:
         db_session.flush()
 
         query = service.get_users(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             assignment_ids=[assignment.id],
             admin_organization_ids=[organization.id],
             segment_authority_provided_ids=[grouping.authority_provided_id],

--- a/tests/unit/lms/views/dashboard/api/user_test.py
+++ b/tests/unit/lms/views/dashboard/api/user_test.py
@@ -335,8 +335,7 @@ class TestUserViews:
         views._students_query(assignment_ids=None, segment_authority_provided_ids=None)  # noqa: SLF001
 
         user_service.get_users.assert_called_once_with(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             course_ids=[sentinel.course_id, sentinel.course_id_2],
             assignment_ids=None,
             instructor_h_userid=pyramid_request.user.h_userid,
@@ -349,8 +348,7 @@ class TestUserViews:
         views._students_query(assignment_ids=None, segment_authority_provided_ids=None)  # noqa: SLF001
 
         user_service.get_users_for_organization.assert_called_once_with(
-            role_scope=RoleScope.COURSE,
-            role_type=RoleType.LEARNER,
+            include_role=(RoleScope.COURSE, RoleType.LEARNER),
             h_userids=None,
             instructor_h_userid=pyramid_request.user.h_userid,
             admin_organization_ids=[],


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1595


All method that return a query of users or a roster take a role scope and a role type parameter.

Refactor that to be a tuple of values instead.

This is to accommodate a future change to add new parameter to "exclude" a certain type of role.

This refactor is big enough that deserves its own commit to make it easier to review.



## Testing

There should not be any functional changes, for sanity checking  navigate around the dashboards.