### PR TITLE
Use an enum for ApplicationSettings and include a default value.

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -4,7 +4,6 @@ from enum import StrEnum
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
-from pyramid.settings import asbool
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -12,7 +11,7 @@ from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.exceptions import ReusedConsumerKey
 from lms.models.family import Family
-from lms.models.json_settings import JSONSetting, JSONSettings
+from lms.models.json_settings import JSONSetting, JSONSettings, SettingFormat
 
 LOG = logging.getLogger(__name__)
 
@@ -69,62 +68,68 @@ class ApplicationSettings(JSONSettings):
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
-            Settings.BLACKBOARD_FILES_ENABLED, asbool
+            Settings.BLACKBOARD_FILES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.BLACKBOARD_GROUPS_ENABLED: JSONSetting(
-            Settings.BLACKBOARD_GROUPS_ENABLED, asbool
+            Settings.BLACKBOARD_GROUPS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_SECTIONS_ENABLED: JSONSetting(
-            Settings.CANVAS_SECTIONS_ENABLED, asbool
+            Settings.CANVAS_SECTIONS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_GROUPS_ENABLED: JSONSetting(
-            Settings.CANVAS_GROUPS_ENABLED, asbool
+            Settings.CANVAS_GROUPS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_FILES_ENABLED: JSONSetting(
-            Settings.CANVAS_FILES_ENABLED, asbool
+            Settings.CANVAS_FILES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_FOLDERS_ENABLED: JSONSetting(
-            Settings.CANVAS_FOLDERS_ENABLED, asbool
+            Settings.CANVAS_FOLDERS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_STRICT_SECTION_MEMBERSHIP: JSONSetting(
-            Settings.CANVAS_STRICT_SECTION_MEMBERSHIP, asbool
+            Settings.CANVAS_STRICT_SECTION_MEMBERSHIP, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_PAGES_ENABLED: JSONSetting(
-            Settings.CANVAS_PAGES_ENABLED, asbool
+            Settings.CANVAS_PAGES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.CANVAS_STUDIO_ADMIN_EMAIL: JSONSetting(
             Settings.CANVAS_STUDIO_ADMIN_EMAIL
         ),
         Settings.CANVAS_STUDIO_CLIENT_ID: JSONSetting(Settings.CANVAS_STUDIO_CLIENT_ID),
         Settings.CANVAS_STUDIO_CLIENT_SECRET: JSONSetting(
-            Settings.CANVAS_STUDIO_CLIENT_SECRET, JSONSetting.AES_SECRET
+            Settings.CANVAS_STUDIO_CLIENT_SECRET, SettingFormat.AES_SECRET
         ),
         Settings.CANVAS_STUDIO_DOMAIN: JSONSetting(Settings.CANVAS_STUDIO_DOMAIN),
         Settings.D2L_CLIENT_ID: JSONSetting(Settings.D2L_CLIENT_ID),
         Settings.D2L_CLIENT_SECRET: JSONSetting(
-            Settings.D2L_CLIENT_SECRET, JSONSetting.AES_SECRET
+            Settings.D2L_CLIENT_SECRET, SettingFormat.AES_SECRET
         ),
-        Settings.D2L_GROUPS_ENABLED: JSONSetting(Settings.D2L_GROUPS_ENABLED, asbool),
-        Settings.D2L_FILES_ENABLED: JSONSetting(Settings.D2L_FILES_ENABLED, asbool),
+        Settings.D2L_GROUPS_ENABLED: JSONSetting(
+            Settings.D2L_GROUPS_ENABLED, SettingFormat.BOOLEAN
+        ),
+        Settings.D2L_FILES_ENABLED: JSONSetting(
+            Settings.D2L_FILES_ENABLED, SettingFormat.BOOLEAN
+        ),
         Settings.GOOGLE_DRIVE_FILES_ENABLED: JSONSetting(
-            Settings.GOOGLE_DRIVE_FILES_ENABLED, asbool
+            Settings.GOOGLE_DRIVE_FILES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED: JSONSetting(
-            Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED, asbool
+            Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.MOODLE_API_TOKEN: JSONSetting(
-            Settings.MOODLE_API_TOKEN, JSONSetting.AES_SECRET
+            Settings.MOODLE_API_TOKEN, SettingFormat.AES_SECRET
         ),
         Settings.MOODLE_GROUPS_ENABLED: JSONSetting(
-            Settings.MOODLE_GROUPS_ENABLED, asbool
+            Settings.MOODLE_GROUPS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.MOODLE_FILES_ENABLED: JSONSetting(
-            Settings.MOODLE_FILES_ENABLED, asbool
+            Settings.MOODLE_FILES_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.MOODLE_PAGES_ENABLED: JSONSetting(
-            Settings.MOODLE_PAGES_ENABLED, asbool
+            Settings.MOODLE_PAGES_ENABLED, SettingFormat.BOOLEAN
         ),
-        Settings.VITALSOURCE_ENABLED: JSONSetting(Settings.VITALSOURCE_ENABLED, asbool),
+        Settings.VITALSOURCE_ENABLED: JSONSetting(
+            Settings.VITALSOURCE_ENABLED, SettingFormat.BOOLEAN
+        ),
         Settings.VITALSOURCE_USER_LTI_PARAM: JSONSetting(
             Settings.VITALSOURCE_USER_LTI_PARAM
         ),
@@ -133,22 +138,26 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.VITALSOURCE_API_KEY: JSONSetting(Settings.VITALSOURCE_API_KEY),
         Settings.VITALSOURCE_STUDENT_PAY_ENABLED: JSONSetting(
-            Settings.VITALSOURCE_STUDENT_PAY_ENABLED, asbool
+            Settings.VITALSOURCE_STUDENT_PAY_ENABLED, SettingFormat.BOOLEAN
         ),
-        Settings.JSTOR_ENABLED: JSONSetting(Settings.JSTOR_ENABLED, asbool),
+        Settings.JSTOR_ENABLED: JSONSetting(
+            Settings.JSTOR_ENABLED, SettingFormat.BOOLEAN
+        ),
         Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
         Settings.YOUTUBE_ENABLED: JSONSetting(
-            Settings.YOUTUBE_ENABLED, asbool, default=True
+            Settings.YOUTUBE_ENABLED, SettingFormat.BOOLEAN, default=True
         ),
-        Settings.HYPOTHESIS_NOTES: JSONSetting(Settings.HYPOTHESIS_NOTES),
+        Settings.HYPOTHESIS_NOTES: JSONSetting(
+            Settings.HYPOTHESIS_NOTES, SettingFormat.STRING
+        ),
         Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG: JSONSetting(
-            Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, asbool
+            Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, SettingFormat.BOOLEAN
         ),
         Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED: JSONSetting(
-            Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED, asbool
+            Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED, SettingFormat.BOOLEAN
         ),
         Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING: JSONSetting(
-            Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, asbool
+            Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, SettingFormat.BOOLEAN
         ),
     }
 

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -145,7 +145,7 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
         Settings.YOUTUBE_ENABLED: JSONSetting(
-            Settings.YOUTUBE_ENABLED, SettingFormat.BOOLEAN, default=True
+            Settings.YOUTUBE_ENABLED, SettingFormat.TRI_STATE, default=True
         ),
         Settings.HYPOTHESIS_NOTES: JSONSetting(
             Settings.HYPOTHESIS_NOTES, SettingFormat.STRING

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -67,42 +67,88 @@ class ApplicationSettings(JSONSettings):
             "hypothesis.lti_13_sourcedid_for_grading"
         )
 
-    fields = (
-        JSONSetting(Settings.BLACKBOARD_FILES_ENABLED, asbool),
-        JSONSetting(Settings.BLACKBOARD_GROUPS_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_SECTIONS_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_GROUPS_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_FILES_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_FOLDERS_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_STRICT_SECTION_MEMBERSHIP, asbool),
-        JSONSetting(Settings.CANVAS_PAGES_ENABLED, asbool),
-        JSONSetting(Settings.CANVAS_STUDIO_ADMIN_EMAIL),
-        JSONSetting(Settings.CANVAS_STUDIO_CLIENT_ID),
-        JSONSetting(Settings.CANVAS_STUDIO_CLIENT_SECRET, JSONSetting.AES_SECRET),
-        JSONSetting(Settings.CANVAS_STUDIO_DOMAIN),
-        JSONSetting(Settings.D2L_CLIENT_ID),
-        JSONSetting(Settings.D2L_CLIENT_SECRET, JSONSetting.AES_SECRET),
-        JSONSetting(Settings.D2L_GROUPS_ENABLED, asbool),
-        JSONSetting(Settings.D2L_FILES_ENABLED, asbool),
-        JSONSetting(Settings.GOOGLE_DRIVE_FILES_ENABLED, asbool),
-        JSONSetting(Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED, asbool),
-        JSONSetting(Settings.MOODLE_API_TOKEN, JSONSetting.AES_SECRET),
-        JSONSetting(Settings.MOODLE_GROUPS_ENABLED, asbool),
-        JSONSetting(Settings.MOODLE_FILES_ENABLED, asbool),
-        JSONSetting(Settings.MOODLE_PAGES_ENABLED, asbool),
-        JSONSetting(Settings.VITALSOURCE_ENABLED, asbool),
-        JSONSetting(Settings.VITALSOURCE_USER_LTI_PARAM),
-        JSONSetting(Settings.VITALSOURCE_USER_LTI_PATTERN),
-        JSONSetting(Settings.VITALSOURCE_API_KEY),
-        JSONSetting(Settings.VITALSOURCE_STUDENT_PAY_ENABLED, asbool),
-        JSONSetting(Settings.JSTOR_ENABLED, asbool),
-        JSONSetting(Settings.JSTOR_SITE_CODE),
-        JSONSetting(Settings.YOUTUBE_ENABLED, asbool),
-        JSONSetting(Settings.HYPOTHESIS_NOTES),
-        JSONSetting(Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, asbool),
-        JSONSetting(Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED, asbool),
-        JSONSetting(Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, asbool),
-    )
+    fields: dict[Settings, JSONSetting] = {
+        Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
+            Settings.BLACKBOARD_FILES_ENABLED, asbool
+        ),
+        Settings.BLACKBOARD_GROUPS_ENABLED: JSONSetting(
+            Settings.BLACKBOARD_GROUPS_ENABLED, asbool
+        ),
+        Settings.CANVAS_SECTIONS_ENABLED: JSONSetting(
+            Settings.CANVAS_SECTIONS_ENABLED, asbool
+        ),
+        Settings.CANVAS_GROUPS_ENABLED: JSONSetting(
+            Settings.CANVAS_GROUPS_ENABLED, asbool
+        ),
+        Settings.CANVAS_FILES_ENABLED: JSONSetting(
+            Settings.CANVAS_FILES_ENABLED, asbool
+        ),
+        Settings.CANVAS_FOLDERS_ENABLED: JSONSetting(
+            Settings.CANVAS_FOLDERS_ENABLED, asbool
+        ),
+        Settings.CANVAS_STRICT_SECTION_MEMBERSHIP: JSONSetting(
+            Settings.CANVAS_STRICT_SECTION_MEMBERSHIP, asbool
+        ),
+        Settings.CANVAS_PAGES_ENABLED: JSONSetting(
+            Settings.CANVAS_PAGES_ENABLED, asbool
+        ),
+        Settings.CANVAS_STUDIO_ADMIN_EMAIL: JSONSetting(
+            Settings.CANVAS_STUDIO_ADMIN_EMAIL
+        ),
+        Settings.CANVAS_STUDIO_CLIENT_ID: JSONSetting(Settings.CANVAS_STUDIO_CLIENT_ID),
+        Settings.CANVAS_STUDIO_CLIENT_SECRET: JSONSetting(
+            Settings.CANVAS_STUDIO_CLIENT_SECRET, JSONSetting.AES_SECRET
+        ),
+        Settings.CANVAS_STUDIO_DOMAIN: JSONSetting(Settings.CANVAS_STUDIO_DOMAIN),
+        Settings.D2L_CLIENT_ID: JSONSetting(Settings.D2L_CLIENT_ID),
+        Settings.D2L_CLIENT_SECRET: JSONSetting(
+            Settings.D2L_CLIENT_SECRET, JSONSetting.AES_SECRET
+        ),
+        Settings.D2L_GROUPS_ENABLED: JSONSetting(Settings.D2L_GROUPS_ENABLED, asbool),
+        Settings.D2L_FILES_ENABLED: JSONSetting(Settings.D2L_FILES_ENABLED, asbool),
+        Settings.GOOGLE_DRIVE_FILES_ENABLED: JSONSetting(
+            Settings.GOOGLE_DRIVE_FILES_ENABLED, asbool
+        ),
+        Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED: JSONSetting(
+            Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED, asbool
+        ),
+        Settings.MOODLE_API_TOKEN: JSONSetting(
+            Settings.MOODLE_API_TOKEN, JSONSetting.AES_SECRET
+        ),
+        Settings.MOODLE_GROUPS_ENABLED: JSONSetting(
+            Settings.MOODLE_GROUPS_ENABLED, asbool
+        ),
+        Settings.MOODLE_FILES_ENABLED: JSONSetting(
+            Settings.MOODLE_FILES_ENABLED, asbool
+        ),
+        Settings.MOODLE_PAGES_ENABLED: JSONSetting(
+            Settings.MOODLE_PAGES_ENABLED, asbool
+        ),
+        Settings.VITALSOURCE_ENABLED: JSONSetting(Settings.VITALSOURCE_ENABLED, asbool),
+        Settings.VITALSOURCE_USER_LTI_PARAM: JSONSetting(
+            Settings.VITALSOURCE_USER_LTI_PARAM
+        ),
+        Settings.VITALSOURCE_USER_LTI_PATTERN: JSONSetting(
+            Settings.VITALSOURCE_USER_LTI_PATTERN
+        ),
+        Settings.VITALSOURCE_API_KEY: JSONSetting(Settings.VITALSOURCE_API_KEY),
+        Settings.VITALSOURCE_STUDENT_PAY_ENABLED: JSONSetting(
+            Settings.VITALSOURCE_STUDENT_PAY_ENABLED, asbool
+        ),
+        Settings.JSTOR_ENABLED: JSONSetting(Settings.JSTOR_ENABLED, asbool),
+        Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
+        Settings.YOUTUBE_ENABLED: JSONSetting(Settings.YOUTUBE_ENABLED, asbool),
+        Settings.HYPOTHESIS_NOTES: JSONSetting(Settings.HYPOTHESIS_NOTES),
+        Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG: JSONSetting(
+            Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, asbool
+        ),
+        Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED: JSONSetting(
+            Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED, asbool
+        ),
+        Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING: JSONSetting(
+            Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, asbool
+        ),
+    }
 
 
 class ApplicationInstance(CreatedUpdatedMixin, Base):

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -67,7 +67,7 @@ class ApplicationSettings(JSONSettings):
             "hypothesis.lti_13_sourcedid_for_grading"
         )
 
-    fields: dict[Settings, JSONSetting] = {
+    fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
             Settings.BLACKBOARD_FILES_ENABLED, asbool
         ),

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -137,7 +137,9 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.JSTOR_ENABLED: JSONSetting(Settings.JSTOR_ENABLED, asbool),
         Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
-        Settings.YOUTUBE_ENABLED: JSONSetting(Settings.YOUTUBE_ENABLED, asbool),
+        Settings.YOUTUBE_ENABLED: JSONSetting(
+            Settings.YOUTUBE_ENABLED, asbool, default=True
+        ),
         Settings.HYPOTHESIS_NOTES: JSONSetting(Settings.HYPOTHESIS_NOTES),
         Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG: JSONSetting(
             Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, asbool

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Mapping
+from enum import StrEnum
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
@@ -16,46 +18,90 @@ LOG = logging.getLogger(__name__)
 
 
 class ApplicationSettings(JSONSettings):
+    class Settings(StrEnum):
+        BLACKBOARD_FILES_ENABLED = "blackboard.files_enabled"
+        BLACKBOARD_GROUPS_ENABLED = "blackboard.groups_enabled"
+
+        CANVAS_SECTIONS_ENABLED = "canvas.sections_enabled"
+        CANVAS_GROUPS_ENABLED = "canvas.groups_enabled"
+        CANVAS_FILES_ENABLED = "canvas.files_enabled"
+        CANVAS_FOLDERS_ENABLED = "canvas.folders_enabled"
+        CANVAS_STRICT_SECTION_MEMBERSHIP = "canvas.strict_section_membership"
+        CANVAS_PAGES_ENABLED = "canvas.pages_enabled"
+
+        CANVAS_STUDIO_ADMIN_EMAIL = "canvas_studio.admin_email"
+        CANVAS_STUDIO_CLIENT_ID = "canvas_studio.client_id"
+        CANVAS_STUDIO_CLIENT_SECRET = "canvas_studio.client_secret"  # noqa: S105
+        CANVAS_STUDIO_DOMAIN = "canvas_studio.domain"
+
+        D2L_CLIENT_ID = "desire2learn.client_id"
+        D2L_CLIENT_SECRET = "desire2learn.client_secret"  # noqa: S105
+        D2L_GROUPS_ENABLED = "desire2learn.groups_enabled"
+        D2L_FILES_ENABLED = "desire2learn.files_enabled"
+
+        GOOGLE_DRIVE_FILES_ENABLED = "google_drive.files_enabled"
+        MICROSOFT_ONEDRIVE_FILES_ENABLED = "microsoft_onedrive.files_enabled"
+
+        MOODLE_API_TOKEN = "moodle.api_token"  # noqa: S105
+        MOODLE_GROUPS_ENABLED = "moodle.groups_enabled"
+        MOODLE_FILES_ENABLED = "moodle.files_enabled"
+        MOODLE_PAGES_ENABLED = "moodle.pages_enabled"
+
+        VITALSOURCE_ENABLED = "vitalsource.enabled"
+        VITALSOURCE_USER_LTI_PARAM = "vitalsource.user_lti_param"
+        VITALSOURCE_USER_LTI_PATTERN = "vitalsource.user_lti_pattern"
+        VITALSOURCE_API_KEY = "vitalsource.api_key"
+        VITALSOURCE_STUDENT_PAY_ENABLED = "vitalsource.student_pay_enabled"
+
+        JSTOR_ENABLED = "jstor.enabled"
+        JSTOR_SITE_CODE = "jstor.site_code"
+
+        YOUTUBE_ENABLED = "youtube.enabled"
+
+        HYPOTHESIS_NOTES = "hypothesis.notes"
+        HYPOTHESIS_AUTO_ASSIGNED_TO_ORG = "hypothesis.auto_assigned_to_org"
+        HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED = (
+            "hypothesis.instructor_email_digests_enabled"
+        )
+        HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING = (
+            "hypothesis.lti_13_sourcedid_for_grading"
+        )
+
     fields = (
-        JSONSetting("blackboard", "files_enabled", asbool),
-        JSONSetting("blackboard", "groups_enabled", asbool),
-        JSONSetting("canvas", "sections_enabled", asbool),
-        JSONSetting("canvas", "groups_enabled", asbool),
-        JSONSetting("canvas", "files_enabled", asbool),
-        JSONSetting("canvas", "folders_enabled", asbool),
-        JSONSetting("canvas", "strict_section_membership", asbool),
-        JSONSetting("canvas", "pages_enabled", asbool),
-        JSONSetting("canvas_studio", "admin_email"),
-        JSONSetting("canvas_studio", "client_id"),
-        JSONSetting("canvas_studio", "client_secret", JSONSetting.AES_SECRET),
-        JSONSetting("canvas_studio", "domain"),
-        JSONSetting("desire2learn", "client_id"),
-        JSONSetting("desire2learn", "client_secret", JSONSetting.AES_SECRET),
-        JSONSetting("desire2learn", "groups_enabled", asbool),
-        JSONSetting("desire2learn", "files_enabled", asbool),
-        JSONSetting("google_drive", "files_enabled", asbool),
-        JSONSetting("microsoft_onedrive", "files_enabled", asbool),
-        JSONSetting("moodle", "api_token", JSONSetting.AES_SECRET),
-        JSONSetting("moodle", "groups_enabled", asbool),
-        JSONSetting("moodle", "files_enabled", asbool),
-        JSONSetting("moodle", "pages_enabled", asbool),
-        JSONSetting("vitalsource", "enabled", asbool),
-        JSONSetting("vitalsource", "user_lti_param"),
-        JSONSetting("vitalsource", "user_lti_pattern"),
-        JSONSetting("vitalsource", "api_key"),
-        JSONSetting("vitalsource", "student_pay_enabled", asbool),
-        JSONSetting("jstor", "enabled", asbool),
-        JSONSetting("jstor", "site_code"),
-        JSONSetting("youtube", "enabled", asbool),
-        JSONSetting("hypothesis", "notes", name="Notes"),
-        JSONSetting(
-            "hypothesis",
-            "auto_assigned_to_org",
-            asbool,
-            name="Auto Assigned To Organisation",
-        ),
-        JSONSetting("hypothesis", "instructor_email_digests_enabled", asbool),
-        JSONSetting("hypothesis", "lti_13_sourcedid_for_grading", asbool),
+        JSONSetting(Settings.BLACKBOARD_FILES_ENABLED, asbool),
+        JSONSetting(Settings.BLACKBOARD_GROUPS_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_SECTIONS_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_GROUPS_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_FILES_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_FOLDERS_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_STRICT_SECTION_MEMBERSHIP, asbool),
+        JSONSetting(Settings.CANVAS_PAGES_ENABLED, asbool),
+        JSONSetting(Settings.CANVAS_STUDIO_ADMIN_EMAIL),
+        JSONSetting(Settings.CANVAS_STUDIO_CLIENT_ID),
+        JSONSetting(Settings.CANVAS_STUDIO_CLIENT_SECRET, JSONSetting.AES_SECRET),
+        JSONSetting(Settings.CANVAS_STUDIO_DOMAIN),
+        JSONSetting(Settings.D2L_CLIENT_ID),
+        JSONSetting(Settings.D2L_CLIENT_SECRET, JSONSetting.AES_SECRET),
+        JSONSetting(Settings.D2L_GROUPS_ENABLED, asbool),
+        JSONSetting(Settings.D2L_FILES_ENABLED, asbool),
+        JSONSetting(Settings.GOOGLE_DRIVE_FILES_ENABLED, asbool),
+        JSONSetting(Settings.MICROSOFT_ONEDRIVE_FILES_ENABLED, asbool),
+        JSONSetting(Settings.MOODLE_API_TOKEN, JSONSetting.AES_SECRET),
+        JSONSetting(Settings.MOODLE_GROUPS_ENABLED, asbool),
+        JSONSetting(Settings.MOODLE_FILES_ENABLED, asbool),
+        JSONSetting(Settings.MOODLE_PAGES_ENABLED, asbool),
+        JSONSetting(Settings.VITALSOURCE_ENABLED, asbool),
+        JSONSetting(Settings.VITALSOURCE_USER_LTI_PARAM),
+        JSONSetting(Settings.VITALSOURCE_USER_LTI_PATTERN),
+        JSONSetting(Settings.VITALSOURCE_API_KEY),
+        JSONSetting(Settings.VITALSOURCE_STUDENT_PAY_ENABLED, asbool),
+        JSONSetting(Settings.JSTOR_ENABLED, asbool),
+        JSONSetting(Settings.JSTOR_SITE_CODE),
+        JSONSetting(Settings.YOUTUBE_ENABLED, asbool),
+        JSONSetting(Settings.HYPOTHESIS_NOTES),
+        JSONSetting(Settings.HYPOTHESIS_AUTO_ASSIGNED_TO_ORG, asbool),
+        JSONSetting(Settings.HYPOTHESIS_INSTRUCTOR_EMAIL_DIGESTS_ENABLED, asbool),
+        JSONSetting(Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, asbool),
     )
 
 

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -110,7 +110,19 @@ class JSONSettings(MutableDict):
         return super().get(group, {}).get(key, default)
 
     def get_setting(self, setting: JSONSetting):
-        return self.get(setting.group, setting.key, setting.default)
+        value = self.get(setting.group, setting.key, setting.default)
+        if value is None:  # None is used a sentinel for "unset" or "default"
+            value = setting.default
+
+        return value
+
+    def get_raw_setting(self, setting: JSONSetting):
+        """Get the value of the setting as is stored on the DB.
+
+        This method for example ignores the default value.
+        """
+
+        return super().get(setting.group, {}).get(setting.key)
 
     def set(self, group, key, value):
         """

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -18,7 +18,7 @@ class JSONSetting:
     """The group name that this setting is a part of."""
 
     key: str
-    """The key within the grouo that this setting is a part of."""
+    """The key within the group that this setting is a part of."""
 
     format: Any = str
     """An identifier to say what type of field this is."""

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import InstrumentedAttribute
 
 
-@dataclass
+@dataclass(init=False)
 class JSONSetting:
     """Describe a permitted field in a JSONSettings object."""
 
@@ -23,19 +23,14 @@ class JSONSetting:
     format: Any = str
     """An identifier to say what type of field this is."""
 
-    name: str | None = None
-    """An optional name for the field."""
+    def __init__(self, compound_key: str, format_: Any = str):
+        self.group, self.key = compound_key.split(".")
+        self.format = format_
 
     @property
     def compound_key(self) -> str:
         """Get the group and key as a single value."""
         return f"{self.group}.{self.key}"
-
-    @property
-    def label(self) -> str:
-        """Get a label for this field."""
-
-        return self.name or self.compound_key
 
 
 class JSONSettings(MutableDict):

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -1,4 +1,5 @@
 import base64
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -62,7 +63,7 @@ class JSONSettings(MutableDict):
     >>> model.settings.changed()
     """
 
-    fields: tuple[JSONSetting, ...] | None = None
+    fields: Mapping[Any, JSONSetting] | None = None
     """
     An optional spec for the acceptable fields and types.
     """

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -24,9 +24,12 @@ class JSONSetting:
     format: Any = str
     """An identifier to say what type of field this is."""
 
-    def __init__(self, compound_key: str, format_: Any = str):
+    default: Any = None
+
+    def __init__(self, compound_key: str, format_: Any = str, default=None):
         self.group, self.key = compound_key.split(".")
         self.format = format_
+        self.default = default
 
     @property
     def compound_key(self) -> str:
@@ -80,6 +83,9 @@ class JSONSettings(MutableDict):
         :return: The value or None
         """
         return super().get(group, {}).get(key, default)
+
+    def get_setting(self, setting: JSONSetting):
+        return self.get(setting.group, setting.key, setting.default)
 
     def set(self, group, key, value):
         """

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -18,6 +18,13 @@ class SettingFormat(Enum):
     """
 
     BOOLEAN = member(asbool)
+    """Regular True/False boolean. Convert it from strings using pyramid's asbool function"""
+
+    TRI_STATE = member(lambda value: None if value == "none" else asbool(value))
+    """Tri state True/False/None. Use "none" for the third state, pass the value to asbool otherwise.
+
+    In settings the third value is meant to represent "unset" or "default"
+    """
 
     AES_SECRET = object()  # Helper to declare settings as secret.
 

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -1,3 +1,4 @@
+from enum import StrEnum, Enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -5,6 +6,15 @@ from sqlalchemy.orm import Mapped, mapped_column
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
 from lms.models.json_settings import JSONSettings
+
+
+class OrganizationSettings(JSONSettings):
+    class Settings(StrEnum, Enum):
+        HYPOTHESIS_NOTES = "hypothesis.notes"
+
+    fields: dict[Settings, JSONSetting] = {
+        Settings.HYPOTHESIS_NOTES: JSONSetting(Settings.HYPOTHESIS_NOTES),
+    }
 
 
 class Organization(CreatedUpdatedMixin, Base):
@@ -39,8 +49,8 @@ class Organization(CreatedUpdatedMixin, Base):
     )
     """Get any application instances associated with this organization."""
 
-    settings: Mapped[JSONSettings] = mapped_column(
-        JSONSettings.as_mutable(JSONB()),
+    settings: Mapped[OrganizationSettings] = mapped_column(
+        OrganizationSettings.as_mutable(JSONB()),
         server_default=sa.text("'{}'::jsonb"),
         nullable=False,
     )

--- a/lms/models/organization.py
+++ b/lms/models/organization.py
@@ -1,18 +1,20 @@
-from enum import StrEnum, Enum
+from collections.abc import Mapping
+from enum import Enum, StrEnum
+
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from lms.db import Base
 from lms.models._mixins import CreatedUpdatedMixin
-from lms.models.json_settings import JSONSettings
+from lms.models.json_settings import JSONSetting, JSONSettings
 
 
 class OrganizationSettings(JSONSettings):
     class Settings(StrEnum, Enum):
         HYPOTHESIS_NOTES = "hypothesis.notes"
 
-    fields: dict[Settings, JSONSetting] = {
+    fields: Mapping[Settings, JSONSetting] = {
         Settings.HYPOTHESIS_NOTES: JSONSetting(Settings.HYPOTHESIS_NOTES),
     }
 

--- a/lms/services/youtube.py
+++ b/lms/services/youtube.py
@@ -90,7 +90,9 @@ def factory(_context, request) -> YouTubeService:
     app_settings = request.registry.settings
 
     return YouTubeService(
-        enabled=ai_settings.get("youtube", "enabled", True),
+        enabled=ai_settings.get_setting(
+            ai_settings.fields[ai_settings.Settings.YOUTUBE_ENABLED]
+        ),
         api_key=app_settings.get("youtube_api_key"),
         http=request.find_service(name="http"),
     )

--- a/lms/templates/admin/application_instance/search.html.jinja2
+++ b/lms/templates/admin/application_instance/search.html.jinja2
@@ -22,7 +22,7 @@
                                 {% for setting in settings.values() %}
                                     <option value="{{ setting.compound_key }}"
                                             {% if request.params.get("settings_key") == setting.compound_key %}selected{% endif %}>
-                                        {{ setting.label }}
+                                        {{ setting.compound_key }}
                                     </option>
                                 {% endfor %}
                             </select>

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -21,6 +21,15 @@
         </label>
     {% endcall %}
 {% endmacro %}
+{% macro setting_checkbox(label, setting, field_name) %}
+    {% call macros.field_body(label) %}
+        <label class="checkbox">
+            <input {% if instance.settings.get_setting(setting) %}checked{% endif %}
+                   type="checkbox"
+                   name="{{ setting.group }}.{{ setting.key }}">
+        </label>
+    {% endcall %}
+{% endmacro %}
 {% macro settings_text_field(label, setting, sub_setting, field_name, default='') %}
     {% call macros.field_body(label) %}
         <input value="{{ instance.settings.get(setting, sub_setting, default) or '' }}"
@@ -63,7 +72,7 @@
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                         <fieldset class="box">
                             {{ macros.form_text_field(request, "Name", "name", field_value=instance.name) }}
-                            {{ macros.settings_textarea(instance, "Notes", fields[instance.settings.Settings.HYPOTHESIS_NOTES]) }}
+                            {{ macros.settings_textarea(instance, "Notes", fields[Settings.HYPOTHESIS_NOTES]) }}
                             {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
                             {{ macros.disabled_text_field("Shared secret", instance.shared_secret) }}
                             {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
@@ -173,7 +182,7 @@
                             {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
                             {{ settings_checkbox('JSTOR enabled', 'jstor', 'enabled') }}
                             {{ settings_text_field('JSTOR site code', 'jstor', 'site_code') }}
-                            {{ settings_checkbox("YouTube enabled", "youtube", "enabled", default=True) }}
+                            {{ setting_checkbox("Youtube enabled", fields[Settings.YOUTUBE_ENABLED]) }}
                         </fieldset>
                         <div class="has-text-right mb-6">
                             <input type="submit" class="button is-primary" value="Save" />

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -12,12 +12,16 @@
         {% endif %}
     </span>
 {% endblock %}
-{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
+{# Tri-state checkbox with enabled/disabled/use-default options. #}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=None) %}
     {% call macros.field_body(label) %}
-        <label class="checkbox">
-            <input {% if instance.settings.get(setting, sub_setting, default) %}checked{% endif %}
-                   type="checkbox"
-                   name="{{ setting }}.{{ sub_setting }}">
+        {% set value = instance.settings.get(setting, sub_setting, default) %}
+        <label class="select">
+            <select name="{{setting}}.{{sub_setting}}">
+              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
+              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
+              <option value="none" {% if value is none %}selected {% endif %}>Default</option>
+            </select>
         </label>
     {% endcall %}
 {% endmacro %}

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -63,7 +63,7 @@
                         <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                         <fieldset class="box">
                             {{ macros.form_text_field(request, "Name", "name", field_value=instance.name) }}
-                            {{ macros.settings_textarea(instance, "Notes", "hypothesis", "notes") }}
+                            {{ macros.settings_textarea(instance, "Notes", fields[instance.settings.Settings.HYPOTHESIS_NOTES]) }}
                             {{ macros.disabled_text_field("Consumer key", instance.consumer_key) }}
                             {{ macros.disabled_text_field("Shared secret", instance.shared_secret) }}
                             {{ macros.form_text_field(request, "Deployment ID", "deployment_id", field_value=instance.deployment_id) }}
@@ -118,7 +118,7 @@
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>
                             {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
-                            {# Note the mismatch betwween canvas nomenclature and ours #}
+                            {# Note the mismatch between canvas nomenclature and ours #}
                             {# developer id -> developer key #}
                             {# developer key -> developer secret #}
                             {{ macros.form_text_field(request, "Developer ID", "developer_key", field_value=instance.developer_key) }}

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -12,25 +12,25 @@
         {% endif %}
     </span>
 {% endblock %}
-{# Tri-state checkbox with enabled/disabled/use-default options. #}
-{% macro settings_checkbox(label, setting, sub_setting, field_name, default=None) %}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
     {% call macros.field_body(label) %}
-        {% set value = instance.settings.get(setting, sub_setting, default) %}
-        <label class="select">
-            <select name="{{setting}}.{{sub_setting}}">
-              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
-              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
-              <option value="none" {% if value is none %}selected {% endif %}>Default</option>
-            </select>
+        <label class="checkbox">
+            <input {% if instance.settings.get(setting, sub_setting, default) %}checked{% endif %}
+                   type="checkbox"
+                   name="{{ setting }}.{{ sub_setting }}">
         </label>
     {% endcall %}
 {% endmacro %}
-{% macro setting_checkbox(label, setting, field_name) %}
+{# Tri-state checkbox with enabled/disabled/use-default options. #}
+{% macro tri_state_settings_checkbox(label, setting) %}
     {% call macros.field_body(label) %}
-        <label class="checkbox">
-            <input {% if instance.settings.get_setting(setting) %}checked{% endif %}
-                   type="checkbox"
-                   name="{{ setting.group }}.{{ setting.key }}">
+        {% set value = instance.settings.get_raw_setting(setting) %}
+        <label class="select">
+            <select name="{{setting.group}}.{{setting.key}}">
+              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
+              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
+              <option value="none" {% if value is none %}selected {% endif %}>Default ({{ setting.default }})</option>
+            </select>
         </label>
     {% endcall %}
 {% endmacro %}
@@ -186,7 +186,7 @@
                             {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
                             {{ settings_checkbox('JSTOR enabled', 'jstor', 'enabled') }}
                             {{ settings_text_field('JSTOR site code', 'jstor', 'site_code') }}
-                            {{ setting_checkbox("Youtube enabled", fields[Settings.YOUTUBE_ENABLED]) }}
+                            {{ tri_state_settings_checkbox("Youtube enabled", fields[Settings.YOUTUBE_ENABLED]) }}
                         </fieldset>
                         <div class="has-text-right mb-6">
                             <input type="submit" class="button is-primary" value="Save" />

--- a/lms/templates/admin/macros.html.jinja2
+++ b/lms/templates/admin/macros.html.jinja2
@@ -52,10 +52,10 @@
         {% endif %}
     {% endcall %}
 {% endmacro %}
-{% macro settings_textarea(object, label, setting, sub_setting, field_name, default='') %}
+{% macro settings_textarea(object, label, setting, field_name, default='') %}
     {% call field_body(label) %}
-        {% set text = object.settings.get(setting, sub_setting, default) or '' %}
-        <textarea class="textarea" name="{{ setting }}.{{ sub_setting }}">{{ text }}</textarea>
+        {% set text = object.settings.get(setting.group, setting.key, default) or '' %}
+        <textarea class="textarea" name="{{ setting.compound_key }}">{{ text }}</textarea>
     {% endcall %}
 {% endmacro %}
 {% macro registration_fields(request, lti_registration, view_button=False) %}

--- a/lms/templates/admin/organization/show.html.jinja2
+++ b/lms/templates/admin/organization/show.html.jinja2
@@ -47,7 +47,7 @@
                             <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
                             {{ macros.disabled_text_field("ID", org.public_id) }}
                             {{ macros.form_text_field(request, "Name", "name", org.name) }}
-                            {{ macros.settings_textarea(org, "Notes", "hypothesis", "notes") }}
+                            {{ macros.settings_textarea(org, "Notes", fields[org.settings.Settings.HYPOTHESIS_NOTES]) }}
                             {{ macros.created_updated_fields(org) }}
                             <div class="has-text-right mb-6">
                                 <input type="submit" class="button is-primary" value="Save" />

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -12,8 +12,8 @@ from lms.views.admin._schemas import EmptyStringInt
 from lms.views.admin.application_instance._core import BaseApplicationInstanceView
 
 SETTINGS_BY_FIELD = {
-    field.compound_key: field
-    for field in ApplicationSettings.fields
+    key: field
+    for key, field in ApplicationSettings.fields.items()
     if field.format != JSONSetting.AES_SECRET
 }
 

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -52,7 +52,7 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
         settings = None
         if settings_key := self.request.params.get("settings_key"):
             if settings_value := self.request.params.get("settings_value"):
-                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(  # type: ignore[operator]
+                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(
                     settings_value
                 )
             else:

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -3,7 +3,7 @@ from pyramid.view import view_config, view_defaults
 from webargs import fields
 
 from lms.models import ApplicationSettings
-from lms.models.json_settings import JSONSetting
+from lms.models.json_settings import JSONSetting, SettingFormat
 from lms.security import Permissions
 from lms.services import InvalidPublicId
 from lms.validation import PyramidRequestSchema
@@ -11,10 +11,10 @@ from lms.views.admin import flash_validation
 from lms.views.admin._schemas import EmptyStringInt
 from lms.views.admin.application_instance._core import BaseApplicationInstanceView
 
-SETTINGS_BY_FIELD = {
+SETTINGS_BY_FIELD: dict[str, JSONSetting] = {
     key: field
     for key, field in ApplicationSettings.fields.items()
-    if field.format != JSONSetting.AES_SECRET
+    if field.format != SettingFormat.AES_SECRET
 }
 
 
@@ -52,7 +52,9 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
         settings = None
         if settings_key := self.request.params.get("settings_key"):
             if settings_value := self.request.params.get("settings_value"):
-                settings_value = SETTINGS_BY_FIELD[settings_key].format(settings_value)
+                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(  # type: ignore[operator]
+                    settings_value
+                )
             else:
                 settings_value = ...
 

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -52,7 +52,7 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
         settings = None
         if settings_key := self.request.params.get("settings_key"):
             if settings_value := self.request.params.get("settings_value"):
-                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(
+                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(  # type: ignore[operator]
                     settings_value
                 )
             else:

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -15,6 +15,6 @@ class ShowApplicationInstanceView(BaseApplicationInstanceView):
     def show_instance(self):
         return {
             "instance": self.application_instance,
-            "Settings": self.application_instance.Settings,
+            "Settings": self.application_instance.settings.Settings,
             "fields": self.application_instance.settings.fields,
         }

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -13,4 +13,7 @@ class ShowApplicationInstanceView(BaseApplicationInstanceView):
     @view_config(route_name="admin.instance")
     @view_config(route_name="admin.instance.section")
     def show_instance(self):
-        return {"instance": self.application_instance}
+        return {
+            "instance": self.application_instance,
+            "fields": self.application_instance.settings.fields,
+        }

--- a/lms/views/admin/application_instance/show.py
+++ b/lms/views/admin/application_instance/show.py
@@ -15,5 +15,6 @@ class ShowApplicationInstanceView(BaseApplicationInstanceView):
     def show_instance(self):
         return {
             "instance": self.application_instance,
+            "Settings": self.application_instance.Settings,
             "fields": self.application_instance.settings.fields,
         }

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -80,11 +80,8 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = self.request.params.get(field.compound_key)
             value = value.strip() if value else None
 
-            if field.format is SettingFormat.BOOLEAN:
-                if value == "none":
-                    value = None
-                else:
-                    value = asbool(value)
+            if field.format in [SettingFormat.BOOLEAN, SettingFormat.TRI_STATE]:
+                value = format.value(value)
                 ai.settings.set(field.group, field.key, value)
 
             elif field.format == SettingFormat.AES_SECRET:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -81,8 +81,8 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = value.strip() if value else None
 
             if field.format in [SettingFormat.BOOLEAN, SettingFormat.TRI_STATE]:
-                value = format.value(value)
-                ai.settings.set(field.group, field.key, value)
+                setting_value = field.format.value(value)  # type: ignore[operator]
+                ai.settings.set(field.group, field.key, setting_value)
 
             elif field.format == SettingFormat.AES_SECRET:
                 if not value:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -81,7 +81,10 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = value.strip() if value else None
 
             if field.format is SettingFormat.BOOLEAN:
-                value = value == "on"
+                if value == "none":
+                    value = None
+                else:
+                    value = asbool(value)
                 ai.settings.set(field.group, field.key, value)
 
             elif field.format == SettingFormat.AES_SECRET:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -1,9 +1,8 @@
 from marshmallow import fields, validate
-from pyramid.settings import asbool
 from pyramid.view import view_config
 
 from lms.models import ApplicationSettings
-from lms.models.json_settings import JSONSetting
+from lms.models.json_settings import SettingFormat
 from lms.security import Permissions
 from lms.services.aes import AESService
 from lms.validation._base import PyramidRequestSchema
@@ -81,18 +80,18 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = self.request.params.get(field.compound_key)
             value = value.strip() if value else None
 
-            if field.format is asbool:
+            if field.format is SettingFormat.BOOLEAN:
                 value = value == "on"
                 ai.settings.set(field.group, field.key, value)
 
-            elif field.format == JSONSetting.AES_SECRET:
+            elif field.format == SettingFormat.AES_SECRET:
                 if not value:
                     continue
 
                 ai.settings.set_secret(self._aes_service, field.group, field.key, value)
 
             else:
-                assert field.format is str  # noqa: S101
+                assert field.format is SettingFormat.STRING  # noqa: S101
                 ai.settings.set(field.group, field.key, value)
 
         self.request.session.flash(

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -73,7 +73,7 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             developer_secret=self.request.params.get("developer_secret", "").strip(),
         )
 
-        for field in ApplicationSettings.fields:
+        for field in ApplicationSettings.fields.values():
             # Notes are updated in the main `info` tab, skip it here
             if field.compound_key == "hypothesis.notes":
                 continue

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -108,7 +108,7 @@ class AdminOrganizationViews:
 
         return {
             "org": org,
-            "Settings": org.settings.fields.Settings,
+            "Settings": org.settings.Settings,
             "fields": org.settings.fields,
             "company": self.hubspot_service.get_company(org.public_id),
             "hierarchy_root": self.organization_service.get_hierarchy_root(org.id),

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -108,6 +108,7 @@ class AdminOrganizationViews:
 
         return {
             "org": org,
+            "fields": org.settings.fields,
             "company": self.hubspot_service.get_company(org.public_id),
             "hierarchy_root": self.organization_service.get_hierarchy_root(org.id),
             "sort_by_name": lambda items: sorted(

--- a/lms/views/admin/organization.py
+++ b/lms/views/admin/organization.py
@@ -108,6 +108,7 @@ class AdminOrganizationViews:
 
         return {
             "org": org,
+            "Settings": org.settings.fields.Settings,
             "fields": org.settings.fields,
             "company": self.hubspot_service.get_company(org.public_id),
             "hierarchy_root": self.organization_service.get_hierarchy_root(org.id),

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -1,10 +1,97 @@
 from unittest.mock import sentinel
 
 import pytest
+from pyramid.settings import asbool
 from sqlalchemy.exc import IntegrityError
 
-from lms.models import ApplicationInstance, Family
+from lms.models import ApplicationInstance, ApplicationSettings, Family
+from lms.models.json_settings import JSONSetting
 from tests import factories
+
+
+class TestApplicationSettings:
+    def test_it(self):
+        settings_fields_keys = [
+            (s.group, s.key, s.compound_key, s.format)
+            for s in ApplicationSettings.fields
+        ]
+
+        assert settings_fields_keys == [
+            ("blackboard", "files_enabled", "blackboard.files_enabled", asbool),
+            ("blackboard", "groups_enabled", "blackboard.groups_enabled", asbool),
+            ("canvas", "sections_enabled", "canvas.sections_enabled", asbool),
+            ("canvas", "groups_enabled", "canvas.groups_enabled", asbool),
+            ("canvas", "files_enabled", "canvas.files_enabled", asbool),
+            ("canvas", "folders_enabled", "canvas.folders_enabled", asbool),
+            (
+                "canvas",
+                "strict_section_membership",
+                "canvas.strict_section_membership",
+                asbool,
+            ),
+            ("canvas", "pages_enabled", "canvas.pages_enabled", asbool),
+            ("canvas_studio", "admin_email", "canvas_studio.admin_email", str),
+            ("canvas_studio", "client_id", "canvas_studio.client_id", str),
+            (
+                "canvas_studio",
+                "client_secret",
+                "canvas_studio.client_secret",
+                JSONSetting.AES_SECRET,
+            ),
+            ("canvas_studio", "domain", "canvas_studio.domain", str),
+            ("desire2learn", "client_id", "desire2learn.client_id", str),
+            (
+                "desire2learn",
+                "client_secret",
+                "desire2learn.client_secret",
+                JSONSetting.AES_SECRET,
+            ),
+            ("desire2learn", "groups_enabled", "desire2learn.groups_enabled", asbool),
+            ("desire2learn", "files_enabled", "desire2learn.files_enabled", asbool),
+            ("google_drive", "files_enabled", "google_drive.files_enabled", asbool),
+            (
+                "microsoft_onedrive",
+                "files_enabled",
+                "microsoft_onedrive.files_enabled",
+                asbool,
+            ),
+            ("moodle", "api_token", "moodle.api_token", JSONSetting.AES_SECRET),
+            ("moodle", "groups_enabled", "moodle.groups_enabled", asbool),
+            ("moodle", "files_enabled", "moodle.files_enabled", asbool),
+            ("moodle", "pages_enabled", "moodle.pages_enabled", asbool),
+            ("vitalsource", "enabled", "vitalsource.enabled", asbool),
+            ("vitalsource", "user_lti_param", "vitalsource.user_lti_param", str),
+            ("vitalsource", "user_lti_pattern", "vitalsource.user_lti_pattern", str),
+            ("vitalsource", "api_key", "vitalsource.api_key", str),
+            (
+                "vitalsource",
+                "student_pay_enabled",
+                "vitalsource.student_pay_enabled",
+                asbool,
+            ),
+            ("jstor", "enabled", "jstor.enabled", asbool),
+            ("jstor", "site_code", "jstor.site_code", str),
+            ("youtube", "enabled", "youtube.enabled", asbool),
+            ("hypothesis", "notes", "hypothesis.notes", str),
+            (
+                "hypothesis",
+                "auto_assigned_to_org",
+                "hypothesis.auto_assigned_to_org",
+                asbool,
+            ),
+            (
+                "hypothesis",
+                "instructor_email_digests_enabled",
+                "hypothesis.instructor_email_digests_enabled",
+                asbool,
+            ),
+            (
+                "hypothesis",
+                "lti_13_sourcedid_for_grading",
+                "hypothesis.lti_13_sourcedid_for_grading",
+                asbool,
+            ),
+        ]
 
 
 class TestApplicationInstance:

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -13,7 +13,7 @@ class TestApplicationSettings:
     def test_it(self):
         settings_fields_keys = [
             (s.group, s.key, s.compound_key, s.format)
-            for s in ApplicationSettings.fields
+            for s in ApplicationSettings.fields.values()
         ]
 
         assert settings_fields_keys == [

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -1,11 +1,10 @@
 from unittest.mock import sentinel
 
 import pytest
-from pyramid.settings import asbool
 from sqlalchemy.exc import IntegrityError
 
 from lms.models import ApplicationInstance, ApplicationSettings, Family
-from lms.models.json_settings import JSONSetting
+from lms.models.json_settings import SettingFormat
 from tests import factories
 
 
@@ -17,79 +16,149 @@ class TestApplicationSettings:
         ]
 
         assert settings_fields_keys == [
-            ("blackboard", "files_enabled", "blackboard.files_enabled", asbool),
-            ("blackboard", "groups_enabled", "blackboard.groups_enabled", asbool),
-            ("canvas", "sections_enabled", "canvas.sections_enabled", asbool),
-            ("canvas", "groups_enabled", "canvas.groups_enabled", asbool),
-            ("canvas", "files_enabled", "canvas.files_enabled", asbool),
-            ("canvas", "folders_enabled", "canvas.folders_enabled", asbool),
+            (
+                "blackboard",
+                "files_enabled",
+                "blackboard.files_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            (
+                "blackboard",
+                "groups_enabled",
+                "blackboard.groups_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            (
+                "canvas",
+                "sections_enabled",
+                "canvas.sections_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            (
+                "canvas",
+                "groups_enabled",
+                "canvas.groups_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            ("canvas", "files_enabled", "canvas.files_enabled", SettingFormat.BOOLEAN),
+            (
+                "canvas",
+                "folders_enabled",
+                "canvas.folders_enabled",
+                SettingFormat.BOOLEAN,
+            ),
             (
                 "canvas",
                 "strict_section_membership",
                 "canvas.strict_section_membership",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
-            ("canvas", "pages_enabled", "canvas.pages_enabled", asbool),
-            ("canvas_studio", "admin_email", "canvas_studio.admin_email", str),
-            ("canvas_studio", "client_id", "canvas_studio.client_id", str),
+            ("canvas", "pages_enabled", "canvas.pages_enabled", SettingFormat.BOOLEAN),
+            (
+                "canvas_studio",
+                "admin_email",
+                "canvas_studio.admin_email",
+                SettingFormat.STRING,
+            ),
+            (
+                "canvas_studio",
+                "client_id",
+                "canvas_studio.client_id",
+                SettingFormat.STRING,
+            ),
             (
                 "canvas_studio",
                 "client_secret",
                 "canvas_studio.client_secret",
-                JSONSetting.AES_SECRET,
+                SettingFormat.AES_SECRET,
             ),
-            ("canvas_studio", "domain", "canvas_studio.domain", str),
-            ("desire2learn", "client_id", "desire2learn.client_id", str),
+            ("canvas_studio", "domain", "canvas_studio.domain", SettingFormat.STRING),
+            (
+                "desire2learn",
+                "client_id",
+                "desire2learn.client_id",
+                SettingFormat.STRING,
+            ),
             (
                 "desire2learn",
                 "client_secret",
                 "desire2learn.client_secret",
-                JSONSetting.AES_SECRET,
+                SettingFormat.AES_SECRET,
             ),
-            ("desire2learn", "groups_enabled", "desire2learn.groups_enabled", asbool),
-            ("desire2learn", "files_enabled", "desire2learn.files_enabled", asbool),
-            ("google_drive", "files_enabled", "google_drive.files_enabled", asbool),
+            (
+                "desire2learn",
+                "groups_enabled",
+                "desire2learn.groups_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            (
+                "desire2learn",
+                "files_enabled",
+                "desire2learn.files_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            (
+                "google_drive",
+                "files_enabled",
+                "google_drive.files_enabled",
+                SettingFormat.BOOLEAN,
+            ),
             (
                 "microsoft_onedrive",
                 "files_enabled",
                 "microsoft_onedrive.files_enabled",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
-            ("moodle", "api_token", "moodle.api_token", JSONSetting.AES_SECRET),
-            ("moodle", "groups_enabled", "moodle.groups_enabled", asbool),
-            ("moodle", "files_enabled", "moodle.files_enabled", asbool),
-            ("moodle", "pages_enabled", "moodle.pages_enabled", asbool),
-            ("vitalsource", "enabled", "vitalsource.enabled", asbool),
-            ("vitalsource", "user_lti_param", "vitalsource.user_lti_param", str),
-            ("vitalsource", "user_lti_pattern", "vitalsource.user_lti_pattern", str),
-            ("vitalsource", "api_key", "vitalsource.api_key", str),
+            ("moodle", "api_token", "moodle.api_token", SettingFormat.AES_SECRET),
+            (
+                "moodle",
+                "groups_enabled",
+                "moodle.groups_enabled",
+                SettingFormat.BOOLEAN,
+            ),
+            ("moodle", "files_enabled", "moodle.files_enabled", SettingFormat.BOOLEAN),
+            ("moodle", "pages_enabled", "moodle.pages_enabled", SettingFormat.BOOLEAN),
+            ("vitalsource", "enabled", "vitalsource.enabled", SettingFormat.BOOLEAN),
+            (
+                "vitalsource",
+                "user_lti_param",
+                "vitalsource.user_lti_param",
+                SettingFormat.STRING,
+            ),
+            (
+                "vitalsource",
+                "user_lti_pattern",
+                "vitalsource.user_lti_pattern",
+                SettingFormat.STRING,
+            ),
+            ("vitalsource", "api_key", "vitalsource.api_key", SettingFormat.STRING),
             (
                 "vitalsource",
                 "student_pay_enabled",
                 "vitalsource.student_pay_enabled",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
-            ("jstor", "enabled", "jstor.enabled", asbool),
-            ("jstor", "site_code", "jstor.site_code", str),
-            ("youtube", "enabled", "youtube.enabled", asbool),
-            ("hypothesis", "notes", "hypothesis.notes", str),
+            ("jstor", "enabled", "jstor.enabled", SettingFormat.BOOLEAN),
+            ("jstor", "site_code", "jstor.site_code", SettingFormat.STRING),
+            ("youtube", "enabled", "youtube.enabled", SettingFormat.BOOLEAN),
+            ("hypothesis", "notes", "hypothesis.notes", SettingFormat.STRING),
             (
                 "hypothesis",
                 "auto_assigned_to_org",
                 "hypothesis.auto_assigned_to_org",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
             (
                 "hypothesis",
                 "instructor_email_digests_enabled",
                 "hypothesis.instructor_email_digests_enabled",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
             (
                 "hypothesis",
                 "lti_13_sourcedid_for_grading",
                 "hypothesis.lti_13_sourcedid_for_grading",
-                asbool,
+                SettingFormat.BOOLEAN,
             ),
         ]
 

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -140,7 +140,7 @@ class TestApplicationSettings:
             ),
             ("jstor", "enabled", "jstor.enabled", SettingFormat.BOOLEAN),
             ("jstor", "site_code", "jstor.site_code", SettingFormat.STRING),
-            ("youtube", "enabled", "youtube.enabled", SettingFormat.BOOLEAN),
+            ("youtube", "enabled", "youtube.enabled", SettingFormat.TRI_STATE),
             ("hypothesis", "notes", "hypothesis.notes", SettingFormat.STRING),
             (
                 "hypothesis",

--- a/tests/unit/lms/models/json_settings_test.py
+++ b/tests/unit/lms/models/json_settings_test.py
@@ -19,7 +19,9 @@ class TestJSONSetting:
 
 class TestJSONSettings:
     def test_data(self, settings):
-        assert settings == {"test_group": {"test_key": "test_value"}}
+        assert settings == {
+            "test_group": {"test_key": "test_value", "key_with_none": None}
+        }
 
     @pytest.mark.parametrize(
         "group,key,default,expected_value",
@@ -40,6 +42,34 @@ class TestJSONSettings:
     )
     def test_get(self, settings, group, key, default, expected_value):
         assert settings.get(group, key, default) == expected_value
+
+    @pytest.mark.parametrize(
+        "group,key,default,expected_value",
+        [
+            # If there's a value in the data it returns it.
+            ("test_group", "test_key", None, "test_value"),
+            # If the key is missing from the data it returns None.
+            ("test_group", "unknown_key", None, None),
+            # If the entire group is missing from the data it returns None.
+            ("unknown_group", "test_key", None, None),
+            # Ignores default if key is present
+            ("test_group", "test_key", "DEFAULT", "test_value"),
+            # If the key is missing from the data it returns the default
+            ("test_group", "unknown_key", "DEFAULT", "DEFAULT"),
+            # If the entire group is missing from the data it also returns the default
+            ("unknown_group", "test_key", "DEFAULT", "DEFAULT"),
+            # If the value is None it also returns the default
+            ("test_group", "key_with_none", "DEFAULT", "DEFAULT"),
+        ],
+    )
+    def test_get_setting(self, settings, group, key, default, expected_value):
+        assert (
+            settings.get_setting(JSONSetting(f"{group}.{key}", default=default))
+            == expected_value
+        )
+
+    def test_get_raw_setting(self, settings):
+        assert settings.get_raw_setting(JSONSetting("test_group.key_with_none")) is None
 
     @pytest.mark.parametrize(
         "group,key,value,expected_value",
@@ -110,17 +140,21 @@ class TestJSONSettings:
 
     def test__repr__(self, settings):
         assert (
-            repr(settings) == "JSONSettings({'test_group': {'test_key': 'test_value'}})"
+            repr(settings)
+            == "JSONSettings({'test_group': {'test_key': 'test_value', 'key_with_none': None}})"
         )
 
     def test__str__(self, settings):
         assert (
-            str(settings) == "JSONSettings({'test_group': {'test_key': 'test_value'}})"
+            str(settings)
+            == "JSONSettings({'test_group': {'test_key': 'test_value', 'key_with_none': None}})"
         )
 
     @pytest.fixture
     def settings(self):
-        return JSONSettings({"test_group": {"test_key": "test_value"}})
+        return JSONSettings(
+            {"test_group": {"test_key": "test_value", "key_with_none": None}}
+        )
 
     @pytest.fixture
     def aes(self):

--- a/tests/unit/lms/models/json_settings_test.py
+++ b/tests/unit/lms/models/json_settings_test.py
@@ -10,19 +10,11 @@ from tests import factories
 
 class TestJSONSetting:
     def test_compound_key(self):
-        setting = JSONSetting("group", "key")
+        setting = JSONSetting("group.key")
 
         assert setting.compound_key == "group.key"
-
-    @pytest.mark.parametrize(
-        "setting,expected",
-        (
-            (JSONSetting("group", "key"), "group.key"),
-            (JSONSetting("group", "key", name="name"), "name"),
-        ),
-    )
-    def test_label(self, setting, expected):
-        assert setting.label == expected
+        assert setting.group == "group"
+        assert setting.key == "key"
 
 
 class TestJSONSettings:

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -87,16 +87,20 @@ class TestUpdateApplicationInstanceView:
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
-            # Tri-state boolean fields
-            ("canvas", "groups_enabled", "true", True),
-            ("canvas", "sections_enabled", "false", False),
-            ("blackboard", "files_enabled", "none", None),
-            ("blackboard", "groups_enabled", "false", False),
+            # Boolean fields
+            ("canvas", "groups_enabled", "on", True),
+            ("canvas", "sections_enabled", "", False),
+            ("blackboard", "files_enabled", "other", False),
+            ("blackboard", "groups_enabled", "off", False),
             ("desire2learn", "client_id", "client_id", "client_id"),
-            ("desire2learn", "groups_enabled", "false", False),
-            ("microsoft_onedrive", "files_enabled", "true", True),
-            ("vitalsource", "enabled", "true", True),
-            ("jstor", "enabled", "false", False),
+            ("desire2learn", "groups_enabled", "off", False),
+            ("microsoft_onedrive", "files_enabled", "on", True),
+            ("vitalsource", "enabled", "on", True),
+            ("jstor", "enabled", "off", False),
+            # Tri-state boolean fields
+            ("youtube", "enabled", "true", True),
+            ("youtube", "enabled", "false", False),
+            ("youtube", "enabled", "none", None),
             # String fields
             ("jstor", "site_code", "CODE", "CODE"),
             ("jstor", "site_code", "  CODE  ", "CODE"),

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -87,16 +87,16 @@ class TestUpdateApplicationInstanceView:
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
-            # Boolean fields
-            ("canvas", "groups_enabled", "on", True),
-            ("canvas", "sections_enabled", "", False),
-            ("blackboard", "files_enabled", "other", False),
-            ("blackboard", "groups_enabled", "off", False),
+            # Tri-state boolean fields
+            ("canvas", "groups_enabled", "true", True),
+            ("canvas", "sections_enabled", "false", False),
+            ("blackboard", "files_enabled", "none", None),
+            ("blackboard", "groups_enabled", "false", False),
             ("desire2learn", "client_id", "client_id", "client_id"),
-            ("desire2learn", "groups_enabled", "off", False),
-            ("microsoft_onedrive", "files_enabled", "on", True),
-            ("vitalsource", "enabled", "on", True),
-            ("jstor", "enabled", "off", False),
+            ("desire2learn", "groups_enabled", "false", False),
+            ("microsoft_onedrive", "files_enabled", "true", True),
+            ("vitalsource", "enabled", "true", True),
+            ("jstor", "enabled", "false", False),
             # String fields
             ("jstor", "site_code", "CODE", "CODE"),
             ("jstor", "site_code", "  CODE  ", "CODE"),

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -49,6 +49,7 @@ class TestAdminOrganizationViews:
 
         assert response == {
             "org": organization_service.get_by_id.return_value,
+            "Settings": organization_service.get_by_id.return_value.settings.Settings,
             "fields": organization_service.get_by_id.return_value.settings.fields,
             "hierarchy_root": organization_service.get_hierarchy_root.return_value,
             "company": hubspot_service.get_company.return_value,

--- a/tests/unit/lms/views/admin/organization_test.py
+++ b/tests/unit/lms/views/admin/organization_test.py
@@ -49,6 +49,7 @@ class TestAdminOrganizationViews:
 
         assert response == {
             "org": organization_service.get_by_id.return_value,
+            "fields": organization_service.get_by_id.return_value.settings.fields,
             "hierarchy_root": organization_service.get_hierarchy_root.return_value,
             "company": hubspot_service.get_company.return_value,
             "sort_by_name": Any.callable(),


### PR DESCRIPTION
Application settings in installs and organizations are a subclass of dict with some extra methods to handle a namespace (group and key).

These were defined for installs (but not orgs) but that definitions are only used to list them for the settings filter in this page:

https://lms.hypothes.is/admin/instances/


This PR:

- Adds an enum value for each setting to avoid having a "string typed" access to them
- Allows using JSONSetting object itself to fetch the setting based on it's config
- Adds an optional default value that can then be used when fetching the setting.

It only applies it to two settings, "hypothesis.notes", which is the only "textarea setting"  and "youtube.enabled" to demonstrate the usage of the default value.