### PR TITLE
Check whether or not we should send emails for mentions

### DIFF
--- a/lms/services/annotation_activity_email.py
+++ b/lms/services/annotation_activity_email.py
@@ -1,10 +1,17 @@
+import logging
 from dataclasses import asdict
 
-from sqlalchemy import select
+from sqlalchemy import exists, func, select
 
 from lms.models import Assignment, LMSUser, Notification
 from lms.services.mailchimp import EmailRecipient, EmailSender
 from lms.tasks.mailchimp import send
+
+# Limit for the number of notifications per annotation
+ANNOTATION_NOTIFICATION_LIMIT = 100
+
+
+LOG = logging.getLogger(__name__)
 
 
 class AnnotationActivityEmailService:
@@ -14,17 +21,38 @@ class AnnotationActivityEmailService:
         self._db = db
         self._sender = sender
 
+    def _user_already_notified(self, annotation_id, mentioned_user):
+        """Check if a user has already been notified about an annotation."""
+        return self._db.execute(
+            select(
+                exists(Notification).where(
+                    Notification.source_annotation_id == annotation_id,
+                    Notification.recipient_id == mentioned_user.id,
+                )
+            )
+        ).scalar_one()
+
+    def _over_notification_limit_for_annotation(self, annotation_id):
+        """Check if we already sent over ANNOTATION_NOTIFICATION_LIMIT notifications for an annotation."""
+        return (
+            self._db.execute(
+                select(func.count(Notification.id)).where(
+                    Notification.source_annotation_id == annotation_id
+                )
+            ).scalar()
+            >= ANNOTATION_NOTIFICATION_LIMIT
+        )
+
     def send_mention(
         self,
         annotation_id: str,
         mentioning_user_h_userid: str,
         mentioned_user_h_userid: str,
         assignment_id: int,
-    ):
+    ) -> Notification | None:
         mentioning_user = self._db.execute(
             select(LMSUser).where(LMSUser.h_userid == mentioning_user_h_userid)
         ).scalar_one()
-
         mentioned_user = self._db.execute(
             select(LMSUser).where(LMSUser.h_userid == mentioned_user_h_userid)
         ).scalar_one()
@@ -32,8 +60,25 @@ class AnnotationActivityEmailService:
             select(Assignment).where(Assignment.id == assignment_id)
         ).scalar_one()
 
-        recipient = EmailRecipient(mentioned_user.email, mentioned_user.display_name)
+        if self._user_already_notified(annotation_id, mentioned_user):
+            LOG.info(
+                "Skipping mention for annotation %r in assignment %r. %r",
+                annotation_id,
+                assignment_id,
+                "user already notified",
+            )
+            return None
 
+        if self._over_notification_limit_for_annotation(annotation_id):
+            LOG.info(
+                "Skipping mention for annotation %r in assignment %r. %r",
+                annotation_id,
+                assignment_id,
+                "over annotation limit",
+            )
+            return None
+
+        recipient = EmailRecipient(mentioned_user.email, mentioned_user.display_name)
         email_vars = {
             "assignment_title": assignment.title,
             "course_title": assignment.course.lms_name,
@@ -46,15 +91,16 @@ class AnnotationActivityEmailService:
             template_vars=email_vars,
             tags=["lms", "mention"],
         )
