### PR TITLE
New model and migration for Notifications

### DIFF
--- a/lms/migrations/versions/0d265909ff85_create_the_notification_table.py
+++ b/lms/migrations/versions/0d265909ff85_create_the_notification_table.py
@@ -1,0 +1,68 @@
+"""Create the notification table."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0d265909ff85"
+down_revision = "a8fd48c30957"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "notification_type",
+            sa.Enum("reply", name="type", native_enum=False, length=64),
+            nullable=False,
+        ),
+        sa.Column("source_annotation_id", sa.String(), nullable=False),
+        sa.Column("sender_id", sa.Integer(), nullable=False),
+        sa.Column("recipient_id", sa.Integer(), nullable=False),
+        sa.Column("assignment_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["assignment_id"],
+            ["assignment.id"],
+            name=op.f("fk__notification__assignment_id__assignment"),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recipient_id"],
+            ["lms_user.id"],
+            name=op.f("fk__notification__recipient_id__lms_user"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["sender_id"],
+            ["lms_user.id"],
+            name=op.f("fk__notification__sender_id__lms_user"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__notification")),
+        sa.UniqueConstraint(
+            "recipient_id",
+            "source_annotation_id",
+            name="uq__notification__recipient_id__source_annotation_id",
+        ),
+    )
+    op.create_index(
+        op.f("ix__notification_recipient_id"),
+        "notification",
+        ["recipient_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix__notification_sender_id"), "notification", ["sender_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix__notification_sender_id"), table_name="notification")
+    op.drop_index(op.f("ix__notification_recipient_id"), table_name="notification")
+    op.drop_table("notification")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -46,6 +46,7 @@ from lms.models.lti_params import CLAIM_PREFIX, LTIParams
 from lms.models.lti_registration import LTIRegistration
 from lms.models.lti_role import LTIRole, LTIRoleOverride, RoleScope, RoleType
 from lms.models.lti_user import LTIUser, display_name
+from lms.models.notification import Notification
 from lms.models.oauth2_token import OAuth2Token
 from lms.models.organization import Organization
 from lms.models.organization_usage import OrganizationUsageReport

--- a/lms/models/notification.py
+++ b/lms/models/notification.py
@@ -1,0 +1,63 @@
+import enum
+
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lms.db import Base, varchar_enum
+from lms.models._mixins import CreatedUpdatedMixin
+from lms.models.lms_user import LMSUser
+
+
+class Notification(CreatedUpdatedMixin, Base):
+    """Keep track of sent notifications.
+
+    Allows us both to report on the number of notifications sent and to
+    ensure that a user doesn't receive multiple notifications for the same event.
+    """
+
+    class Type(enum.StrEnum):
+        REPLY = "reply"
+        MENTION = "mention"
+
+    __tablename__ = "notification"
+
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
+
+    notification_type: Mapped[Type] = varchar_enum(Type)
+
+    source_annotation_id: Mapped[str] = mapped_column()
+
+    sender_id: Mapped[int] = mapped_column(
+        ForeignKey("lms_user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    """FK to LMSUser.id - the user that generated the notification, the author of the annotation"""
+    sender: Mapped[LMSUser] = relationship(
+        "LMSUser", uselist=False, foreign_keys=[sender_id]
+    )
+
+    recipient_id: Mapped[int] = mapped_column(
+        ForeignKey("lms_user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    """FK to LMSUser.id - the user receiving the notification"""
+    recipient: Mapped[LMSUser] = relationship(
+        "LMSUser", uselist=False, foreign_keys=[recipient_id]
+    )
+
+    assignment_id: Mapped[int] = mapped_column(
+        ForeignKey("assignment.id", ondelete="cascade")
+    )
+    assignment = relationship("Assignment")
+    """Assignment that the notification is related to"""
+
+    __table_args__ = (
+        # Ensure that a recipient can only have one notification for a given source annotation
+        UniqueConstraint(
+            "recipient_id",
+            "source_annotation_id",
+            name="uq__notification__recipient_id__source_annotation_id",
+        ),
+    )


### PR DESCRIPTION
Allows us both to report on the number of notifications sent and to ensure that a user doesn't receive multiple notifications for the same event.

This table is very similar its counterpart in H, with the following differences:

- annotation ID is just an opaque string, not a foreign key
- We store a reference to the "sender" which in H is implied to be the creator of the annotation.
- We include a FK to the relevant assignment


Model and migration on the same PR as this is not yet used.


Testing on: https://github.com/hypothesis/lms/pull/7060