### PR TITLE
Change the tests of multi_truncate to test every function but trailing_year

### DIFF
--- a/tests/unit/lms/data_tasks/report/create_from_scratch/test_01_functions/test_01_date_functions.py
+++ b/tests/unit/lms/data_tasks/report/create_from_scratch/test_01_functions/test_01_date_functions.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import date
 
 import importlib_resources
 import pytest
@@ -9,29 +9,17 @@ TASK_ROOT = importlib_resources.files("lms.data_tasks")
 
 
 class TestDateFunctions:
-    NOW = datetime(2025, 3, 6, tzinfo=UTC)  # We hardcode the date to avoid flakiness
-    # 2024 was a leap year so the math accounts for that 366 days
-    ONE_YEAR_AGO = (NOW - timedelta(days=366)).date()
-    TWO_YEARS_AGO = (NOW - timedelta(days=366 + 365)).date()
+    # We hardcode the date to avoid flakiness
+    NOW = date(2025, 3, 6)
 
     @pytest.mark.usefixtures("with_date_functions")
     @pytest.mark.parametrize(
         "timescale,value,expected",
         (
-            ("trailing_year", "'2025/03/06'::date", ONE_YEAR_AGO),
-            # Technically this test could fail if you run this exactly at midnight
-            ("trailing_year", "'2025/03/06'::date - INTERVAL '1 second'", ONE_YEAR_AGO),
-            ("trailing_year", "'2025/03/06'::date - INTERVAL '1 day'", ONE_YEAR_AGO),
-            (
-                "trailing_year",
-                "'2025/03/06'::date - INTERVAL '1 year 1 day'",
-                TWO_YEARS_AGO,
-            ),
-            (
-                "trailing_year",
-                "'2025/03/06'::date - INTERVAL '1 year 10 day'",
-                TWO_YEARS_AGO,
-            ),
+            ("all_time", f"'{NOW}'::date", date(1901, 1, 1)),
+            ("academic_year", f"'{NOW}'::date", date(2024, 7, 1)),
+            ("semester", f"'{NOW}'::date", date(2025, 1, 1)),
+            ("week", f"'{NOW}'::date", date(2025, 3, 2)),  # Weeks start on Sunday
         ),
     )
     def test_multi_truncate(self, db_session, timescale, value, expected):


### PR DESCRIPTION
trailing_year relies on the current date internally and it's behavior is wonky around leap years.

Instead of trying to reliable test for it or change it's behavior we'll test every other function in the module.