-        self._db.add(
-            Notification(
-                notification_type=Notification.Type.MENTION,
-                source_annotation_id=annotation_id,
-                sender_id=mentioning_user.id,
-                recipient_id=mentioned_user.id,
-                assignment_id=assignment_id,
-            )
+
+        notification = Notification(
+            notification_type=Notification.Type.MENTION,
+            source_annotation_id=annotation_id,
+            sender_id=mentioning_user.id,
+            recipient_id=mentioned_user.id,
+            assignment_id=assignment_id,
         )
+        self._db.add(notification)
+        return notification
 
 
 def factory(_context, request):

--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -63,6 +63,10 @@ def annotation_event(*, event) -> None:
     annotation_event = AnnotationEvent(**event)
     annotation = annotation_event.annotation
 
+    if annotation_event.action not in {"create", "update"}:
+        LOG.info("Skipping event type %s", annotation_event.action)
+        return
+
     if annotation.permissions.is_private:
         LOG.info("Skipping private annotation %s", annotation.id)
         return

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -43,6 +43,7 @@ from tests.factories.lms_user import LMSUser
 from tests.factories.lti_registration import LTIRegistration
 from tests.factories.lti_role import LTIRole, LTIRoleOverride
 from tests.factories.lti_user import LTIUser
+from tests.factories.notification import Notification
 from tests.factories.oauth2_token import OAuth2Token
 from tests.factories.organization import Organization
 from tests.factories.organization_usage import OrganizationUsageReport

--- a/tests/factories/notification.py
+++ b/tests/factories/notification.py
@@ -1,0 +1,10 @@
+from factory import Faker, make_factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+
+Notification = make_factory(
+    models.Notification,
+    FACTORY_CLASS=SQLAlchemyModelFactory,
+    source_annotation_id=Faker("hexify", text="^" * 40),
+)

--- a/tests/unit/lms/services/annotation_activity_email_test.py
+++ b/tests/unit/lms/services/annotation_activity_email_test.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from lms.models import Notification
 from lms.services.annotation_activity_email import (
+    ANNOTATION_NOTIFICATION_LIMIT,
     AnnotationActivityEmailService,
     factory,
 )
@@ -46,6 +47,56 @@ class TestAnnotationActivityEmailService:
         assert notification.sender_id == mentioning_user.id
         assert notification.recipient_id == mentioned_user.id
         assert notification.assignment_id == assignment.id
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["notification_for_mentioned_user", "notifications_for_annotation"],
+    )
+    def test_with_should_not_notify(
+        self,
+        fixture_name,
+        request,
+        svc,
+        send,
+        db_session,
+        mentioning_user,
+        mentioned_user,
+        assignment,
+    ):
+        _ = request.getfixturevalue(fixture_name)
+        db_session.flush()
+
+        assert not svc.send_mention(
+            "ANNOTATION_ID",
+            mentioning_user.h_userid,
+            mentioned_user.h_userid,
+            assignment.id,
+        )
+
+        send.delay.assert_not_called()
+
+    @pytest.fixture
+    def notification_for_mentioned_user(
+        self, mentioned_user, mentioning_user, assignment
+    ):
+        return factories.Notification(
+            source_annotation_id="ANNOTATION_ID",
+            recipient=mentioned_user,
+            sender=mentioning_user,
+            assignment=assignment,
+            notification_type=Notification.Type.MENTION,
+        )
+
+    @pytest.fixture
+    def notifications_for_annotation(self, assignment):
+        for _ in range(ANNOTATION_NOTIFICATION_LIMIT):
+            factories.Notification(
+                source_annotation_id="ANNOTATION_ID",
+                recipient=factories.LMSUser(),
+                sender=factories.LMSUser(),
+                assignment=assignment,
+                notification_type=Notification.Type.MENTION,
+            )
 
     @pytest.fixture
     def mentioned_user(self):

--- a/tests/unit/lms/tasks/annotations_test.py
+++ b/tests/unit/lms/tasks/annotations_test.py
@@ -28,6 +28,13 @@ class TestAnnotationEvent:
             assignment.id,
         )
 
+    def test_annotation_event_delete(self, annotation_event, caplog):
+        annotation_event["action"] = "delete"
+
+        annotations.annotation_event(event=annotation_event)
+
+        assert "Skipping event type" in caplog.text
+
     def test_annotation_event_private_annotation(
         self, private_annotation_event, caplog
     ):


### PR DESCRIPTION
Check the following conditions:

- Never send more than one email per user per annotation
- Never send more that 100 emails for the same annotation

This is based on the same solution over in H

https://github.com/hypothesis/h/blob/main/h/services/notification.py#L20

# Testing

- Checkout this branch on the H side https://github.com/hypothesis/h/pull/9419

- Edit an annotation you have created before with mentions https://hypothesis.instructure.com/courses/125/assignments/873

- Check the logs in LMS:


```- 
Skipping mention from 'DISPLAY NAME TEACHER' to 'Hypothesis 101 Student' in assignment 'localhost (make devdata) HTML Assignment' because user already notified    
```

