### PR TITLE
Basic processing of annotation events that contain mentions

### DIFF
--- a/.cookiecutter/includes/conf/supervisord-dev.conf.json
+++ b/.cookiecutter/includes/conf/supervisord-dev.conf.json
@@ -11,7 +11,7 @@
       "command": "newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py --bind 0.0.0.0:48001 --certfile=.certificates/localhost/localhost.crt --keyfile=.certificates/localhost/localhost.key"
     },
     "worker": {
-      "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO"
+      "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO -Q celery,annotation"
     },
     "worker-email-digests": {
       "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel=INFO -Q email_digests -n celery-email_digests-@%%h"

--- a/.cookiecutter/includes/conf/supervisord.conf.json
+++ b/.cookiecutter/includes/conf/supervisord.conf.json
@@ -4,7 +4,7 @@
       "command": "newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py"
     },
     "worker": {
-      "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO"
+      "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO -Q celery,annotation"
     },
     "worker-email-digests": {
       "command": "newrelic-admin run-program celery -A lms.tasks.celery:app worker --loglevel INFO -Q email_digests -n celery-email_digests-@%%h"

--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -13,6 +13,7 @@ mailchimp-transactional
 marshmallow
 oauthlib
 pycryptodomex
+pydantic
 PyJWT[crypto]
 pyramid-exclog
 pyramid-googleauth

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ supervisord.pid
 .devdata*
 .eslintcache
 *.tsbuildinfo
+.vscode
 .certificates
 
 # See https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ db: python
 $(call help,make devdata,load development data and environment variables)
 devdata: python
 	@tox -qe dev --run-command 'python3 -m lms.scripts.init_db --create --stamp'
-	@tox -qe dev --run-command 'python bin/make_devdata'
+	@PYTHONPATH=$(CURDIR) TOX_TESTENV_PASSENV=PYTHONPATH tox -qe dev --run-command 'python bin/make_devdata'
 
 .PHONY: dev
 $(call help,make dev,run the whole app \(all workers\))

--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -1,17 +1,105 @@
 import logging
 
+from pydantic import BaseModel
+from sqlalchemy import select
+
+from lms.models import Assignment, LMSUser
 from lms.tasks.celery import app
+
+
+class _AssignmentMetadata(BaseModel):
+    resource_link_id: str
+
+
+class _LMSMetadata(BaseModel):
+    guid: str
+    assignment: _AssignmentMetadata
+
+
+class _AnnotationMetadata(BaseModel):
+    lms: _LMSMetadata
+
+
+class _AnnotationMention(BaseModel):
+    userid: str
+
+
+class _AnnotationPermissions(BaseModel):
+    read: list[str]
+    admin: list[str]
+    update: list[str]
+    delete: list[str]
+
+    @property
+    def is_private(self) -> bool:
+        # Private annotations have the same read permissions as the rest, the userid.
+        return self.read[0] == self.admin[0] == self.update[0] == self.delete[0]
+
+
+class _Annotation(BaseModel):
+    id: str
+    user: str
+    permissions: _AnnotationPermissions
+    mentions: list[_AnnotationMention]
+    metadata: _AnnotationMetadata
+
+
+class AnnotationEvent(BaseModel):
+    action: str
+    annotation: _Annotation
+
 
 LOG = logging.getLogger(__name__)
 
 
 @app.task
-def annotation_event(*, event) -> None:  # noqa: ARG001
+def annotation_event(*, event) -> None:
     """
     Process annotations events.
 
     These are published directly on LMS's queue by H
     """
-    # For now we are just consuming the messages to keep the queue clean while
-    # we deploy the publishing side on H.
-    return
+    annotation_event = AnnotationEvent(**event)
+    annotation = annotation_event.annotation
+
+    if annotation.permissions.is_private:
+        LOG.info("Skipping private annotation %s", annotation.id)
+        return
+
+    guid = annotation.metadata.lms.guid
+    resource_link_id = annotation.metadata.lms.assignment.resource_link_id
+
+    with app.request_context() as request, request.tm:
+        db = request.db
+
+        mentioning_user = db.execute(
+            select(LMSUser).where(LMSUser.h_userid == annotation.user)
+        ).scalar_one()
+        assignment = db.execute(
+            select(Assignment).where(
+                Assignment.tool_consumer_instance_guid == guid,
+                Assignment.resource_link_id == resource_link_id,
+            )
+        ).scalar_one()
+
+        for mention in annotation.mentions:
+            mentioned_user = db.execute(
+                select(LMSUser).where(LMSUser.h_userid == mention.userid)
+            ).scalar_one()
+
+            if not mentioned_user.email:
+                LOG.info(
+                    "Mentioned user %s has no email address", mentioned_user.h_userid
+                )
+                continue
+
+            if mentioned_user == mentioning_user:
+                LOG.info("Skipping self-mention of user %s", mentioned_user.h_userid)
+                continue
+
+            LOG.info(
+                "Processing mention from '%s' by '%s' in assignment '%s'",
+                mentioning_user.display_name,
+                mentioned_user.display_name,
+                assignment.title,
+            )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,6 +20,10 @@ amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
+annotated-types==0.7.0
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 asttokens==2.4.1
     # via stack-data
 attrs==23.1.0
@@ -258,6 +262,12 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.21.0
     # via -r requirements/prod.txt
+pydantic==2.9.2
+    # via -r requirements/prod.txt
+pydantic-core==2.23.4
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 pygments==2.17.2
     # via ipython
 pyjwt[crypto]==2.10.1
@@ -371,6 +381,8 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   sqlalchemy
 tzdata==2023.3
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -20,6 +20,10 @@ amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
+annotated-types==0.7.0
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 attrs==23.1.0
     # via
     #   -r requirements/prod.txt
@@ -253,6 +257,12 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.21.0
     # via -r requirements/prod.txt
+pydantic==2.9.2
+    # via -r requirements/prod.txt
+pydantic-core==2.23.4
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/prod.txt
@@ -360,6 +370,8 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -30,6 +30,11 @@ amqp==5.2.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   kombu
+annotated-types==0.7.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pydantic
 attrs==23.1.0
     # via
     #   -r requirements/functests.txt
@@ -116,7 +121,7 @@ data-tasks==0.0.5
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-execnet==2.0.2
+execnet==2.1.1
     # via
     #   -r requirements/tests.txt
     #   pytest-xdist
@@ -368,6 +373,15 @@ pycryptodomex==3.21.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+pydantic==2.9.2
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+pydantic-core==2.23.4
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pydantic
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/functests.txt
@@ -428,7 +442,7 @@ pytest-factoryboy==2.7.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-pytest-xdist[psutil]==3.5.0
+pytest-xdist[psutil]==3.6.1
     # via -r requirements/tests.txt
 python-dateutil==2.8.2
     # via
@@ -519,6 +533,8 @@ typing-extensions==4.9.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -21,6 +21,7 @@ mailchimp-transactional
 marshmallow
 oauthlib
 pycryptodomex
+pydantic
 PyJWT[crypto]
 pyramid-exclog
 pyramid-googleauth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -14,6 +14,8 @@ alembic==1.14.0
     # via -r requirements/prod.in
 amqp==5.2.0
     # via kombu
+annotated-types==0.7.0
+    # via pydantic
 attrs==23.1.0
     # via
     #   aiohttp
@@ -157,6 +159,10 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.21.0
     # via -r requirements/prod.in
+pydantic==2.9.2
+    # via -r requirements/prod.in
+pydantic-core==2.23.4
+    # via pydantic
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/prod.in
@@ -241,6 +247,8 @@ translationstring==1.4
 typing-extensions==4.9.0
     # via
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   sqlalchemy
 tzdata==2023.3
     # via celery

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -24,6 +24,10 @@ amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
+annotated-types==0.7.0
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 attrs==23.1.0
     # via
     #   -r requirements/prod.txt
@@ -264,6 +268,12 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.21.0
     # via -r requirements/prod.txt
+pydantic==2.9.2
+    # via -r requirements/prod.txt
+pydantic-core==2.23.4
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/prod.txt
@@ -376,6 +386,8 @@ typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   pytest-factoryboy
     #   sqlalchemy
 tzdata==2023.3

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -20,6 +20,10 @@ amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
+annotated-types==0.7.0
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 attrs==23.1.0
     # via
     #   -r requirements/prod.txt
@@ -235,6 +239,12 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.21.0
     # via -r requirements/prod.txt
+pydantic==2.9.2
+    # via -r requirements/prod.txt
+pydantic-core==2.23.4
+    # via
+    #   -r requirements/prod.txt
+    #   pydantic
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/prod.txt
@@ -340,6 +350,8 @@ typing-extensions==4.9.0
     #   -r requirements/prod.txt
     #   alembic
     #   mypy
+    #   pydantic
+    #   pydantic-core
     #   sqlalchemy
 tzdata==2023.3
     # via

--- a/tests/unit/lms/tasks/annotations_test.py
+++ b/tests/unit/lms/tasks/annotations_test.py
@@ -1,7 +1,149 @@
-from unittest.mock import sentinel
+import logging
+from contextlib import contextmanager
+
+import pytest
 
 from lms.tasks import annotations
+from tests import factories
 
 
-def test_annotation_event():
-    assert not annotations.annotation_event(event=sentinel.event)
+class TestAnnotationEvent:
+    def test_annotation_event(self, annotation_event, caplog):
+        annotations.annotation_event(event=annotation_event)
+
+        assert "Processing mention" in caplog.text
+
+    def test_annotation_event_private_annotation(
+        self, private_annotation_event, caplog
+    ):
+        annotations.annotation_event(event=private_annotation_event)
+
+        assert "Skipping private annotation" in caplog.text
+
+    def test_annotation_event_with_no_email(
+        self, annotation_event, caplog, mentioned_user
+    ):
+        mentioned_user.email = None
+
+        annotations.annotation_event(event=annotation_event)
+
+        assert "has no email address" in caplog.text
+
+    def test_annotation_event_self_mention(self, self_mention_annotation_event, caplog):
+        annotations.annotation_event(event=self_mention_annotation_event)
+
+        assert "Skipping self-mention" in caplog.text
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.Assignment()
+
+    @pytest.fixture
+    def mentioning_user(self):
+        return factories.LMSUser(email="EMAIL")
+
+    @pytest.fixture
+    def mentioned_user(self):
+        return factories.LMSUser(email="EMAIL")
+
+    @pytest.fixture
+    def annotation_event(self, assignment, mentioning_user, mentioned_user):
+        return {
+            "action": "create",
+            "annotation": {
+                "id": "w6fNigSgEfCOTdupAyRrPQ",
+                "created": "2025-03-19T09:01:37.181037+00:00",
+                "updated": "2025-03-19T09:01:37.181037+00:00",
+                "user": mentioning_user.h_userid,
+                "uri": "https://example.com/",
+                "text": '<a data-hyp-mention="" data-userid="acct:270d2d38d2ddd16c911661e62f116c@lms.hypothes.is">@Dean Dean</a> ',
+                "tags": [],
+                "group": "GgW8qVLX",
+                "permissions": {
+                    "read": ["group:GgW8qVLX"],
+                    "admin": ["acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"],
+                    "update": ["acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"],
+                    "delete": ["acct:3a022b6c146dfd9df4ea8662178eac@lms.hypothes.is"],
+                },
+                "target": [
+                    {
+                        "source": "https://example.com/",
+                        "selector": [
+                            {
+                                "type": "RangeSelector",
+                                "endOffset": 117,
+                                "startOffset": 112,
+                                "endContainer": "/div[1]/p[1]",
+                                "startContainer": "/div[1]/p[1]",
+                            },
+                            {"end": 142, "type": "TextPositionSelector", "start": 137},
+                            {
+                                "type": "TextQuoteSelector",
+                                "exact": "prior",
+                                "prefix": "   domain in literature without ",
+                                "suffix": " coordination or asking for perm",
+                            },
+                        ],
+                    }
+                ],
+                "document": {"title": ["Example Domain"]},
+                "links": {
+                    "incontext": "http://localhost:8000/w6fNigSgEfCOTdupAyRrPQ/example.com/",
+                    "json": "http://localhost:5000/api/annotations/w6fNigSgEfCOTdupAyRrPQ",
+                },
+                "mentions": [
+                    {
+                        "userid": mentioned_user.h_userid,
+                        "original_userid": mentioned_user.h_userid,
+                        "username": "270d2d38d2ddd16c911661e62f116c",
+                        "display_name": mentioned_user.display_name,
+                        "link": None,
+                        "description": None,
+                        "joined": None,
+                    }
+                ],
+                "user_info": {"display_name": "DISPLAY NAME TEACHER"},
+                "metadata": {
+                    "lms": {
+                        "guid": assignment.tool_consumer_instance_guid,
+                        "assignment": {
+                            "resource_link_id": assignment.resource_link_id,
+                        },
+                    }
+                },
+                "flagged": False,
+                "hidden": False,
+            },
+        }
+
+    @pytest.fixture
+    def private_annotation_event(self, annotation_event):
+        annotation_event["annotation"]["permissions"]["read"] = annotation_event[
+            "annotation"
+        ]["permissions"]["admin"]
+        return annotation_event
+
+    @pytest.fixture
+    def self_mention_annotation_event(self, annotation_event):
+        annotation_event["annotation"]["mentions"][0]["userid"] = annotation_event[
+            "annotation"
+        ]["user"]
+        return annotation_event
+
+    @pytest.fixture
+    def caplog(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        return caplog
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.annotations.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app


### PR DESCRIPTION
In this PR:

- We apply the latest changes from the cookiecutter
- We include pydantic as a dependency

See: 
https://hypothes-is.slack.com/archives/C1MA4E9B9/p1742317088514549

- And we do basic processing of annotation events, just a log line per mention for now.

# Testing

- On an LMS assignment, test the following cases:

  - Self mention
  - Mention someone else, but post it on "Only me"
  - Mention someone else

The logs on the LMS server will reflect each of those cases.