### PR TITLE
Store different LTI name fields separately in the DB

### DIFF
--- a/lms/migrations/versions/833f6b0237d8_new_lmsuser_name_columns.py
+++ b/lms/migrations/versions/833f6b0237d8_new_lmsuser_name_columns.py
@@ -1,0 +1,19 @@
+"""New LMSUser name columns."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "833f6b0237d8"
+down_revision = "0d265909ff85"
+
+
+def upgrade() -> None:
+    op.add_column("lms_user", sa.Column("given_name", sa.String(), nullable=True))
+    op.add_column("lms_user", sa.Column("family_name", sa.String(), nullable=True))
+    op.add_column("lms_user", sa.Column("name", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lms_user", "name")
+    op.drop_column("lms_user", "family_name")
+    op.drop_column("lms_user", "given_name")

--- a/lms/models/lms_user.py
+++ b/lms/models/lms_user.py
@@ -51,6 +51,12 @@ class LMSUser(CreatedUpdatedMixin, Base):
     email: Mapped[str | None] = mapped_column()
 
     display_name: Mapped[str | None] = mapped_column(index=True)
+    """Display name that we have obtained by combining LTI fields."""
+
+    given_name: Mapped[str | None] = mapped_column()
+    family_name: Mapped[str | None] = mapped_column()
+    name: Mapped[str | None] = mapped_column()
+    """These are verbatim values from the LTI launch."""
 
     application_instances: Mapped[list[ApplicationInstance]] = relationship(
         secondary="lms_user_application_instance",

--- a/lms/services/lti_names_roles.py
+++ b/lms/services/lti_names_roles.py
@@ -18,6 +18,7 @@ class Member(TypedDict):
     """Structure of the members returned by the name and roles LTI API."""
 
     email: str
+    given_name: str
     family_name: str
     name: str
     picture: str

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -21,7 +21,7 @@ from lms.models import (
     RoleType,
 )
 from lms.models.h_user import get_h_userid, get_h_username
-from lms.models.lti_user import display_name
+from lms.models.lti_user import display_name as get_display_name
 from lms.services.canvas_api.client import CanvasAPIClient
 from lms.services.canvas_api.factory import canvas_api_client_factory
 from lms.services.d2l_api.client import D2LAPIClient
@@ -509,10 +509,15 @@ class RosterService:
             lms_api_user_id = self._get_lms_api_user_id(
                 member, application_instance.family
             )
-            name = display_name(
-                given_name=member.get("name", ""),
-                family_name=member.get("family_name", ""),
-                full_name="",
+
+            given_name = member.get("given_name", None)
+            family_name = member.get("family_name", None)
+            name = member.get("name", None)
+
+            display_name = get_display_name(
+                given_name=given_name or "",
+                family_name=family_name or "",
+                full_name=name or "",
                 custom_display_name="",
             )
 
@@ -541,7 +546,10 @@ class RosterService:
                     "lti_user_id": lti_user_id,
                     "lti_v13_user_id": lti_v13_user_id,
                     "h_userid": h_userid,
-                    "display_name": name,
+                    "display_name": display_name,
+                    "given_name": given_name,
+                    "family_name": family_name,
+                    "name": name,
                     "lms_api_user_id": lms_api_user_id,
                     "email": email,
                 }

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -104,12 +104,18 @@ class UserService:
                     "email": user.email,
                     "display_name": user.display_name,
                     "lms_api_user_id": lms_api_user_id,
+                    "given_name": lti_params.get("lis_person_name_given"),
+                    "family_name": lti_params.get("lis_person_name_family"),
+                    "name": lti_params.get("lis_person_name_full"),
                 }
             ],
             index_elements=["h_userid"],
             update_columns=[
                 "updated",
                 "display_name",
+                "given_name",
+                "family_name",
+                "name",
                 "email",
                 (
                     "lti_v13_user_id",

--- a/tests/unit/lms/services/user_test.py
+++ b/tests/unit/lms/services/user_test.py
@@ -89,6 +89,13 @@ class TestUserService:
         assert lms_user.updated == user.updated
         assert lms_user.lti_v13_user_id == pyramid_request.lti_params.v13.get("sub")
         assert lms_user.lms_api_user_id == "lms_api_user_id"
+        assert lms_user.given_name == pyramid_request.lti_params.get(
+            "lis_person_name_given"
+        )
+        assert lms_user.family_name == pyramid_request.lti_params.get(
+            "lis_person_name_family"
+        )
+        assert lms_user.name == pyramid_request.lti_params.get("lis_person_name_full")
 
     def test_upsert_lms_user_doesnt_clear_lti_v13_user_id(
         self, service, lti_user, pyramid_request, db_session


### PR DESCRIPTION
We already combine these in "display_name" but
storing them separately make it easier to for example sort names by last name.


## Testing 

- Truncate your users table, in `make sql`

`truncate lms_user cascade`


- Launch a LTI1.1 assignment: https://hypothesis.instructure.com/courses/125/assignments/873

- Query the user:

```
postgres=# select display_name, given_name, family_name, name from lms_user;
     display_name     |   given_name   | family_name |          name          
----------------------+----------------+-------------+------------------------
 DISPLAY NAME TEACHER | Hypothesis 101 | Teacher     | Hypothesis 101 Teacher
(1 row)
```


- Truncate the table again


- Launch a 1.3 assignment https://hypothesis.instructure.com/courses/319/assignments/3308

- Query the user, is should have the same information:

```
postgres=# select display_name, given_name, family_name, name from lms_user;
     display_name     |   given_name   | family_name |          name          
----------------------+----------------+-------------+------------------------
 DISPLAY NAME TEACHER | Hypothesis 101 | Teacher     | Hypothesis 101 Teacher
(1 row)
```


- Truncate the table again
- In make shell schedule getting assignment rosters:

```
from lms.tasks.roster import schedule_fetching_assignment_rosters
schedule_fetching_assignment_rosters.delay()
```

- Check the table again:

```
 select display_name, given_name, family_name, name from lms_user;
      display_name      |      given_name       | family_name |          name          
------------------------+-----------------------+-------------+------------------------
 Hypothesis 101 Student | Hypothesis 101        | Student     | Hypothesis 101 Student
 Hypothesis 101 Teacher | Hypothesis 101        | Teacher     | Hypothesis 101 Teacher
 eng+coursecopystudent  | eng+coursecopystudent |             | eng+coursecopystudent
 AC Student 1           | AC Student            | 1           | AC Student 1
 AC Student 2           | AC Student            | 2           | AC Student 2
 AC Student 3           | AC Student            | 3           | AC Student 3
(6 rows)
```
