### PR TITLE
Fix mentions tests missing parameter

### DIFF
--- a/tests/unit/lms/services/annotation_activity_email_test.py
+++ b/tests/unit/lms/services/annotation_activity_email_test.py
@@ -85,6 +85,7 @@ class TestAnnotationActivityEmailService:
 
         assert not svc.send_mention(
             "ANNOTATION_ID",
+            "ANNOTATION_TEXT",
             mentioning_user.h_userid,
             mentioned_user.h_userid,
             assignment.id,


### PR DESCRIPTION
This was missed as the new parameter was added in another branch and the original change was not rebased.