### PR TITLE
Align canvas 1.1 and 1.3 config custom variables

### DIFF
--- a/lms/templates/config.xml.jinja2
+++ b/lms/templates/config.xml.jinja2
@@ -16,19 +16,9 @@ http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
   <blti:title>Hypothesis</blti:title>
   <blti:launch_url>{{ launch_url }}</blti:launch_url>
   <blti:custom>
-    <lticm:property name="custom_canvas_course_id">$Canvas.course.id</lticm:property>
-    <lticm:property name="custom_canvas_api_domain">$Canvas.api.domain</lticm:property>
-    <lticm:property name="custom_display_name">$Person.name.display</lticm:property>
-    <lticm:property name="custom_canvas_user_id">$Canvas.user.id</lticm:property>
-    <lticm:property name="custom_context_id_history">$Context.id.history</lticm:property>
-    <lticm:property name="custom_course_starts">$Canvas.course.startAt</lticm:property>
-    <lticm:property name="custom_course_ends">$Canvas.course.endAt</lticm:property>
-    <lticm:property name="custom_term_name">$Canvas.term.name</lticm:property>
-    <lticm:property name="custom_term_start">$Canvas.term.startAt</lticm:property>
-    <lticm:property name="custom_term_end">$Canvas.term.endAt</lticm:property>
-    <lticm:property name="custom_assignment_id">$Canvas.assignment.id</lticm:property>
-    <lticm:property name="custom_allowed_attempts">$Canvas.assignment.allowedAttempts</lticm:property>
-    <lticm:property name="custom_submitted_attempts">$Canvas.assignment.submission.studentAttempts</lticm:property>
+    {% for name, value in custom_variables %}
+    <lticm:property name="{{ name }}">{{ value }}</lticm:property>
+    {% endfor %}
   </blti:custom>
   <blti:extensions platform="canvas.instructure.com">
     <lticm:options name="link_selection">

--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -7,6 +7,23 @@ configured in Canvas.
 
 from pyramid.view import view_config
 
+CUSTOM_VARIABLES = [
+    ("custom_canvas_course_id", "$Canvas.course.id"),
+    ("custom_canvas_api_domain", "$Canvas.api.domain"),
+    ("custom_canvas_user_id", "$Canvas.user.id"),
+    ("custom_display_name", "$Person.name.display"),
+    ("custom_context_id_history", "$Context.id.history"),
+    ("custom_course_starts", "$Canvas.course.startAt"),
+    ("custom_course_ends", "$Canvas.course.endAt"),
+    ("custom_term_id", "$Canvas.term.id"),
+    ("custom_term_name", "$Canvas.term.name"),
+    ("custom_term_start", "$Canvas.term.startAt"),
+    ("custom_term_end", "$Canvas.term.endAt"),
+    ("custom_assignment_id", "$Canvas.assignment.id"),
+    ("custom_allowed_attempts", "$Canvas.assignment.allowedAttempts"),
+    ("custom_submitted_attempts", "$Canvas.assignment.submission.studentAttempts"),
+]
+
 
 @view_config(
     route_name="canvas.v11.config",
@@ -24,6 +41,7 @@ def config_xml(request):
     return {
         "launch_url": request.route_url("lti_launches"),
         "content_item_url": request.route_url("content_item_selection"),
+        "custom_variables": CUSTOM_VARIABLES,
     }
 
 
@@ -76,22 +94,7 @@ def config_json(request):
             }
         ],
         "public_jwk_url": request.route_url("lti.jwks"),
-        "custom_fields": {
-            "custom_canvas_course_id": "$Canvas.course.id",
-            "custom_canvas_api_domain": "$Canvas.api.domain",
-            "custom_canvas_user_id": "$Canvas.user.id",
-            "custom_display_name": "$Person.name.display",
-            "custom_context_id_history": "$Context.id.history",
-            "custom_course_starts": "$Canvas.course.startAt",
-            "custom_course_ends": "$Canvas.course.endAt",
-            "custom_term_id": "$Canvas.term.id",
-            "custom_term_name": "$Canvas.term.name",
-            "custom_term_start": "$Canvas.term.startAt",
-            "custom_term_end": "$Canvas.term.endAt",
-            "custom_assignment_id": "$Canvas.assignment.id",
-            "custom_allowed_attempts": "$Canvas.assignment.allowedAttempts",
-            "custom_submitted_attempts": "$Canvas.assignment.submission.studentAttempts",
-        },
+        "custom_fields": dict(CUSTOM_VARIABLES),
         "scopes": [
             "https://purl.imsglobal.org/spec/lti-ags/scope/score",
             "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",


### PR DESCRIPTION
Use a common list of variables in both config files


These are out of sync since: https://github.com/hypothesis/lms/commit/bbecb19fd515873b988d43aee99f1d79306b426a




### Testing 

For the LTI1.3 config (json) the unit test checks the exact contents.

For the LTI1.1 compare the the local and prod version:


http://localhost:8001/config_xml
https://lms.hypothes.is/config_xml