### PR TITLE
Use tri-state enabled/disabled/default controls for feature flags

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -145,7 +145,7 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
         Settings.YOUTUBE_ENABLED: JSONSetting(
-            Settings.YOUTUBE_ENABLED, SettingFormat.BOOLEAN, default=True
+            Settings.YOUTUBE_ENABLED, SettingFormat.TRI_STATE, default=True
         ),
         Settings.HYPOTHESIS_NOTES: JSONSetting(
             Settings.HYPOTHESIS_NOTES, SettingFormat.STRING

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -110,7 +110,19 @@ class JSONSettings(MutableDict):
         return super().get(group, {}).get(key, default)
 
     def get_setting(self, setting: JSONSetting):
-        return self.get(setting.group, setting.key, setting.default)
+        value = self.get(setting.group, setting.key, setting.default)
+        if value is None:  # None is used a sentinel for "unset" or "default"
+            value = setting.default
+
+        return value
+
+    def get_raw_setting(self, setting: JSONSetting):
+        """Get the value of the setting as is stored on the DB.
+
+        This method for example ignores the default value.
+        """
+
+        return super().get(setting.group, {}).get(setting.key)
 
     def set(self, group, key, value):
         """

--- a/lms/models/json_settings.py
+++ b/lms/models/json_settings.py
@@ -18,6 +18,13 @@ class SettingFormat(Enum):
     """
 
     BOOLEAN = member(asbool)
+    """Regular True/False boolean. Convert it from strings using pyramid's asbool function"""
+
+    TRI_STATE = member(lambda value: None if value == "none" else asbool(value))
+    """Tri state True/False/None. Use "none" for the third state, pass the value to asbool otherwise.
+
+    In settings the third value is meant to represent "unset" or "default"
+    """
 
     AES_SECRET = object()  # Helper to declare settings as secret.
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -12,12 +12,16 @@
         {% endif %}
     </span>
 {% endblock %}
-{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
+{# Tri-state checkbox with enabled/disabled/use-default options. #}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=None) %}
     {% call macros.field_body(label) %}
-        <label class="checkbox">
-            <input {% if instance.settings.get(setting, sub_setting, default) %}checked{% endif %}
-                   type="checkbox"
-                   name="{{ setting }}.{{ sub_setting }}">
+        {% set value = instance.settings.get(setting, sub_setting, default) %}
+        <label class="select">
+            <select name="{{setting}}.{{sub_setting}}">
+              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
+              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
+              <option value="none" {% if value is none %}selected {% endif %}>Default</option>
+            </select>
         </label>
     {% endcall %}
 {% endmacro %}

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -12,25 +12,25 @@
         {% endif %}
     </span>
 {% endblock %}
-{# Tri-state checkbox with enabled/disabled/use-default options. #}
-{% macro settings_checkbox(label, setting, sub_setting, field_name, default=None) %}
+{% macro settings_checkbox(label, setting, sub_setting, field_name, default=False) %}
     {% call macros.field_body(label) %}
-        {% set value = instance.settings.get(setting, sub_setting, default) %}
-        <label class="select">
-            <select name="{{setting}}.{{sub_setting}}">
-              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
-              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
-              <option value="none" {% if value is none %}selected {% endif %}>Default</option>
-            </select>
+        <label class="checkbox">
+            <input {% if instance.settings.get(setting, sub_setting, default) %}checked{% endif %}
+                   type="checkbox"
+                   name="{{ setting }}.{{ sub_setting }}">
         </label>
     {% endcall %}
 {% endmacro %}
-{% macro setting_checkbox(label, setting, field_name) %}
+{# Tri-state checkbox with enabled/disabled/use-default options. #}
+{% macro tri_state_settings_checkbox(label, setting) %}
     {% call macros.field_body(label) %}
-        <label class="checkbox">
-            <input {% if instance.settings.get_setting(setting) %}checked{% endif %}
-                   type="checkbox"
-                   name="{{ setting.group }}.{{ setting.key }}">
+        {% set value = instance.settings.get_raw_setting(setting) %}
+        <label class="select">
+            <select name="{{setting.group}}.{{setting.key}}">
+              <option value="true" {% if value is true %}selected{% endif %}>Enabled</option>
+              <option value="false" {% if value is false %}selected{% endif %}>Disabled</option>
+              <option value="none" {% if value is none %}selected {% endif %}>Default ({{ setting.default }})</option>
+            </select>
         </label>
     {% endcall %}
 {% endmacro %}
@@ -186,7 +186,7 @@
                             {{ settings_checkbox("Microsoft OneDrive enabled", "microsoft_onedrive", "files_enabled", default=True) }}
                             {{ settings_checkbox('JSTOR enabled', 'jstor', 'enabled') }}
                             {{ settings_text_field('JSTOR site code', 'jstor', 'site_code') }}
-                            {{ setting_checkbox("Youtube enabled", fields[Settings.YOUTUBE_ENABLED]) }}
+                            {{ tri_state_settings_checkbox("Youtube enabled", fields[Settings.YOUTUBE_ENABLED]) }}
                         </fieldset>
                         <div class="has-text-right mb-6">
                             <input type="submit" class="button is-primary" value="Save" />

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -52,7 +52,7 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
         settings = None
         if settings_key := self.request.params.get("settings_key"):
             if settings_value := self.request.params.get("settings_value"):
-                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(  # type: ignore[operator]
+                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(
                     settings_value
                 )
             else:

--- a/lms/views/admin/application_instance/search.py
+++ b/lms/views/admin/application_instance/search.py
@@ -52,7 +52,7 @@ class SearchApplicationInstanceViews(BaseApplicationInstanceView):
         settings = None
         if settings_key := self.request.params.get("settings_key"):
             if settings_value := self.request.params.get("settings_value"):
-                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(
+                settings_value = SETTINGS_BY_FIELD[settings_key].format.value(  # type: ignore[operator]
                     settings_value
                 )
             else:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -80,11 +80,8 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = self.request.params.get(field.compound_key)
             value = value.strip() if value else None
 
-            if field.format is SettingFormat.BOOLEAN:
-                if value == "none":
-                    value = None
-                else:
-                    value = asbool(value)
+            if field.format in [SettingFormat.BOOLEAN, SettingFormat.TRI_STATE]:
+                value = format.value(value)
                 ai.settings.set(field.group, field.key, value)
 
             elif field.format == SettingFormat.AES_SECRET:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -81,8 +81,8 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = value.strip() if value else None
 
             if field.format in [SettingFormat.BOOLEAN, SettingFormat.TRI_STATE]:
-                value = format.value(value)
-                ai.settings.set(field.group, field.key, value)
+                setting_value = field.format.value(value)  # type: ignore[operator]
+                ai.settings.set(field.group, field.key, setting_value)
 
             elif field.format == SettingFormat.AES_SECRET:
                 if not value:

--- a/lms/views/admin/application_instance/update.py
+++ b/lms/views/admin/application_instance/update.py
@@ -81,7 +81,10 @@ class UpdateApplicationInstanceView(BaseApplicationInstanceView):
             value = value.strip() if value else None
 
             if field.format is SettingFormat.BOOLEAN:
-                value = value == "on"
+                if value == "none":
+                    value = None
+                else:
+                    value = asbool(value)
                 ai.settings.set(field.group, field.key, value)
 
             elif field.format == SettingFormat.AES_SECRET:

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -140,7 +140,7 @@ class TestApplicationSettings:
             ),
             ("jstor", "enabled", "jstor.enabled", SettingFormat.BOOLEAN),
             ("jstor", "site_code", "jstor.site_code", SettingFormat.STRING),
-            ("youtube", "enabled", "youtube.enabled", SettingFormat.BOOLEAN),
+            ("youtube", "enabled", "youtube.enabled", SettingFormat.TRI_STATE),
             ("hypothesis", "notes", "hypothesis.notes", SettingFormat.STRING),
             (
                 "hypothesis",

--- a/tests/unit/lms/models/json_settings_test.py
+++ b/tests/unit/lms/models/json_settings_test.py
@@ -19,7 +19,9 @@ class TestJSONSetting:
 
 class TestJSONSettings:
     def test_data(self, settings):
-        assert settings == {"test_group": {"test_key": "test_value"}}
+        assert settings == {
+            "test_group": {"test_key": "test_value", "key_with_none": None}
+        }
 
     @pytest.mark.parametrize(
         "group,key,default,expected_value",
@@ -40,6 +42,34 @@ class TestJSONSettings:
     )
     def test_get(self, settings, group, key, default, expected_value):
         assert settings.get(group, key, default) == expected_value
+
+    @pytest.mark.parametrize(
+        "group,key,default,expected_value",
+        [
+            # If there's a value in the data it returns it.
+            ("test_group", "test_key", None, "test_value"),
+            # If the key is missing from the data it returns None.
+            ("test_group", "unknown_key", None, None),
+            # If the entire group is missing from the data it returns None.
+            ("unknown_group", "test_key", None, None),
+            # Ignores default if key is present
+            ("test_group", "test_key", "DEFAULT", "test_value"),
+            # If the key is missing from the data it returns the default
+            ("test_group", "unknown_key", "DEFAULT", "DEFAULT"),
+            # If the entire group is missing from the data it also returns the default
+            ("unknown_group", "test_key", "DEFAULT", "DEFAULT"),
+            # If the value is None it also returns the default
+            ("test_group", "key_with_none", "DEFAULT", "DEFAULT"),
+        ],
+    )
+    def test_get_setting(self, settings, group, key, default, expected_value):
+        assert (
+            settings.get_setting(JSONSetting(f"{group}.{key}", default=default))
+            == expected_value
+        )
+
+    def test_get_raw_setting(self, settings):
+        assert settings.get_raw_setting(JSONSetting("test_group.key_with_none")) is None
 
     @pytest.mark.parametrize(
         "group,key,value,expected_value",
@@ -110,17 +140,21 @@ class TestJSONSettings:
 
     def test__repr__(self, settings):
         assert (
-            repr(settings) == "JSONSettings({'test_group': {'test_key': 'test_value'}})"
+            repr(settings)
+            == "JSONSettings({'test_group': {'test_key': 'test_value', 'key_with_none': None}})"
         )
 
     def test__str__(self, settings):
         assert (
-            str(settings) == "JSONSettings({'test_group': {'test_key': 'test_value'}})"
+            str(settings)
+            == "JSONSettings({'test_group': {'test_key': 'test_value', 'key_with_none': None}})"
         )
 
     @pytest.fixture
     def settings(self):
-        return JSONSettings({"test_group": {"test_key": "test_value"}})
+        return JSONSettings(
+            {"test_group": {"test_key": "test_value", "key_with_none": None}}
+        )
 
     @pytest.fixture
     def aes(self):

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -87,16 +87,20 @@ class TestUpdateApplicationInstanceView:
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
-            # Tri-state boolean fields
-            ("canvas", "groups_enabled", "true", True),
-            ("canvas", "sections_enabled", "false", False),
-            ("blackboard", "files_enabled", "none", None),
-            ("blackboard", "groups_enabled", "false", False),
+            # Boolean fields
+            ("canvas", "groups_enabled", "on", True),
+            ("canvas", "sections_enabled", "", False),
+            ("blackboard", "files_enabled", "other", False),
+            ("blackboard", "groups_enabled", "off", False),
             ("desire2learn", "client_id", "client_id", "client_id"),
-            ("desire2learn", "groups_enabled", "false", False),
-            ("microsoft_onedrive", "files_enabled", "true", True),
-            ("vitalsource", "enabled", "true", True),
-            ("jstor", "enabled", "false", False),
+            ("desire2learn", "groups_enabled", "off", False),
+            ("microsoft_onedrive", "files_enabled", "on", True),
+            ("vitalsource", "enabled", "on", True),
+            ("jstor", "enabled", "off", False),
+            # Tri-state boolean fields
+            ("youtube", "enabled", "true", True),
+            ("youtube", "enabled", "false", False),
+            ("youtube", "enabled", "none", None),
             # String fields
             ("jstor", "site_code", "CODE", "CODE"),
             ("jstor", "site_code", "  CODE  ", "CODE"),

--- a/tests/unit/lms/views/admin/application_instance/update_test.py
+++ b/tests/unit/lms/views/admin/application_instance/update_test.py
@@ -87,16 +87,16 @@ class TestUpdateApplicationInstanceView:
     @pytest.mark.parametrize(
         "setting,sub_setting,value,expected",
         (
-            # Boolean fields
-            ("canvas", "groups_enabled", "on", True),
-            ("canvas", "sections_enabled", "", False),
-            ("blackboard", "files_enabled", "other", False),
-            ("blackboard", "groups_enabled", "off", False),
+            # Tri-state boolean fields
+            ("canvas", "groups_enabled", "true", True),
+            ("canvas", "sections_enabled", "false", False),
+            ("blackboard", "files_enabled", "none", None),
+            ("blackboard", "groups_enabled", "false", False),
             ("desire2learn", "client_id", "client_id", "client_id"),
-            ("desire2learn", "groups_enabled", "off", False),
-            ("microsoft_onedrive", "files_enabled", "on", True),
-            ("vitalsource", "enabled", "on", True),
-            ("jstor", "enabled", "off", False),
+            ("desire2learn", "groups_enabled", "false", False),
+            ("microsoft_onedrive", "files_enabled", "true", True),
+            ("vitalsource", "enabled", "true", True),
+            ("jstor", "enabled", "false", False),
             # String fields
             ("jstor", "site_code", "CODE", "CODE"),
             ("jstor", "site_code", "  CODE  ", "CODE"),


### PR DESCRIPTION
See: https://github.com/hypothesis/lms/pull/6043

This PR adapts #6043 to be used on top of https://github.com/hypothesis/lms/pull/7041 and only applies it to one setting for now.

## Testing

- Open the admin pages settings for one AI: http://localhost:8001/admin/instances/8/
- Check the value of the setting in `make shell`

```
ai = db.get(models.ApplicationInstance, 8)
ai.settings.get_setting(ai.settings.fields[ai.settings.Settings.YOUTUBE_ENABLED])                                                                                                    
True
```

Change the values in the admin pages and recheck in the shell, you'll need to `db.refresh(ai)` between changes.


- Finally set the value to "Default (True)" in the admin pages, change now the default in the code 


```
diff --git a/lms/models/application_instance.py b/lms/models/application_instance.py
index ae11fd38b..3152e9c2d 100644
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -145,7 +145,7 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.JSTOR_SITE_CODE: JSONSetting(Settings.JSTOR_SITE_CODE),
         Settings.YOUTUBE_ENABLED: JSONSetting(
-            Settings.YOUTUBE_ENABLED, SettingFormat.TRI_STATE, default=True
+            Settings.YOUTUBE_ENABLED, SettingFormat.TRI_STATE, default=False
         ),
         Settings.HYPOTHESIS_NOTES: JSONSetting(
```

- The admin page selector now reads "Default (False)".


- Repeat the setting read from the shell (restarting the shell to fetch the new default), you'll now get a False value.
