### PR TITLE
Explicitly indicate authorization errors using an error code

### DIFF
--- a/lms/error_code.py
+++ b/lms/error_code.py
@@ -18,3 +18,6 @@ class ErrorCode(StrEnum):
     REUSED_CONSUMER_KEY = "reused_consumer_key"
     CANVAS_SUBMISSION_COURSE_NOT_AVAILABLE = "canvas_submission_course_not_available"
     CANVAS_SUBMISSION_MAX_ATTEMPTS = "canvas_submission_max_attempts"
+
+    OAUTH2_AUTHORIZATION_ERROR = "oauth2_authorization_error"
+    """Show the authorization dialog on the front end."""

--- a/lms/static/scripts/frontend_apps/components/test/BasicLTILaunchApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/BasicLTILaunchApp-test.js
@@ -174,8 +174,10 @@ describe('BasicLTILaunchApp', () => {
     });
 
     it('displays authorization prompt if content URL fetch fails and we can re-authorize', async () => {
-      // Make the initial URL fetch request reject with an unspecified `APIError`.
-      fakeApiCall.rejects(new APIError(400, {}));
+      // Make the initial URL fetch request reject with an authorization error.
+      fakeApiCall.rejects(
+        new APIError(400, { error_code: 'oauth2_authorization_error' }),
+      );
 
       const wrapper = renderLTILaunchApp();
       await spinnerVisible(wrapper);
@@ -206,8 +208,10 @@ describe('BasicLTILaunchApp', () => {
     });
 
     it('does not create a second auth window when Authorize button is clicked twice', async () => {
-      // Make the initial URL fetch request reject with an unspecified `APIError`.
-      fakeApiCall.rejects(new APIError(400, {}));
+      // Make the initial URL fetch request reject with an authorization error.
+      fakeApiCall.rejects(
+        new APIError(400, { error_code: 'oauth2_authorization_error' }),
+      );
 
       const wrapper = renderLTILaunchApp();
       const errorDialog = await waitForElement(
@@ -798,7 +802,9 @@ describe('BasicLTILaunchApp', () => {
     it('shows an error dialog if the first request fails and second succeeds', async () => {
       const wrapper = renderLTILaunchApp();
       // Should show an error after the first request fails
-      contentUrlReject(new APIError(400, {}));
+      contentUrlReject(
+        new APIError(400, { error_code: 'oauth2_authorization_error' }),
+      );
       await waitForElement(
         wrapper,
         'LaunchErrorDialog[errorState="error-authorizing"]',
@@ -822,7 +828,9 @@ describe('BasicLTILaunchApp', () => {
       await contentVisible(wrapper);
 
       // Should show an error after failure
-      groupsCallReject(new APIError(400, {}));
+      groupsCallReject(
+        new APIError(400, { error_code: 'oauth2_authorization_error' }),
+      );
       await waitForElement(
         wrapper,
         'LaunchErrorDialog[errorState="error-authorizing"]',
@@ -846,8 +854,12 @@ describe('BasicLTILaunchApp', () => {
       it('shows an error dialog if the initial content/groups requests reject and second attempt also rejects', async () => {
         const wrapper = renderLTILaunchApp();
         // Both requests reject first
-        contentUrlReject(new APIError(400, {}));
-        groupsCallReject(new APIError(400, {}));
+        contentUrlReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
+        groupsCallReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
 
         const errorDialog = await waitForElement(
           wrapper,
@@ -869,8 +881,12 @@ describe('BasicLTILaunchApp', () => {
       it('shows an error dialog if contentUrl succeeds but groups rejects first', async () => {
         const wrapper = renderLTILaunchApp();
         // Both requests reject first
-        contentUrlReject(new APIError(400, {}));
-        groupsCallReject(new APIError(400, {}));
+        contentUrlReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
+        groupsCallReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
 
         const errorDialog = await waitForElement(
           wrapper,
@@ -878,7 +894,9 @@ describe('BasicLTILaunchApp', () => {
         );
         resetApiCalls();
         // groups still fails, but contentUrl does not.
-        groupsCallReject(new APIError(400, {}));
+        groupsCallReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
         // Click the "Authorize" button.
         act(() => {
           errorDialog.prop('onRetry')();
@@ -891,8 +909,12 @@ describe('BasicLTILaunchApp', () => {
         const wrapper = renderLTILaunchApp();
 
         // Make initial content URL and groups requests fail.
-        contentUrlReject(new APIError(400, {}));
-        groupsCallReject(new APIError(400, {}));
+        contentUrlReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
+        groupsCallReject(
+          new APIError(400, { error_code: 'oauth2_authorization_error' }),
+        );
 
         resetApiCalls();
 

--- a/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/LMSFilePicker-test.js
@@ -195,10 +195,10 @@ describe('LMSFilePicker', () => {
     assert.deepEqual(pathItems3[1], fakeFolders[0]);
   });
 
-  it('shows the authorization prompt if fetching files fails with an APIError that has no `serverMessage`', async () => {
+  it('shows the authorization prompt if fetching files fails with an APIError that has `oauth2_authorization_code`', async () => {
     fakeApiCall.rejects(
       new APIError('Not authorized', {
-        /** without serverMessage */
+        error_code: 'oauth2_authorization_error',
       }),
     );
 
@@ -230,7 +230,7 @@ describe('LMSFilePicker', () => {
   it('shows the "Authorize" and "Try again" buttons after 2 failed authorization requests', async () => {
     fakeApiCall.rejects(
       new APIError('Not authorized', {
-        /** without serverMessage */
+        error_code: 'oauth2_authorization_error',
       }),
     );
 

--- a/lms/static/scripts/frontend_apps/errors.ts
+++ b/lms/static/scripts/frontend_apps/errors.ts
@@ -140,16 +140,9 @@ export function isAPIError(error: ErrorLike): error is APIError {
 
 /**
  * Should the error be treated as an authorization error?
- *
- * This is a special case. We're handling an APIError resulting from an API
- * request, but there are no further details in the response body to guide us.
- * This implicitly means that we're facing an authorization-related issue.
- *
- * Put another way, if an APIError has neither an errorCode nor a serverMessage,
- * it is considered an "authorization error".
  */
 export function isAuthorizationError(error: ErrorLike): boolean {
-  return isAPIError(error) && !error.serverMessage && !error.errorCode;
+  return isAPIError(error) && error.errorCode === 'oauth2_authorization_error';
 }
 
 /**

--- a/lms/static/scripts/frontend_apps/test/errors-test.js
+++ b/lms/static/scripts/frontend_apps/test/errors-test.js
@@ -49,11 +49,7 @@ describe('isAuthorizationError', () => {
       expected: false,
     },
     {
-      error: new APIError(404, {}),
-      expected: true,
-    },
-    {
-      error: new APIError(404, { details: 'moose' }),
+      error: new APIError(404, { error_code: 'oauth2_authorization_error' }),
       expected: true,
     },
   ].forEach((testCase, idx) => {

--- a/tests/unit/lms/views/api/exceptions_test.py
+++ b/tests/unit/lms/views/api/exceptions_test.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 from pyramid.httpexceptions import HTTPBadRequest
 
+from lms.error_code import ErrorCode
 from lms.models.oauth2_token import Service
 from lms.product.product import Routes
 from lms.services import ExternalRequestError, OAuth2TokenError, SerializableError
@@ -47,7 +48,7 @@ class TestOAuth2TokenError:
         error_body = views.oauth2_token_error()
 
         assert pyramid_request.response.status_code == 400
-        assert error_body == ErrorBody()
+        assert error_body == ErrorBody(error_code=ErrorCode.OAUTH2_AUTHORIZATION_ERROR)
 
 
 class TestExternalRequestError:
@@ -90,14 +91,6 @@ class TestExternalRequestError:
                 "validation_errors": context.validation_errors,
             },
         )
-
-    @pytest.mark.parametrize("message", [None, ""])
-    def test_it_injects_a_default_error_message(self, context, message, views):
-        context.message = message
-
-        error_body = views.external_request_error()
-
-        assert error_body.message == "External request failed"
 
     @pytest.fixture
     def context(self):


### PR DESCRIPTION
Instead of relying on the implicit assumption that a error response without code and message means authorization error explicitly set a new error code for it.

On top of making this situation clearer, this also allows to avoid having to send a message when none is needed just to avoid implicitly marking the error as an authorization error.

Slack thread: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1743415186086139

## Testing

- Force authorization errors with something like

```
truncate oauth2_token;
```

in `make sql`.

- Launch an assignment that interacts with the LMS API:

https://hypothesis.instructure.com/courses/125/assignments/873


- You'll get the authorization dialog