### PR TITLE
Style mentions email template

### DIFF
--- a/lms/services/annotation_activity_email.py
+++ b/lms/services/annotation_activity_email.py
@@ -38,7 +38,6 @@ class AnnotationActivityEmailService:
         email_vars = {
             "assignment_title": assignment.title,
             "course_title": assignment.course.lms_name,
-            "mentioned_user": mentioned_user.display_name,
             "annotation_text": annotation_text,
         }
         send.delay(

--- a/lms/templates/email/email_layout.html.jinja2
+++ b/lms/templates/email/email_layout.html.jinja2
@@ -1,0 +1,652 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <!-- NAME: FLYER -->
+    <!--[if gte mso 15]>
+      <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+      </xml>
+    <![endif]-->
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>There has been some activity in Hypothesis</title>
+    <style type="text/css">
+ p{
+     margin:0;
+     margin-bottom: 20px;
+     padding:0;
+}
+ table{
+     border-collapse:collapse;
+}
+ h1,h2,h3,h4,h5,h6{
+     display:block;
+     margin:0;
+     padding:0;
+}
+ img,a img{
+     border:0;
+     height:auto;
+     outline:none;
+     text-decoration:none;
+}
+ body,#bodyTable,#bodyCell{
+     height:100%;
+     margin:0;
+     padding:0;
+     width:100%;
+}
+ .mcnPreviewText{
+     display:none !important;
+}
+ #outlook a{
+     padding:0;
+}
+ img{
+     -ms-interpolation-mode:bicubic;
+}
+ table{
+     mso-table-lspace:0pt;
+     mso-table-rspace:0pt;
+}
+ .ReadMsgBody{
+     width:100%;
+}
+ .ExternalClass{
+     width:100%;
+}
+ p,a,li,td,blockquote{
+     mso-line-height-rule:exactly;
+}
+ a[href^=tel],a[href^=sms]{
+     color:inherit;
+     cursor:default;
+     text-decoration:none;
+}
+ p,a,li,td,body,table,blockquote{
+     -ms-text-size-adjust:100%;
+     -webkit-text-size-adjust:100%;
+}
+ .ExternalClass,.ExternalClass p,.ExternalClass td,.ExternalClass div,.ExternalClass span,.ExternalClass font{
+     line-height:100%;
+}
+ a[x-apple-data-detectors]{
+     color:inherit !important;
+     text-decoration:none !important;
+     font-size:inherit !important;
+     font-family:inherit !important;
+     font-weight:inherit !important;
+     line-height:inherit !important;
+}
+ a.mcnButton{
+     display:block;
+}
+ .mcnImage,.mcnRetinaImage{
+     vertical-align:bottom;
+}
+ .mcnTextContent{
+     word-break:break-word;
+}
+ .mcnTextContent img{
+     height:auto !important;
+}
+ .mcnDividerBlock{
+     table-layout:fixed !important;
+}
+/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
+ body,#bodyTable{
+    /*@editable*/
+    background-color:#363636;
+}
+/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
+ #bodyCell{
+    /*@editable*/
+    border-top:0;
+}
+/* @tab Page @section heading 1 @tip Set the styling for all first-level headings in your emails. These should be the largest of your headings. @style heading 1 */
+ h1{
+    /*@editable*/
+    color:#bd1c2b !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:40px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:100%;
+    /*@editable*/
+    letter-spacing:-1px;
+    /*@editable*/
+    text-align:center;
+}
+/* @tab Page @section heading 2 @tip Set the styling for all second-level headings in your emails. @style heading 2 */
+ h2{
+    /*@editable*/
+    color:#404040 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:26px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:-.75px;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Page @section heading 3 @tip Set the styling for all third-level headings in your emails. @style heading 3 */
+ h3{
+    /*@editable*/
+    color:#606060 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:18px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:-.5px;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Page @section heading 4 @tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings. @style heading 4 */
+ h4{
+    /*@editable*/
+    color:#808080 !important;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:16px;
+    /*@editable*/
+    font-style:normal;
+    /*@editable*/
+    font-weight:bold;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    letter-spacing:normal;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Preheader @section preheader style @tip Set the background color and borders for your email's preheader area. */
+ #templatePreheader{
+    /*@editable*/
+    background-color:#FFFFFF;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:1px solid #D5D5D5;
+}
+/* @tab Preheader @section preheader text @tip Set the styling for your email's preheader text. Choose a size and color that is easy to read. */
+ .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:11px;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Preheader @section preheader link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
+ .preheaderContainer .mcnTextContent a{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+/* @tab Header @section header style @tip Set the background color and borders for your email's header area. */
+ #templateHeader{
+    /*@editable*/
+    background-color:#EEEEEE;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Header @section header text @tip Set the styling for your email's header text. Choose a size and color that is easy to read. */
+ .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+    /*@editable*/
+    color:#606060;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:15px;
+    /*@editable*/
+    line-height:150%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Header @section header link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
+ .headerContainer .mcnTextContent a{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+/* @tab Body @section body style @tip Set the background color and borders for your email's body area. */
+ #templateBody{
+    /*@editable*/
+    background-color:#eeeeee;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Body @section body container @tip Set the background color and border for your email's body text container. */
+ #bodyBackground{
+    /*@editable*/
+    background-color:#FFFFFF;
+    /*@editable*/
+    border:1px solid #D5D5D5;
+}
+/* @tab Body @section body text @tip Set the styling for your email's body text. Choose a size and color that is easy to read. */
+ .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+    /*@editable*/
+    color:#606060;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:15px;
+    /*@editable*/
+    line-height:150%;
+    /*@editable*/
+    text-align:left;
+}
+/* @tab Body @section body link @tip Set the styling for your email's body links. Choose a color that helps them stand out from your text. */
+ .bodyContainer .mcnTextContent a{
+    /*@editable*/
+    color:#bd1c2b;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+/* @tab Footer @section footer style @tip Set the background color and borders for your email's footer area. */
+ #templateFooter{
+    /*@editable*/
+    background-color:#363636;
+    /*@editable*/
+    border-top:0;
+    /*@editable*/
+    border-bottom:0;
+}
+/* @tab Footer @section footer text @tip Set the styling for your email's footer text. Choose a size and color that is easy to read. */
+ .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+    /*@editable*/
+    color:#CCCCCC;
+    /*@editable*/
+    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    /*@editable*/
+    font-size:11px;
+    /*@editable*/
+    line-height:125%;
+    /*@editable*/
+    text-align:center;
+}
+/* @tab Footer @section footer link @tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text. */
+ .footerContainer .mcnTextContent a{
+    /*@editable*/
+    color:#CCCCCC;
+    /*@editable*/
+    font-weight:normal;
+    /*@editable*/
+    text-decoration:underline;
+}
+ @media only screen and (max-width: 480px){
+     body,table,td,p,a,li,blockquote{
+         -webkit-text-size-adjust:none !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     body{
+         width:100% !important;
+         min-width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .templateContainer{
+         max-width:600px !important;
+         width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnRetinaImage{
+         max-width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImage{
+         height:auto !important;
+         width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnCartContainer,.mcnCaptionTopContent,.mcnRecContentContainer,.mcnCaptionBottomContent,.mcnTextContentContainer,.mcnBoxedTextContentContainer,.mcnImageGroupContentContainer,.mcnCaptionLeftTextContentContainer,.mcnCaptionRightTextContentContainer,.mcnCaptionLeftImageContentContainer,.mcnCaptionRightImageContentContainer,.mcnImageCardLeftTextContentContainer,.mcnImageCardRightTextContentContainer,.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
+         max-width:100% !important;
+         width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnBoxedTextContentContainer{
+         min-width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageGroupContent{
+         padding:9px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnCaptionLeftContentOuter .mcnTextContent,.mcnCaptionRightContentOuter .mcnTextContent{
+         padding-top:9px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageCardTopImageContent,.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent,.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent{
+         padding-top:18px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageCardBottomImageContent{
+         padding-bottom:9px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageGroupBlockInner{
+         padding-top:0 !important;
+         padding-bottom:0 !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageGroupBlockOuter{
+         padding-top:9px !important;
+         padding-bottom:9px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnTextContent,.mcnBoxedTextContentColumn{
+         padding-right:18px !important;
+         padding-left:18px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcnImageCardLeftImageContent,.mcnImageCardRightImageContent{
+         padding-right:18px !important;
+         padding-bottom:0 !important;
+         padding-left:18px !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+     .mcpreview-image-uploader{
+         display:none !important;
+         width:100% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 1 @tip Make the first-level headings larger in size for better readability on small screens. */
+     h1{
+        /*@editable*/
+        font-size:24px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 2 @tip Make the second-level headings larger in size for better readability on small screens. */
+     h2{
+        /*@editable*/
+        font-size:20px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 3 @tip Make the third-level headings larger in size for better readability on small screens. */
+     h3{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section heading 4 @tip Make the fourth-level headings larger in size for better readability on small screens. */
+     h4{
+        /*@editable*/
+        font-size:16px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Boxed Text @tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
+     .mcnBoxedTextContentContainer .mcnTextContent,.mcnBoxedTextContentContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Preheader Visibility @tip Set the visibility of the email's preheader on small screens. You can hide it to save space. */
+     #templatePreheader{
+        /*@editable*/
+        display:block !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Preheader Text @tip Make the preheader text larger in size for better readability on small screens. */
+     .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:14px !important;
+        /*@editable*/
+        line-height:115% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Header Text @tip Make the header text larger in size for better readability on small screens. */
+     .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section Body Text @tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
+     .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:18px !important;
+        /*@editable*/
+        line-height:125% !important;
+    }
+}
+ @media only screen and (max-width: 480px){
+    /* @tab Mobile Styles @section footer text @tip Make the body content text larger in size for better readability on small screens. */
+     .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+        /*@editable*/
+        font-size:14px !important;
+        /*@editable*/
+        line-height:115% !important;
+    }
+}
+    </style>
+  </head>
+  <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
+    <center>
+      <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
+        <tr>
+          <td align="center" valign="top" id="bodyCell">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td align="center" valign="top">
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templatePreheader">
+                    <tr>
+                      <td align="center" valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
+                          <tr>
+                            <td valign="top" class="preheaderContainer" style="padding-top:10px; padding-bottom:10px;"></td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td align="center" valign="top">
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader">
+                    <tr>
+                      <td align="center" valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
+                          <tr>
+                            <td valign="top" class="headerContainer" style="padding-top:15px; padding-bottom:10px;">
+                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width:100%;">
+                                <tbody class="mcnDividerBlockOuter">
+                                  <tr>
+                                    <td class="mcnDividerBlockInner" style="min-width: 100%; padding: 15px 18px 10px;">
+                                      <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 2px solid #EEEEEE;">
+                                        <tbody>
+                                          <tr>
+                                            <td>
+                                              <span></span>
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnImageBlock" style="min-width:100%;">
+                                <tbody class="mcnImageBlockOuter">
+                                  <tr>
+                                    <td valign="top" style="padding:9px" class="mcnImageBlockInner">
+                                      <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer" style="min-width:100%;">
+                                        <tbody>
+                                          <tr>
+                                            <td class="mcnImageContent" valign="top" style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
+                                              <img align="center" alt="" src="{{ 'lms:static/images/hypothesis-wordmark-logo.png'|static_url }}" width="225.60000000000002" style="max-width:1358px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td align="center" valign="top">
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateBody">
+                    <tr>
+                      <td align="center" valign="top" style="padding-top:10px; padding-right:10px; padding-bottom:5px; padding-left:10px;">
+                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
+                          <tr>
+                            <td align="center" valign="top">
+                              <table border="0" cellpadding="0" cellspacing="0" width="100%" id="bodyBackground">
+                                <tr>
+                                  <td valign="top" class="bodyContainer" style="padding-top:10px; padding-bottom:10px;">
+                                      {% block content %}{% endblock %}
+                                  </td>
+                                </tr>
+                              </table>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td align="center" valign="top">
+                              <img src="https://cdn-images.mailchimp.com/template_images/gallery/couponshadow.png" height="20" width="600" class="mcnImage" style="display:block; max-width:560px;">
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td align="center" valign="top" style="padding-bottom:40px;">
+                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateFooter">
+                    <tr>
+                      <td align="center" valign="top">
+                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
+                          <tr>
+                            <td valign="top" class="footerContainer" style="padding-top:10px; padding-bottom:10px;">
+                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
+                                <tbody class="mcnTextBlockOuter">
+                                  <tr>
+                                    <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+                                      <!--[if mso]>
+                                      <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                                        <tr>
+                                          <![endif]-->
+                                          <!--[if mso]>
+                                          <td valign="top" width="600" style="width:600px;">
+                                            <![endif]-->
+                                            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
+                                              <tbody>
+                                                <tr>
+                                                  <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+                                                    Hypothesis, 2261 Market Street, #632, San Francisco, California 94114, United States of America<br>
+                                                    <br>
+                                                    <br>
+                                                    <a href="{{ preferences_url }}">Change your email preferences</a> or <a href="{{ unsubscribe_url }}">unsubscribe from these emails</a>.
+                                                  </td>
+                                                </tr>
+                                              </tbody>
+                                            </table>
+                                            <!--[if mso]>
+                                          </td>
+                                          <![endif]-->
+                                          <!--[if mso]>
+                                        </tr>
+                                      </table>
+                                      <![endif]-->
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>

--- a/lms/templates/email/instructor_email_digest/body.html.jinja2
+++ b/lms/templates/email/instructor_email_digest/body.html.jinja2
@@ -1,778 +1,131 @@
-<!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-  <head>
-    <!-- NAME: FLYER -->
-    <!--[if gte mso 15]>
-      <xml>
-        <o:OfficeDocumentSettings>
-          <o:AllowPNG/>
-          <o:PixelsPerInch>96</o:PixelsPerInch>
-        </o:OfficeDocumentSettings>
-      </xml>
-    <![endif]-->
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>There has been some activity in Hypothesis</title>
-    <style type="text/css">
- p{
-     margin:0;
-     margin-bottom: 20px;
-     padding:0;
-}
- table{
-     border-collapse:collapse;
-}
- h1,h2,h3,h4,h5,h6{
-     display:block;
-     margin:0;
-     padding:0;
-}
- img,a img{
-     border:0;
-     height:auto;
-     outline:none;
-     text-decoration:none;
-}
- body,#bodyTable,#bodyCell{
-     height:100%;
-     margin:0;
-     padding:0;
-     width:100%;
-}
- .mcnPreviewText{
-     display:none !important;
-}
- #outlook a{
-     padding:0;
-}
- img{
-     -ms-interpolation-mode:bicubic;
-}
- table{
-     mso-table-lspace:0pt;
-     mso-table-rspace:0pt;
-}
- .ReadMsgBody{
-     width:100%;
-}
- .ExternalClass{
-     width:100%;
-}
- p,a,li,td,blockquote{
-     mso-line-height-rule:exactly;
-}
- a[href^=tel],a[href^=sms]{
-     color:inherit;
-     cursor:default;
-     text-decoration:none;
-}
- p,a,li,td,body,table,blockquote{
-     -ms-text-size-adjust:100%;
-     -webkit-text-size-adjust:100%;
-}
- .ExternalClass,.ExternalClass p,.ExternalClass td,.ExternalClass div,.ExternalClass span,.ExternalClass font{
-     line-height:100%;
-}
- a[x-apple-data-detectors]{
-     color:inherit !important;
-     text-decoration:none !important;
-     font-size:inherit !important;
-     font-family:inherit !important;
-     font-weight:inherit !important;
-     line-height:inherit !important;
-}
- a.mcnButton{
-     display:block;
-}
- .mcnImage,.mcnRetinaImage{
-     vertical-align:bottom;
-}
- .mcnTextContent{
-     word-break:break-word;
-}
- .mcnTextContent img{
-     height:auto !important;
-}
- .mcnDividerBlock{
-     table-layout:fixed !important;
-}
-/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
- body,#bodyTable{
-    /*@editable*/
-    background-color:#363636;
-}
-/* @tab Page @section background style @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding. */
- #bodyCell{
-    /*@editable*/
-    border-top:0;
-}
-/* @tab Page @section heading 1 @tip Set the styling for all first-level headings in your emails. These should be the largest of your headings. @style heading 1 */
- h1{
-    /*@editable*/
-    color:#bd1c2b !important;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:40px;
-    /*@editable*/
-    font-style:normal;
-    /*@editable*/
-    font-weight:bold;
-    /*@editable*/
-    line-height:100%;
-    /*@editable*/
-    letter-spacing:-1px;
-    /*@editable*/
-    text-align:center;
-}
-/* @tab Page @section heading 2 @tip Set the styling for all second-level headings in your emails. @style heading 2 */
- h2{
-    /*@editable*/
-    color:#404040 !important;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:26px;
-    /*@editable*/
-    font-style:normal;
-    /*@editable*/
-    font-weight:bold;
-    /*@editable*/
-    line-height:125%;
-    /*@editable*/
-    letter-spacing:-.75px;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Page @section heading 3 @tip Set the styling for all third-level headings in your emails. @style heading 3 */
- h3{
-    /*@editable*/
-    color:#606060 !important;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:18px;
-    /*@editable*/
-    font-style:normal;
-    /*@editable*/
-    font-weight:bold;
-    /*@editable*/
-    line-height:125%;
-    /*@editable*/
-    letter-spacing:-.5px;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Page @section heading 4 @tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings. @style heading 4 */
- h4{
-    /*@editable*/
-    color:#808080 !important;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:16px;
-    /*@editable*/
-    font-style:normal;
-    /*@editable*/
-    font-weight:bold;
-    /*@editable*/
-    line-height:125%;
-    /*@editable*/
-    letter-spacing:normal;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Preheader @section preheader style @tip Set the background color and borders for your email's preheader area. */
- #templatePreheader{
-    /*@editable*/
-    background-color:#FFFFFF;
-    /*@editable*/
-    border-top:0;
-    /*@editable*/
-    border-bottom:1px solid #D5D5D5;
-}
-/* @tab Preheader @section preheader text @tip Set the styling for your email's preheader text. Choose a size and color that is easy to read. */
- .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
-    /*@editable*/
-    color:#bd1c2b;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:11px;
-    /*@editable*/
-    line-height:125%;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Preheader @section preheader link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
- .preheaderContainer .mcnTextContent a{
-    /*@editable*/
-    color:#bd1c2b;
-    /*@editable*/
-    font-weight:normal;
-    /*@editable*/
-    text-decoration:underline;
-}
-/* @tab Header @section header style @tip Set the background color and borders for your email's header area. */
- #templateHeader{
-    /*@editable*/
-    background-color:#EEEEEE;
-    /*@editable*/
-    border-top:0;
-    /*@editable*/
-    border-bottom:0;
-}
-/* @tab Header @section header text @tip Set the styling for your email's header text. Choose a size and color that is easy to read. */
- .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
-    /*@editable*/
-    color:#606060;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:15px;
-    /*@editable*/
-    line-height:150%;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Header @section header link @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text. */
- .headerContainer .mcnTextContent a{
-    /*@editable*/
-    color:#bd1c2b;
-    /*@editable*/
-    font-weight:normal;
-    /*@editable*/
-    text-decoration:underline;
-}
-/* @tab Body @section body style @tip Set the background color and borders for your email's body area. */
- #templateBody{
-    /*@editable*/
-    background-color:#eeeeee;
-    /*@editable*/
-    border-top:0;
-    /*@editable*/
-    border-bottom:0;
-}
-/* @tab Body @section body container @tip Set the background color and border for your email's body text container. */
- #bodyBackground{
-    /*@editable*/
-    background-color:#FFFFFF;
-    /*@editable*/
-    border:1px solid #D5D5D5;
-}
-/* @tab Body @section body text @tip Set the styling for your email's body text. Choose a size and color that is easy to read. */
- .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
-    /*@editable*/
-    color:#606060;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:15px;
-    /*@editable*/
-    line-height:150%;
-    /*@editable*/
-    text-align:left;
-}
-/* @tab Body @section body link @tip Set the styling for your email's body links. Choose a color that helps them stand out from your text. */
- .bodyContainer .mcnTextContent a{
-    /*@editable*/
-    color:#bd1c2b;
-    /*@editable*/
-    font-weight:normal;
-    /*@editable*/
-    text-decoration:underline;
-}
-/* @tab Footer @section footer style @tip Set the background color and borders for your email's footer area. */
- #templateFooter{
-    /*@editable*/
-    background-color:#363636;
-    /*@editable*/
-    border-top:0;
-    /*@editable*/
-    border-bottom:0;
-}
-/* @tab Footer @section footer text @tip Set the styling for your email's footer text. Choose a size and color that is easy to read. */
- .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
-    /*@editable*/
-    color:#CCCCCC;
-    /*@editable*/
-    font-family:'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    /*@editable*/
-    font-size:11px;
-    /*@editable*/
-    line-height:125%;
-    /*@editable*/
-    text-align:center;
-}
-/* @tab Footer @section footer link @tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text. */
- .footerContainer .mcnTextContent a{
-    /*@editable*/
-    color:#CCCCCC;
-    /*@editable*/
-    font-weight:normal;
-    /*@editable*/
-    text-decoration:underline;
-}
- @media only screen and (max-width: 480px){
-     body,table,td,p,a,li,blockquote{
-         -webkit-text-size-adjust:none !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     body{
-         width:100% !important;
-         min-width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .templateContainer{
-         max-width:600px !important;
-         width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnRetinaImage{
-         max-width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImage{
-         height:auto !important;
-         width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnCartContainer,.mcnCaptionTopContent,.mcnRecContentContainer,.mcnCaptionBottomContent,.mcnTextContentContainer,.mcnBoxedTextContentContainer,.mcnImageGroupContentContainer,.mcnCaptionLeftTextContentContainer,.mcnCaptionRightTextContentContainer,.mcnCaptionLeftImageContentContainer,.mcnCaptionRightImageContentContainer,.mcnImageCardLeftTextContentContainer,.mcnImageCardRightTextContentContainer,.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
-         max-width:100% !important;
-         width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnBoxedTextContentContainer{
-         min-width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageGroupContent{
-         padding:9px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnCaptionLeftContentOuter .mcnTextContent,.mcnCaptionRightContentOuter .mcnTextContent{
-         padding-top:9px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageCardTopImageContent,.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent,.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent{
-         padding-top:18px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageCardBottomImageContent{
-         padding-bottom:9px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageGroupBlockInner{
-         padding-top:0 !important;
-         padding-bottom:0 !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageGroupBlockOuter{
-         padding-top:9px !important;
-         padding-bottom:9px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnTextContent,.mcnBoxedTextContentColumn{
-         padding-right:18px !important;
-         padding-left:18px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcnImageCardLeftImageContent,.mcnImageCardRightImageContent{
-         padding-right:18px !important;
-         padding-bottom:0 !important;
-         padding-left:18px !important;
-    }
-}
- @media only screen and (max-width: 480px){
-     .mcpreview-image-uploader{
-         display:none !important;
-         width:100% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section heading 1 @tip Make the first-level headings larger in size for better readability on small screens. */
-     h1{
-        /*@editable*/
-        font-size:24px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section heading 2 @tip Make the second-level headings larger in size for better readability on small screens. */
-     h2{
-        /*@editable*/
-        font-size:20px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section heading 3 @tip Make the third-level headings larger in size for better readability on small screens. */
-     h3{
-        /*@editable*/
-        font-size:18px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section heading 4 @tip Make the fourth-level headings larger in size for better readability on small screens. */
-     h4{
-        /*@editable*/
-        font-size:16px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section Boxed Text @tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
-     .mcnBoxedTextContentContainer .mcnTextContent,.mcnBoxedTextContentContainer .mcnTextContent p{
-        /*@editable*/
-        font-size:18px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section Preheader Visibility @tip Set the visibility of the email's preheader on small screens. You can hide it to save space. */
-     #templatePreheader{
-        /*@editable*/
-        display:block !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section Preheader Text @tip Make the preheader text larger in size for better readability on small screens. */
-     .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
-        /*@editable*/
-        font-size:14px !important;
-        /*@editable*/
-        line-height:115% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section Header Text @tip Make the header text larger in size for better readability on small screens. */
-     .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
-        /*@editable*/
-        font-size:18px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section Body Text @tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px. */
-     .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
-        /*@editable*/
-        font-size:18px !important;
-        /*@editable*/
-        line-height:125% !important;
-    }
-}
- @media only screen and (max-width: 480px){
-    /* @tab Mobile Styles @section footer text @tip Make the body content text larger in size for better readability on small screens. */
-     .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
-        /*@editable*/
-        font-size:14px !important;
-        /*@editable*/
-        line-height:115% !important;
-    }
-}
-    </style>
-  </head>
-  <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-    <center>
-      <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
-        <tr>
-          <td align="center" valign="top" id="bodyCell">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-              <tr>
-                <td align="center" valign="top">
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templatePreheader">
-                    <tr>
-                      <td align="center" valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
-                          <tr>
-                            <td valign="top" class="preheaderContainer" style="padding-top:10px; padding-bottom:10px;"></td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td align="center" valign="top">
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader">
-                    <tr>
-                      <td align="center" valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
-                          <tr>
-                            <td valign="top" class="headerContainer" style="padding-top:15px; padding-bottom:10px;">
-                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width:100%;">
-                                <tbody class="mcnDividerBlockOuter">
-                                  <tr>
-                                    <td class="mcnDividerBlockInner" style="min-width: 100%; padding: 15px 18px 10px;">
-                                      <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 2px solid #EEEEEE;">
-                                        <tbody>
-                                          <tr>
-                                            <td>
-                                              <span></span>
-                                            </td>
-                                          </tr>
-                                        </tbody>
-                                      </table>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnImageBlock" style="min-width:100%;">
-                                <tbody class="mcnImageBlockOuter">
-                                  <tr>
-                                    <td valign="top" style="padding:9px" class="mcnImageBlockInner">
-                                      <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer" style="min-width:100%;">
-                                        <tbody>
-                                          <tr>
-                                            <td class="mcnImageContent" valign="top" style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
-                                              <img align="center" alt="" src="{{ 'lms:static/images/hypothesis-wordmark-logo.png'|static_url }}" width="225.60000000000002" style="max-width:1358px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
-                                            </td>
-                                          </tr>
-                                        </tbody>
-                                      </table>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td align="center" valign="top">
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateBody">
-                    <tr>
-                      <td align="center" valign="top" style="padding-top:10px; padding-right:10px; padding-bottom:5px; padding-left:10px;">
-                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
-                          <tr>
-                            <td align="center" valign="top">
-                              <table border="0" cellpadding="0" cellspacing="0" width="100%" id="bodyBackground">
-                                <tr>
-                                  <td valign="top" class="bodyContainer" style="padding-top:10px; padding-bottom:10px;">
-                                    <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
-                                      <tbody class="mcnTextBlockOuter">
-                                        <tr>
-                                          <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-                                            <!--[if mso]>
-                                            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-                                              <tr>
-                                                <![endif]-->
-                                                <!--[if mso]>
-                                                <td valign="top" width="599" style="width:599px;">
-                                                  <![endif]-->
-                                                  <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
-                                                    <tbody>
-                                                      <tr>
-                                                        <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-                                                          <h1 style="text-align: center;"><span style="font-size:31px">There has been some activity in Hypothesis</span></h1>
-                                                        </td>
-                                                      </tr>
-                                                    </tbody>
-                                                  </table>
-                                                  <!--[if mso]>
-                                                </td>
-                                                <![endif]-->
-                                                <!--[if mso]>
-                                              </tr>
-                                            </table>
-                                            <![endif]-->
-                                          </td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                    <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
-                                      <tbody class="mcnTextBlockOuter">
-                                        <tr>
-                                          <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-                                            <!--[if mso]>
-                                            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-                                              <tr>
-                                                <![endif]-->
-                                                <!--[if mso]>
-                                                <td valign="top" width="599" style="width:599px;">
-                                                  <![endif]-->
-                                                  <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
-                                                    <tbody>
-                                                      <tr>
-                                                        <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+{% extends 'templates/email/email_layout.html.jinja2' %}
 
-                                                          <p>Hi,</p>
-
-                                                          <p>
-                                                            {% if total_annotations > 1 and annotators|length > 1 and courses|length > 1 -%}
-                                                              {{ annotators|length}} of your students made {{ total_annotations }} new annotations in {{ courses|length }} courses.
-                                                            {%- elif annotators|length > 1 -%}
-                                                              {{ annotators|length}} of your students made {{ total_annotations }} new annotations.
-                                                            {%- elif courses|length > 1 -%}
-                                                              One of your students made {{ total_annotations }} new annotations in {{ courses|length }} courses.
-                                                            {%- elif total_annotations > 1 -%}
-                                                              One of your students made {{ total_annotations }} new annotations.
-                                                            {%- else -%}
-                                                              One of your students made a new annotation.
-                                                            {%- endif %}
-                                                          </p>
-
-                                                          {% for course in courses %}
-                                                            <h3>{{ course.title }}</h3>
-                                                            <p>
-                                                              {% if course.num_annotations > 1 and course.annotators|length > 1 %}
-                                                                {{ course.annotators|length }} students made {{ course.num_annotations }} new annotations in this course.
-                                                              {% elif course.num_annotations > 1 %}
-                                                                1 student made {{ course.num_annotations }} new annotations in this course.
-                                                              {% else %}
-                                                                A student made a new annotation in this course.
-                                                              {% endif %}
-                                                              {% if course.assignments|length > 0 %}
-                                                                {% for assignment in course.assignments %}
-                                                                  <br/>
-                                                                  <strong>{{ assignment.title }}</strong>
-                                                                  <br/>
-                                                                 {% if assignment.num_annotations > 1 and assignment.annotators|length > 1 %}
-                                                                   {{ assignment.annotators|length }} students made {{ assignment.num_annotations }} new annotations in this assignment.
-                                                                 {% elif assignment.num_annotations > 1 %}
-                                                                   1 student made {{ assignment.num_annotations }} new annotations in this assignment.
-                                                                 {% else %}
-                                                                   A student made a new annotation in this assignment.
-                                                                 {% endif %}
-                                                                {% endfor %}
-                                                              {% endif %}
-                                                            </p>
-                                                          {% endfor %}
-
-                                                          <p><b>We'd love your feedback so we can continue to make improvements
-                                                          to our product. <a href="https://survey.hsforms.com/1pY2LBb_hR9aJMgo9jS0mVQ3quew">Take our survey</a>
-                                                          to tell us what you think of these new daily emails for
-                                                          instructors.</b></p>
-
-                                                        </td>
-                                                      </tr>
-                                                    </tbody>
-                                                  </table>
-                                                  <!--[if mso]>
-                                                </td>
-                                                <![endif]-->
-                                                <!--[if mso]>
-                                              </tr>
-                                            </table>
-                                            <![endif]-->
-                                          </td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                    <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonBlock" style="min-width:100%;">
-                                      <tbody class="mcnButtonBlockOuter">
-                                        <tr>
-                                          <td style="padding-top:0; padding-right:18px; padding-bottom:18px; padding-left:18px;" valign="top" align="center" class="mcnButtonBlockInner">
-                                            <table border="0" cellpadding="0" cellspacing="0" class="mcnButtonContentContainer" style="border-collapse: separate !important;border-radius: 3px;background-color: #BD1C2B;">
-                                              <tbody>
-                                                <tr>
-                                                  <td align="center" valign="middle" class="mcnButtonContent" style="font-family: Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; padding: 15px;">
-                                                    <a class="mcnButton " title="Share feedback" href="https://survey.hsforms.com/1pY2LBb_hR9aJMgo9jS0mVQ3quew" target="_blank" style="font-weight: bold;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF;">Share Feedback</a>
-                                                  </td>
-                                                </tr>
-                                              </tbody>
-                                            </table>
-                                          </td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                  </td>
-                                </tr>
-                              </table>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td align="center" valign="top">
-                              <img src="https://cdn-images.mailchimp.com/template_images/gallery/couponshadow.png" height="20" width="600" class="mcnImage" style="display:block; max-width:560px;">
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td align="center" valign="top" style="padding-bottom:40px;">
-                  <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateFooter">
-                    <tr>
-                      <td align="center" valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0" width="600" class="templateContainer">
-                          <tr>
-                            <td valign="top" class="footerContainer" style="padding-top:10px; padding-bottom:10px;">
-                              <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
-                                <tbody class="mcnTextBlockOuter">
-                                  <tr>
-                                    <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-                                      <!--[if mso]>
-                                      <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-                                        <tr>
-                                          <![endif]-->
-                                          <!--[if mso]>
-                                          <td valign="top" width="600" style="width:600px;">
-                                            <![endif]-->
-                                            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
-                                              <tbody>
-                                                <tr>
-                                                  <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-                                                    Hypothesis, 2261 Market Street, #632, San Francisco, California 94114, United States of America<br>
-                                                    <br>
-                                                    <br>
-                                                    <a href="{{ preferences_url}}">Change your email preferences</a> or <a href="{{ unsubscribe_url }}">unsubscribe from these emails</a>.
-                                                  </td>
-                                                </tr>
-                                              </tbody>
-                                            </table>
-                                            <!--[if mso]>
-                                          </td>
-                                          <![endif]-->
-                                          <!--[if mso]>
-                                        </tr>
-                                      </table>
-                                      <![endif]-->
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
+{% block content %}
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
+    <tbody class="mcnTextBlockOuter">
+    <tr>
+        <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+            <!--[if mso]>
+            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                <tr>
+            <![endif]-->
+            <!--[if mso]>
+            <td valign="top" width="599" style="width:599px;">
+            <![endif]-->
+            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
+                <tbody>
+                <tr>
+                    <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+                        <h1 style="text-align: center;"><span style="font-size:31px">There has been some activity in Hypothesis</span></h1>
+                    </td>
+                </tr>
+                </tbody>
             </table>
-          </td>
-        </tr>
-      </table>
-    </center>
-  </body>
-</html>
+            <!--[if mso]>
+            </td>
+            <![endif]-->
+            <!--[if mso]>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
+    <tbody class="mcnTextBlockOuter">
+    <tr>
+        <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+            <!--[if mso]>
+            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                <tr>
+            <![endif]-->
+            <!--[if mso]>
+            <td valign="top" width="599" style="width:599px;">
+            <![endif]-->
+            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
+                <tbody>
+                <tr>
+                    <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+                        <p>Hi,</p>
+
+                        <p>
+                            {% if total_annotations > 1 and annotators|length > 1 and courses|length > 1 -%}
+                                {{ annotators|length}} of your students made {{ total_annotations }} new annotations in {{ courses|length }} courses.
+                            {%- elif annotators|length > 1 -%}
+                                {{ annotators|length}} of your students made {{ total_annotations }} new annotations.
+                            {%- elif courses|length > 1 -%}
+                                One of your students made {{ total_annotations }} new annotations in {{ courses|length }} courses.
+                            {%- elif total_annotations > 1 -%}
+                                One of your students made {{ total_annotations }} new annotations.
+                            {%- else -%}
+                                One of your students made a new annotation.
+                            {%- endif %}
+                        </p>
+
+                        {% for course in courses %}
+                            <h3>{{ course.title }}</h3>
+                            <p>
+                                {% if course.num_annotations > 1 and course.annotators|length > 1 %}
+                                    {{ course.annotators|length }} students made {{ course.num_annotations }} new annotations in this course.
+                                {% elif course.num_annotations > 1 %}
+                                    1 student made {{ course.num_annotations }} new annotations in this course.
+                                {% else %}
+                                    A student made a new annotation in this course.
+                                {% endif %}
+                                {% if course.assignments|length > 0 %}
+                                    {% for assignment in course.assignments %}
+                                        <br/>
+                                        <strong>{{ assignment.title }}</strong>
+                                        <br/>
+                                        {% if assignment.num_annotations > 1 and assignment.annotators|length > 1 %}
+                                            {{ assignment.annotators|length }} students made {{ assignment.num_annotations }} new annotations in this assignment.
+                                        {% elif assignment.num_annotations > 1 %}
+                                            1 student made {{ assignment.num_annotations }} new annotations in this assignment.
+                                        {% else %}
+                                            A student made a new annotation in this assignment.
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endif %}
+                            </p>
+                        {% endfor %}
+
+                        <p><b>We'd love your feedback so we can continue to make improvements
+                            to our product. <a href="https://survey.hsforms.com/1pY2LBb_hR9aJMgo9jS0mVQ3quew">Take our survey</a>
+                            to tell us what you think of these new daily emails for
+                            instructors.</b></p>
+
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <!--[if mso]>
+            </td>
+            <![endif]-->
+            <!--[if mso]>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonBlock" style="min-width:100%;">
+    <tbody class="mcnButtonBlockOuter">
+    <tr>
+        <td style="padding-top:0; padding-right:18px; padding-bottom:18px; padding-left:18px;" valign="top" align="center" class="mcnButtonBlockInner">
+            <table border="0" cellpadding="0" cellspacing="0" class="mcnButtonContentContainer" style="border-collapse: separate !important;border-radius: 3px;background-color: #BD1C2B;">
+                <tbody>
+                <tr>
+                    <td align="center" valign="middle" class="mcnButtonContent" style="font-family: Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; padding: 15px;">
+                        <a class="mcnButton " title="Share feedback" href="https://survey.hsforms.com/1pY2LBb_hR9aJMgo9jS0mVQ3quew" target="_blank" style="font-weight: bold;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF;">Share Feedback</a>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+{% endblock %}

--- a/lms/templates/email/instructor_email_digest/body.html.jinja2
+++ b/lms/templates/email/instructor_email_digest/body.html.jinja2
@@ -1,4 +1,4 @@
-{% extends 'templates/email/email_layout.html.jinja2' %}
+{% extends 'lms:templates/email/email_layout.html.jinja2' %}
 
 {% block content %}
 <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">

--- a/lms/templates/email/mention/body.html.jinja2
+++ b/lms/templates/email/mention/body.html.jinja2
@@ -1,11 +1,86 @@
-{% extends 'templates/email/email_layout.html.jinja2' %}
+{% extends 'lms:templates/email/email_layout.html.jinja2' %}
 
 {% block content %}
-<p>Hi {{ mentioned_user}}</p>
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
+    <tbody class="mcnTextBlockOuter">
+    <tr>
+        <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+            <!--[if mso]>
+            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                <tr>
+            <![endif]-->
+            <!--[if mso]>
+            <td valign="top" width="599" style="width:599px;">
+            <![endif]-->
+            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
+                <tbody>
+                <tr>
+                    <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+                        <h1 style="text-align: center;">
+                            <span style="font-size:31px">Someone has mentioned you on an annotation</span>
+                        </h1>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <!--[if mso]>
+            </td>
+            <![endif]-->
+            <!--[if mso]>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width:100%;">
+    <tbody class="mcnTextBlockOuter">
+    <tr>
+        <td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+            <!--[if mso]>
+            <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                <tr>
+            <![endif]-->
+            <!--[if mso]>
+            <td valign="top" width="599" style="width:599px;">
+            <![endif]-->
+            <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
+                <tbody>
+                <tr>
+                    <td valign="top" class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
 
-<p>Someone has mentioned you on an annotation:</p>
+                        <p>{{ course_title }} - {{ assignment_title }}</p>
 
-<p>{{ course_title }} - {{ assignment_title }}</p>
 
-<p> {{ annotation_text | safe }} </p>
+                        <table align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:100%; min-width:100%; border: 1px solid #D5D5D5; margin-bottom: 10px">
+                            <tbody>
+                            <tr>
+                                <td valign="top" style="padding: 10px;">
+                                    {% if annotation_quote %}
+                                        <blockquote style="font-style: italic; border-left: 4px solid lightgrey; color: grey; margin: 0 0 10px 0; padding-left: 10px">
+                                            {{ annotation_quote }}
+                                        </blockquote>
+                                    {% endif %}
+
+                                    <p style="margin-bottom: 0">{{ annotation_text | safe }}</p>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <!--[if mso]>
+            </td>
+            <![endif]-->
+            <!--[if mso]>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
 {% endblock %}

--- a/lms/templates/email/mention/body.html.jinja2
+++ b/lms/templates/email/mention/body.html.jinja2
@@ -1,3 +1,6 @@
+{% extends 'templates/email/email_layout.html.jinja2' %}
+
+{% block content %}
 <p>Hi {{ mentioned_user}}</p>
 
 <p>Someone has mentioned you on an annotation:</p>
@@ -5,3 +8,4 @@
 <p>{{ course_title }} - {{ assignment_title }}</p>
 
 <p> {{ annotation_text | safe }} </p>
+{% endblock %}

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -107,7 +107,6 @@ class AdminEmailViews:
 
 
 MENTION_EMAIL_TEMPLATE_VARS = {
-    "mentioned_user": "MENTIONED USER",
     "course_title": "COURSE TITLE",
     "assignment_title": "ASSIGNMENT TITLE",
     "annotation_text": "ANNOTATION TEXT",

--- a/tests/unit/lms/services/annotation_activity_email_test.py
+++ b/tests/unit/lms/services/annotation_activity_email_test.py
@@ -37,7 +37,6 @@ class TestAnnotationActivityEmailService:
                 "assignment_title": assignment.title,
                 "annotation_text": "ANNOTATION_TEXT",
                 "course_title": assignment.course.lms_name,
-                "mentioned_user": mentioned_user.display_name,
             },
             tags=["lms", "mention"],
         )


### PR DESCRIPTION
Closes #7064 

Make mentions email look similar to the one sent by `h`, which is in turn based in the email digest here.

![image](https://github.com/user-attachments/assets/e6731ce8-40fd-4ded-81d0-2ebab5e853c2)

In order to achieve this, this PR extracts a common jinja layout from which both mentions and email digest templates extend.

Then every template just defines the part that is different via a content block.

The layout expects only two parameters, which the mentions email does not yet provide, `preferences_url` and `unsubscribe_url`, but adding those is not addressed here.

This PR also makes the next changes to the mention template params:

* Removes `mentioned_user`, as this information is part of the annotation text already.
* Adds `annotation_quote`, so that the pseudo annotation card looks closer to how it looks in the sidebar. As opposed to `h`, we do not display the mentioning user for data privacy reasons.
    This param is currently not passed to the template. We'll address that separately.

The new template can be tested by going to http://localhost:8001/admin/email/mentions