### PR TITLE
Collect student emails based on a new feature flag

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -65,6 +65,7 @@ class ApplicationSettings(JSONSettings):
         HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING = (
             "hypothesis.lti_13_sourcedid_for_grading"
         )
+        HYPOTHESIS_COLLECT_STUDENT_EMAILS = "hypothesis.collect_student_emails"
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
@@ -158,6 +159,11 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING: JSONSetting(
             Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, SettingFormat.BOOLEAN
+        ),
+        Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS: JSONSetting(
+            Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS,
+            SettingFormat.TRI_STATE,
+            default=False,
         ),
     }
 

--- a/lms/models/lti_user.py
+++ b/lms/models/lti_user.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from lms.models.application_instance import ApplicationInstance
 from lms.models.h_user import HUser
-from lms.models.lti_role import LTIRole, Role, RoleScope, RoleType
+from lms.models.lti_role import LTIRole, Role
 
 
 @dataclass
@@ -72,33 +72,23 @@ class LTIUser:
     @property
     def is_instructor(self):
         """Whether this user is an instructor."""
-        # We consider admins to be instructors for authorization purposes
-        return self.is_admin or any(
-            # And any instructor in the course
-            role.type == RoleType.INSTRUCTOR and role.scope == RoleScope.COURSE
-            for role in self.effective_lti_roles
-        )
+        from lms.services.lti_role_service import LTIRoleService
+
+        return LTIRoleService.is_instructor(self.effective_lti_roles)
 
     @property
     def is_learner(self):
         """Whether this user is a learner."""
+        from lms.services.lti_role_service import LTIRoleService
 
-        if self.is_instructor:
-            return False
-
-        return any(
-            role.type == RoleType.LEARNER and role.scope == RoleScope.COURSE
-            for role in self.effective_lti_roles
-        )
+        return LTIRoleService.is_learner(self.effective_lti_roles)
 
     @property
     def is_admin(self):
         """Whether this user is an admin."""
-        return any(
-            role.type == RoleType.ADMIN
-            and role.scope in {RoleScope.COURSE, RoleScope.SYSTEM}
-            for role in self.effective_lti_roles
-        )
+        from lms.services.lti_role_service import LTIRoleService
+
+        return LTIRoleService.is_admin(self.effective_lti_roles)
 
 
 def display_name(

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -127,6 +127,7 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
+                            {{ settings_checkbox('Collect student emails', 'hypothesis', 'collect_student_emails') }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -127,7 +127,7 @@
                             <legend class="label has-text-centered">General settings</legend>
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
-                            {{ settings_checkbox('Collect student emails', 'hypothesis', 'collect_student_emails') }}
+                            {{ tri_state_settings_checkbox("Collect student emails", fields[Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS]) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -160,6 +160,12 @@ class TestApplicationSettings:
                 "hypothesis.lti_13_sourcedid_for_grading",
                 SettingFormat.BOOLEAN,
             ),
+            (
+                "hypothesis",
+                "collect_student_emails",
+                "hypothesis.collect_student_emails",
+                SettingFormat.TRI_STATE,
+            ),
         ]
 
 


### PR DESCRIPTION
Based on the new style of tri-state "checkboxes" introduced in https://github.com/hypothesis/lms/pull/7046


### Testing

- Truncate your local users, in `make sql`:


`truncate lms_user, "user" cascade;`


- Launch https://hypothesis.instructure.com/courses/319/assignments/3336 as `eng+canvasstudent@hypothes.is`


- Check the DB, no email was recorded:

```
select display_name, email  from lms_user;
      display_name      | email 
------------------------+-------
 Hypothesis 101 Student | 
(1 row)
```

- Change the value of the new setting on the admin pages:

http://localhost:8001/admin/instances/102/settings

Set "Collect student emails" to Enabled.


- Launch https://hypothesis.instructure.com/courses/319/assignments/3336 again

- We got the email now:

```
select display_name, email  from lms_user;
      display_name      |             email             
------------------------+-------------------------------
 Hypothesis 101 Student | eng...@hypothes.is
(1 row)
```

- Disable (or set to default) the setting again in http://localhost:8001/admin/instances/102/settings


- Truncate any local rosters:

```truncate assignment_roster, task_done cascade;```


- An force a roster fetch in `make shell`

```
from lms.tasks.roster import schedule_fetching_assignment_rosters
schedule_fetching_assignment_rosters.delay()
```

- We have now a bunch of people in the DB but no emails except for the teacher and the TA

```
select display_name, email  from lms_user;
          display_name          |               email               
--------------------------------+-----------------------------------
 Hypothesis 101 Student Student | 
 Hypothesis 101 Teacher Teacher | eng...@hypothes.is
 Leopoldd                       | 
 Charlie Corr Corr              | 
 Dieter Dark Dark               | 
 eng+coursecopystudent          | eng...@hypothes.is
 AC Student 1 1                 | 
 AC Student 2 2                 | 
 AC Student 3 3                 | 
 Alan Anderson Anderson         |                                                                                                                                                                                                                                                                                                                  "marcos@lenovo:~/hypo/" 16:50 12-mar-25
 Evan Ents Ents                 | 
 Frank Foster Foster            | 
 Grant Garrison Garrison        | 
 Horace Henderson Henderson     | 
 Ian Ink Ink                    | 
 Test Student Student           | 
 Jake Jerlich Jerlich           | 
 Kevin Kosta Kosta              | 
 Lemmy Lancaster Lancaster      | 
 Manny Margs Margs              | 
 Nancy Nunzio Nunzio            | 
(21 rows)
```

- Re-enable the feature flag
- Truncate again to force another roster fetch

```truncate assignment_roster, task_done cascade;```

- An fetch it again

```
from lms.tasks.roster import schedule_fetching_assignment_rosters
schedule_fetching_assignment_rosters.delay()
```

- Now we have emails for everyone