### PR TITLE
Change the default email collection to true

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -163,7 +163,7 @@ class ApplicationSettings(JSONSettings):
         Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS: JSONSetting(
             Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS,
             SettingFormat.TRI_STATE,
-            default=False,
+            default=True,
         ),
     }
 


### PR DESCRIPTION
Now that schools that opted out have been
explicitly set to False we can enable this for the rests of the installs