### PR TITLE
Adding Canvas.user.loginId to the default list of custom variables

### DIFF
--- a/lms/views/canvas/config.py
+++ b/lms/views/canvas/config.py
@@ -11,6 +11,7 @@ CUSTOM_VARIABLES = [
     ("custom_canvas_course_id", "$Canvas.course.id"),
     ("custom_canvas_api_domain", "$Canvas.api.domain"),
     ("custom_canvas_user_id", "$Canvas.user.id"),
+    ("custom_canvas_user_login_id", "$Canvas.user.loginId"),
     ("custom_display_name", "$Person.name.display"),
     ("custom_context_id_history", "$Context.id.history"),
     ("custom_course_starts", "$Canvas.course.startAt"),

--- a/tests/unit/lms/views/canvas/config_test.py
+++ b/tests/unit/lms/views/canvas/config_test.py
@@ -49,6 +49,7 @@ class TestConfigJSON:
                 "custom_canvas_course_id": "$Canvas.course.id",
                 "custom_canvas_api_domain": "$Canvas.api.domain",
                 "custom_canvas_user_id": "$Canvas.user.id",
+                "custom_canvas_user_login_id": "$Canvas.user.loginId",
                 "custom_display_name": "$Person.name.display",
                 "custom_context_id_history": "$Context.id.history",
                 "custom_course_starts": "$Canvas.course.startAt",


### PR DESCRIPTION
While we only ever needed this for the VitalSource integration, as the field to fetch the user reference, it's less error prone to always ask for it in every new install.


See:

- https://hypothes-is.slack.com/archives/C2BLQDKHA/p1740060985408929?thread_ts=1739542083.490679&cid=C2BLQDKHA
