### PR TITLE
Add application instance feature flag for PDF image annotation

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -67,6 +67,7 @@ class ApplicationSettings(JSONSettings):
         )
         HYPOTHESIS_COLLECT_STUDENT_EMAILS = "hypothesis.collect_student_emails"
         HYPOTHESIS_MENTIONS = "hypothesis.mentions"
+        HYPOTHESIS_PDF_IMAGE_ANNOTATION = "hypothesis.pdf_image_annotation"
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
@@ -168,6 +169,11 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.HYPOTHESIS_MENTIONS: JSONSetting(
             Settings.HYPOTHESIS_MENTIONS, SettingFormat.TRI_STATE, default=True
+        ),
+        Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION: JSONSetting(
+            Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION,
+            SettingFormat.TRI_STATE,
+            default=False,
         ),
     }
 

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -129,6 +129,7 @@
                             {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
                             {{ tri_state_settings_checkbox("Collect student emails", fields[Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS]) }}
                             {{ tri_state_settings_checkbox("Mentions", fields[Settings.HYPOTHESIS_MENTIONS]) }}
+                            {{ tri_state_settings_checkbox("PDF image annotation", fields[Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION]) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -264,6 +264,11 @@ class BasicLaunchViews:
         ):
             self.context.js_config.enable_client_feature("at_mentions")
 
+        if ai_settings.get_setting(
+            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION]
+        ):
+            self.context.js_config.enable_client_feature("pdf_image_annotation")
+
         # Run any non standard code for the current product
         self._misc_plugin.post_launch_assignment_hook(
             self.request, self.context.js_config, assignment

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -182,6 +182,12 @@ class TestApplicationSettings:
                 "hypothesis.mentions",
                 SettingFormat.TRI_STATE,
             ),
+            (
+                "hypothesis",
+                "pdf_image_annotation",
+                "hypothesis.pdf_image_annotation",
+                SettingFormat.TRI_STATE,
+            ),
         ]
 
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -312,6 +312,26 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    @pytest.mark.parametrize("enable", [True, False])
+    def test__show_document_enables_client_features(
+        self, svc, context, pyramid_request, assignment, enable
+    ):
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "mentions", enable
+        )
+        pyramid_request.lti_user.application_instance.settings.set(
+            "hypothesis", "pdf_image_annotation", enable
+        )
+
+        svc._show_document(assignment)  # noqa: SLF001
+
+        enabled_features = {
+            call.args[0] for call in context.js_config.enable_client_feature.mock_calls
+        }
+
+        expected_features = {"at_mentions", "pdf_image_annotation"} if enable else set()
+        assert enabled_features == expected_features
+
     @pytest.mark.parametrize("use_toolbar_editing", [True, False])
     @pytest.mark.parametrize("use_toolbar_grading", [True, False])
     @pytest.mark.parametrize("is_gradable", [True, False])


### PR DESCRIPTION
Add an application instance feature flag to enable PDF image annotation. The only effect of this flag in the LMS app is to enable the `pdf_image_annotation` feature in the client.

**Testing:**

1. Go to http://localhost:5000/admin/features and make sure the `pdf_image_annotation` flag is *not* turned on for _everyone_ (first party only or specific users only is fine)
2. Go to http://localhost:8001/admin/instances/8/settings and change the "PDF image annotation" setting to "Enabled"
3. Go to a PDF assignment using this application instance such as https://hypothesis.instructure.com/courses/125/assignments/874 and verify that the client sidebar shows the extra controls that are part of the PDF image annotation feature

<img width="120" alt="PDF image annotation controls" src="https://github.com/user-attachments/assets/92e36131-1f51-4a41-bde3-7fdba1d2f2c8" />
