### PR TITLE
Pass annotation quote from mention event to mention email template

### DIFF
--- a/lms/services/annotation_activity_email.py
+++ b/lms/services/annotation_activity_email.py
@@ -45,10 +45,11 @@ class AnnotationActivityEmailService:
             >= ANNOTATION_NOTIFICATION_LIMIT
         )
 
-    def send_mention(
+    def send_mention(  # noqa: PLR0913
         self,
         annotation_id: str,
         annotation_text: str,
+        annotation_quote: str | None,
         mentioning_user_h_userid: str,
         mentioned_user_h_userid: str,
         assignment_id: int,
@@ -86,6 +87,7 @@ class AnnotationActivityEmailService:
             "assignment_title": assignment.title,
             "course_title": assignment.course.lms_name,
             "annotation_text": annotation_text,
+            "annotation_quote": annotation_quote,
             "preferences_url": self._email_preferences_service.preferences_url(
                 mentioned_user.h_userid, "mention"
             ),

--- a/lms/tasks/annotations.py
+++ b/lms/tasks/annotations.py
@@ -44,6 +44,7 @@ class _Annotation(BaseModel):
     mentions: list[_AnnotationMention]
     metadata: _AnnotationMetadata
     text_rendered: str
+    quote: str | None
 
 
 class AnnotationEvent(BaseModel):
@@ -115,6 +116,7 @@ def annotation_event(*, event) -> None:
             annotation_activity_email_service.send_mention(
                 annotation.id,
                 annotation.text_rendered,
+                annotation.quote,
                 mentioning_user.h_userid,
                 mentioned_user.h_userid,
                 assignment.id,

--- a/lms/views/admin/email.py
+++ b/lms/views/admin/email.py
@@ -109,7 +109,8 @@ class AdminEmailViews:
 MENTION_EMAIL_TEMPLATE_VARS = {
     "course_title": "COURSE TITLE",
     "assignment_title": "ASSIGNMENT TITLE",
-    "annotation_text": "ANNOTATION TEXT",
+    "annotation_text": 'ANNOTATION TEXT <a data-hyp-mention="" data-userid="acct:1234567@lms.hypothes.is">@John Doe</a>',
+    "annotation_quote": "ANNOTATION QUOTE",
 }
 
 

--- a/tests/unit/lms/services/annotation_activity_email_test.py
+++ b/tests/unit/lms/services/annotation_activity_email_test.py
@@ -31,6 +31,7 @@ class TestAnnotationActivityEmailService:
         svc.send_mention(
             "ANNOTATION_ID",
             "ANNOTATION_TEXT",
+            "ANNOTATION_QUOTE",
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,
@@ -51,6 +52,7 @@ class TestAnnotationActivityEmailService:
             template_vars={
                 "assignment_title": assignment.title,
                 "annotation_text": "ANNOTATION_TEXT",
+                "annotation_quote": "ANNOTATION_QUOTE",
                 "course_title": assignment.course.lms_name,
                 "preferences_url": email_preferences_service.preferences_url.return_value,
             },
@@ -86,6 +88,7 @@ class TestAnnotationActivityEmailService:
         assert not svc.send_mention(
             "ANNOTATION_ID",
             "ANNOTATION_TEXT",
+            "ANNOTATION_QUOTE",
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,

--- a/tests/unit/lms/tasks/annotations_test.py
+++ b/tests/unit/lms/tasks/annotations_test.py
@@ -24,6 +24,7 @@ class TestAnnotationEvent:
         annotation_activity_email_service.send_mention.assert_called_once_with(
             annotation_event["annotation"]["id"],
             annotation_event["annotation"]["text_rendered"],
+            annotation_event["annotation"]["quote"],
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,
@@ -78,6 +79,7 @@ class TestAnnotationEvent:
                 "created": "2025-03-19T09:01:37.181037+00:00",
                 "updated": "2025-03-19T09:01:37.181037+00:00",
                 "text_rendered": "ANNOTATION TEXT",
+                "quote": "ANNOTATION QUOTE",
                 "user": mentioning_user.h_userid,
                 "uri": "https://example.com/",
                 "text": '<a data-hyp-mention="" data-userid="acct:270d2d38d2ddd16c911661e62f116c@lms.hypothes.is">@Dean Dean</a> ',


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h/pull/9428

Part of https://github.com/orgs/hypothesis/projects/153/views/1?pane=issue&itemId=103523869

Forward the annotation quote from the mention event to the template.

![image](https://github.com/user-attachments/assets/1927b7e1-e6d6-4f7e-ad4f-d4392dfa5b7b)
