### PR TITLE
Use shades of green, yellow and red from frontend-shared

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/AssignmentActivity.tsx
@@ -73,7 +73,7 @@ function SyncErrorMessage({ grades }: { grades: StudentGradingSync[] }) {
     <div
       className={classnames(
         'rounded px-2 py-1',
-        'font-bold text-grade-error bg-grade-error-light',
+        'font-bold text-red-dark bg-red-light',
       )}
     >
       Error syncing {count} {count === 1 ? 'grade' : 'grades'}

--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeIndicator.tsx
@@ -43,8 +43,8 @@ function AnnotationCount({
       </div>
       <div
         className={classnames('rounded-full p-1', {
-          'bg-grade-success-light text-grade-success': requirementWasMet,
-          'bg-grade-error-light text-grade-error': !requirementWasMet,
+          'bg-green-light text-green-dark': requirementWasMet,
+          'bg-red-light text-red-dark': !requirementWasMet,
         })}
       >
         {requirementWasMet ? <CheckIcon /> : <CancelIcon />}

--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
@@ -27,13 +27,11 @@ export default function GradeStatusChip({ grade }: GradeStatusChipProps) {
       className={classnames(
         'rounded inline-block font-bold px-2 py-0.5 cursor-default',
         {
-          'bg-grade-success text-white': grade === 1,
-          'bg-grade-success-light text-grade-success':
-            grade >= 0.8 && grade < 1,
-          'bg-grade-warning-light text-grade-warning':
-            grade >= 0.5 && grade < 0.8,
-          'bg-grade-error-light text-grade-error': grade > 0 && grade < 0.5,
-          'bg-grade-error text-white': grade === 0,
+          'bg-green-dark text-white': grade === 1,
+          'bg-green-light text-green-dark': grade >= 0.8 && grade < 1,
+          'bg-yellow-light text-yellow-dark': grade >= 0.5 && grade < 0.8,
+          'bg-red-light text-red-dark': grade > 0 && grade < 0.5,
+          'bg-red-dark text-white': grade === 0,
           'bg-grey-3 text-grey-7': gradeIsInvalid,
         },
       )}

--- a/lms/static/scripts/frontend_apps/components/dashboard/StudentStatusBadge.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/StudentStatusBadge.tsx
@@ -25,7 +25,7 @@ export default function StudentStatusBadge({
         'px-1 py-0.5 rounded cursor-auto font-bold uppercase text-[0.65rem]',
         {
           'bg-grey-7 text-white': type === 'new' || type === 'drop',
-          'bg-grade-error-light text-grade-error': type === 'error',
+          'bg-red-light text-red-dark': type === 'error',
           'bg-grey-2 text-grey-7': type === 'syncing',
         },
       )}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.27.0",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^9.2.1",
+    "@hypothesis/frontend-shared": "^9.3.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,16 +17,6 @@ export default /** @type {Partial<import('tailwindcss').Config>} */ ({
       animation: {
         gradeSubmitSuccess: 'gradeSubmitSuccess 2s ease-out forwards',
       },
-      colors: {
-        grade: {
-          success: '#005c3d',
-          'success-light': '#dfebe7',
-          error: '#891b1d',
-          'error-light': '#f0e2e3',
-          warning: '#774903',
-          'warning-light': '#fef7ec',
-        },
-      },
       fontFamily: {
         sans: [
           '"Helvetica Neue"',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,15 +2057,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "@hypothesis/frontend-shared@npm:9.2.1"
+"@hypothesis/frontend-shared@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@hypothesis/frontend-shared@npm:9.3.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: fe7c87658069722ae16053591daec238d4725e77656fd609e4f9a9c842f4f760882b922cdbbb7f7807d20a43b05787ebbc659c658179f0bf49a98b47c906e18b
+  checksum: 2ebc0a8f573fc9897648bafd1b57007d7a9ddd9b982c374e0807cd9599aa977b037375e09063c328f0444b88251c4c9d9e500dada37603e60648e76841913044
   languageName: node
   linkType: hard
 
@@ -7808,7 +7808,7 @@ __metadata:
     "@babel/preset-react": ^7.26.3
     "@babel/preset-typescript": ^7.27.0
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^9.2.1
+    "@hypothesis/frontend-shared": ^9.3.0
     "@hypothesis/frontend-testing": ^1.5.0
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
Replace locally-defined grade-specific shades of green, yellow and red with the ones from frontend 
-shared that were introduced in https://github.com/hypothesis/frontend-shared/pull/1944

There should be no visual differences:

![Captura desde 2025-04-15 10-23-17](https://github.com/user-attachments/assets/e9258185-1a09-41dc-b699-e7b5ba344cf5)
![Captura desde 2025-04-15 10-23-33](https://github.com/user-attachments/assets/e9c3e93f-7083-4732-802d-a7b9b8f824cf)
![Captura desde 2025-04-15 10-28-01](https://github.com/user-attachments/assets/e22caf30-e513-4bf6-906b-c8eef44ee5db)
![Captura desde 2025-04-15 10-27-32](https://github.com/user-attachments/assets/50345050-fe0d-4a2c-b44e-de72cb306fda)
![Captura desde 2025-04-15 10-27-21](https://github.com/user-attachments/assets/969c285d-32a0-4d5d-bee2-50855c599d35)

