### PR TITLE
Fix dashboard logo size

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/DashboardApp.tsx
@@ -19,7 +19,7 @@ export default function DashboardApp() {
       <div className="px-3 py-4 bg-white border-b shadow">
         <div className="flex justify-between items-center mx-auto max-w-6xl">
           <RouterLink href="" aria-label="All courses">
-            <LogoIcon />
+            <LogoIcon className="w-6 h-6" />
           </RouterLink>
 
           <div className="flex gap-6">


### PR DESCRIPTION
A few weeks ago we [updated and consolidated](https://github.com/hypothesis/frontend-shared/pull/1849/files) all our icons. Among other things, that accidentally reduced the default size of the logo icon.

This PR ensures the same size as before is used when rendered in the LMS dashboard header icon.

Before:
![Captura desde 2025-03-24 11-17-40](https://github.com/user-attachments/assets/33b15c09-b323-4b00-99fd-7999c4bc3f16)

After:
![Captura desde 2025-03-24 11-17-45](https://github.com/user-attachments/assets/263a5c81-a76e-48a8-aa97-211720f51ac8)

