### PR TITLE
Include the annotation text in the mention email body

### DIFF
--- a/lms/routes.py
+++ b/lms/routes.py
@@ -241,7 +241,7 @@ def includeme(config):  # noqa: PLR0915
     config.add_route("admin.email", "/admin/email")
     config.add_route(
         "admin.email.section",
-        "/admin/email/{section:digest|mention}",
+        "/admin/email/{section:digest|mentions}",
     )
 
     config.add_route(

--- a/lms/services/annotation_activity_email.py
+++ b/lms/services/annotation_activity_email.py
@@ -17,6 +17,7 @@ class AnnotationActivityEmailService:
     def send_mention(
         self,
         annotation_id: str,
+        annotation_text: str,
         mentioning_user_h_userid: str,
         mentioned_user_h_userid: str,
         assignment_id: int,
@@ -38,6 +39,7 @@ class AnnotationActivityEmailService:
             "assignment_title": assignment.title,
             "course_title": assignment.course.lms_name,
             "mentioned_user": mentioned_user.display_name,
+            "annotation_text": annotation_text,
         }
         send.delay(
             template="lms:templates/email/mention/",

--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -43,6 +43,7 @@ class _Annotation(BaseModel):
     permissions: _AnnotationPermissions
     mentions: list[_AnnotationMention]
     metadata: _AnnotationMetadata
+    text_rendered: str
 
 
 class AnnotationEvent(BaseModel):
@@ -103,12 +104,13 @@ def annotation_event(*, event) -> None:
 
             LOG.info(
                 "Processing mention from '%s' to '%s' in assignment '%s'",
-                mentioning_user.display_name,
-                mentioned_user.display_name,
+                mentioning_user.h_userid,
+                mentioned_user.h_userid,
                 assignment.title,
             )
             annotation_activity_email_service.send_mention(
                 annotation.id,
+                annotation.text_rendered,
                 mentioning_user.h_userid,
                 mentioned_user.h_userid,
                 assignment.id,

--- a/lms/templates/admin/email.html.jinja2
+++ b/lms/templates/admin/email.html.jinja2
@@ -111,5 +111,5 @@
 {% endblock content %}
 
 {% block extra_scripts %}
-    {{ macros.enable_tabs(default_tab="digest") }}
+    {{ macros.enable_tabs(prefix_segments_amount=2, default_tab="digest") }}
 {% endblock %}

--- a/lms/templates/email/mention/body.html.jinja2
+++ b/lms/templates/email/mention/body.html.jinja2
@@ -3,3 +3,5 @@
 <p>Someone has mentioned you on an annotation:</p>
 
 <p>{{ course_title }} - {{ assignment_title }}</p>
+
+<p> {{ annotation_text | safe }} </p>

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -110,6 +110,7 @@ MENTION_EMAIL_TEMPLATE_VARS = {
     "mentioned_user": "MENTIONED USER",
     "course_title": "COURSE TITLE",
     "assignment_title": "ASSIGNMENT TITLE",
+    "annotation_text": "ANNOTATION TEXT",
 }
 
 

--- a/tests/unit/lms/services/annotation_activity_email_test.py
+++ b/tests/unit/lms/services/annotation_activity_email_test.py
@@ -21,6 +21,7 @@ class TestAnnotationActivityEmailService:
 
         svc.send_mention(
             "ANNOTATION_ID",
+            "ANNOTATION_TEXT",
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,
@@ -34,6 +35,7 @@ class TestAnnotationActivityEmailService:
             ),
             template_vars={
                 "assignment_title": assignment.title,
+                "annotation_text": "ANNOTATION_TEXT",
                 "course_title": assignment.course.lms_name,
                 "mentioned_user": mentioned_user.display_name,
             },

--- a/tests/unit/lms/tasks/annotations_test.py
+++ b/tests/unit/lms/tasks/annotations_test.py
@@ -23,6 +23,7 @@ class TestAnnotationEvent:
         assert "Processing mention" in caplog.text
         annotation_activity_email_service.send_mention.assert_called_once_with(
             annotation_event["annotation"]["id"],
+            annotation_event["annotation"]["text_rendered"],
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,
@@ -69,6 +70,7 @@ class TestAnnotationEvent:
                 "id": "w6fNigSgEfCOTdupAyRrPQ",
                 "created": "2025-03-19T09:01:37.181037+00:00",
                 "updated": "2025-03-19T09:01:37.181037+00:00",
+                "text_rendered": "ANNOTATION TEXT",
                 "user": mentioning_user.h_userid,
                 "uri": "https://example.com/",
                 "text": '<a data-hyp-mention="" data-userid="acct:270d2d38d2ddd16c911661e62f116c@lms.hypothes.is">@Dean Dean</a> ',


### PR DESCRIPTION
Include the text of the annotation on the email template for mentions.

This PR also fixes tab navigation via the URL


# Testing

- Go to http://localhost:8001/admin/email/mentions
- The sample annotation text is displayed at the bottom.