### PR TITLE
Consume messages about annotations published by H

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -25,7 +25,7 @@ stopsignal=KILL
 stopasgroup=true
 
 [program:worker]
-command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO
+command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO -Q celery,annotation
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal=KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=NONE
 stderr_logfile=NONE
 
 [program:worker]
-command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO
+command=newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO -Q celery,annotation
 stdout_events_enabled=true
 stderr_events_enabled=true
 stdout_logfile=NONE

--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -1,0 +1,17 @@
+import logging
+
+from lms.tasks.celery import app
+
+LOG = logging.getLogger(__name__)
+
+
+@app.task
+def annotation_event(*, event) -> None:  # noqa: ARG001
+    """
+    Process annotations events.
+
+    These are published directly on LMS's queue by H
+    """
+    # For now we are just consuming the messages to keep the queue clean while
+    # we deploy the publishing side on H.
+    return

--- a/lms/tasks/celery.py
+++ b/lms/tasks/celery.py
@@ -43,6 +43,8 @@ app.conf.update(
     task_routes={
         # Route all email_digests task to their own queue
         "lms.tasks.email_digests.*": "email_digests",
+        # These tasks are enqueued directly by H, but declare them on the right queue as well
+        "lms.tasks.annotations.*": "annotation",
     },
     # Tell Celery to kill any task run (by raising
     # celery.exceptions.SoftTimeLimitExceeded) if it takes longer than

--- a/tests/unit/lms/tasks/annotations_test.py
+++ b/tests/unit/lms/tasks/annotations_test.py
@@ -1,0 +1,7 @@
+from unittest.mock import sentinel
+
+from lms.tasks import annotations
+
+
+def test_annotation_event():
+    assert not annotations.annotation_event(event=sentinel.event)


### PR DESCRIPTION
Right now we won't do anything about the messages, just consume them to keep the queue empty This will be useful to setup the publishing side without building a backlog of tasks.


See https://github.com/hypothesis/h/pull/9402 for more context and testing instructions.