### PR TITLE
Add an AI setting for mentions

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -66,6 +66,7 @@ class ApplicationSettings(JSONSettings):
             "hypothesis.lti_13_sourcedid_for_grading"
         )
         HYPOTHESIS_COLLECT_STUDENT_EMAILS = "hypothesis.collect_student_emails"
+        HYPOTHESIS_MENTIONS = "hypothesis.mentions"
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
@@ -162,6 +163,11 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS: JSONSetting(
             Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS,
+            SettingFormat.TRI_STATE,
+            default=False,
+        ),
+        Settings.HYPOTHESIS_MENTIONS: JSONSetting(
+            Settings.HYPOTHESIS_MENTIONS,
             SettingFormat.TRI_STATE,
             default=False,
         ),

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -128,6 +128,7 @@
                             {{ settings_checkbox('Enable instructor email digests', 'hypothesis', 'instructor_email_digests_enabled') }}
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                             {{ tri_state_settings_checkbox("Collect student emails", fields[Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS]) }}
+                            {{ tri_state_settings_checkbox("Mentions", fields[Settings.HYPOTHESIS_MENTIONS]) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -249,8 +249,18 @@ class BasicLaunchViews:
         # enabled based on the current application instance settings, those
         # should be enabled here via `self.context.js_config.enable_client_feature`.
         ai_settings = self.request.lti_user.application_instance.settings
-        if ai_settings.get_setting(
-            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_MENTIONS]
+        if (
+            ai_settings.get_setting(
+                ai_settings.fields[ai_settings.Settings.HYPOTHESIS_MENTIONS]
+            )
+            and
+            # Currently the only way to notify about mentions is email,
+            # if we are not emails disable mentions altogether
+            ai_settings.get_setting(
+                ai_settings.fields[
+                    ai_settings.Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS
+                ]
+            )
         ):
             self.context.js_config.enable_client_feature("at_mentions")
 

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -248,8 +248,11 @@ class BasicLaunchViews:
         # If there are any Hypothesis client feature flags that need to be
         # enabled based on the current application instance settings, those
         # should be enabled here via `self.context.js_config.enable_client_feature`.
-        #
-        # There are currently no such features.
+        ai_settings = self.request.lti_user.application_instance.settings
+        if ai_settings.get_setting(
+            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_MENTIONS]
+        ):
+            self.context.js_config.enable_client_feature("at_mentions")
 
         # Run any non standard code for the current product
         self._misc_plugin.post_launch_assignment_hook(

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -166,6 +166,12 @@ class TestApplicationSettings:
                 "hypothesis.collect_student_emails",
                 SettingFormat.TRI_STATE,
             ),
+            (
+                "hypothesis",
+                "mentions",
+                "hypothesis.mentions",
+                SettingFormat.TRI_STATE,
+            ),
         ]
 
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -258,6 +258,7 @@ class TestBasicLaunchViews:
             yield has_permission
 
     @pytest.mark.parametrize("mentions_feature", [True, False])
+    @pytest.mark.parametrize("collect_student_emails", [True, False])
     def test__show_document(
         self,
         svc,
@@ -270,9 +271,13 @@ class TestBasicLaunchViews:
         misc_plugin,
         assignment,
         mentions_feature,
+        collect_student_emails,
     ):
         pyramid_request.lti_user.application_instance.settings.set(
             "hypothesis", "mentions", mentions_feature
+        )
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "collect_student_emails", collect_student_emails
         )
 
         result = svc._show_document(assignment)  # noqa: SLF001
@@ -300,7 +305,7 @@ class TestBasicLaunchViews:
         misc_plugin.post_launch_assignment_hook.assert_called_once_with(
             pyramid_request, context.js_config, assignment
         )
-        if mentions_feature:
+        if mentions_feature and collect_student_emails:
             context.js_config.enable_client_feature.assert_called_once_with(
                 "at_mentions"
             )


### PR DESCRIPTION
This setting is forwarded to the client config using "js_config.enable_client_feature"


Same approach as: https://github.com/hypothesis/lms/pull/5692

See: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1741795591884319