### PR TITLE
Install git on the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM python:3.11.11-alpine3.19
 LABEL authors="Hypothes.is Project and contributors"
 
 # Install system build and runtime dependencies.
-RUN apk add libpq supervisor
+RUN apk add libpq supervisor git
 
 # Create the lms user, group, home directory and package directory.
 RUN addgroup -S lms \


### PR DESCRIPTION
Git is required by get_version to come up with the version number based on the current commit.