### PR TITLE
Store middle name when present in LTI params

### DIFF
--- a/lms/models/lms_user.py
+++ b/lms/models/lms_user.py
@@ -54,6 +54,7 @@ class LMSUser(CreatedUpdatedMixin, Base):
     """Display name that we have obtained by combining LTI fields."""
 
     given_name: Mapped[str | None] = mapped_column()
+    middle_name: Mapped[str | None] = mapped_column()
     family_name: Mapped[str | None] = mapped_column()
     name: Mapped[str | None] = mapped_column()
     """These are verbatim values from the LTI launch."""

--- a/lms/models/lti_params.py
+++ b/lms/models/lti_params.py
@@ -126,6 +126,8 @@ _V11_TO_V13 = (
     ("lis_person_name_given", ["given_name"]),
     ("lis_person_name_family", ["family_name"]),
     ("lis_person_name_full", ["name"]),
+    # Middle name is LTI1.3 only
+    ("middle_name", ["middle_name"]),
     ("lis_person_contact_email_primary", ["email"]),
     ("roles", [f"{CLAIM_PREFIX}/roles"]),
     ("context_id", [f"{CLAIM_PREFIX}/context", "id"]),

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -512,6 +512,7 @@ class RosterService:
 
             given_name = member.get("given_name", None)
             family_name = member.get("family_name", None)
+            middle_name = member.get("middle_name", None)
             name = member.get("name", None)
 
             display_name = get_display_name(
@@ -549,6 +550,7 @@ class RosterService:
                     "display_name": display_name,
                     "given_name": given_name,
                     "family_name": family_name,
+                    "middle_name": middle_name,
                     "name": name,
                     "lms_api_user_id": lms_api_user_id,
                     "email": email,

--- a/lms/services/roster.py
+++ b/lms/services/roster.py
@@ -510,10 +510,10 @@ class RosterService:
                 member, application_instance.family
             )
 
-            given_name = member.get("given_name", None)
-            family_name = member.get("family_name", None)
-            middle_name = member.get("middle_name", None)
-            name = member.get("name", None)
+            given_name = member.get("given_name", None) or None
+            family_name = member.get("family_name", None) or None
+            middle_name = member.get("middle_name", None) or None
+            name = member.get("name", None) or None
 
             display_name = get_display_name(
                 given_name=given_name or "",

--- a/lms/services/user.py
+++ b/lms/services/user.py
@@ -105,6 +105,7 @@ class UserService:
                     "display_name": user.display_name,
                     "lms_api_user_id": lms_api_user_id,
                     "given_name": lti_params.get("lis_person_name_given"),
+                    "middle_name": lti_params.get("middle_name"),
                     "family_name": lti_params.get("lis_person_name_family"),
                     "name": lti_params.get("lis_person_name_full"),
                 }
@@ -114,6 +115,7 @@ class UserService:
                 "updated",
                 "display_name",
                 "given_name",
+                "middle_name",
                 "family_name",
                 "name",
                 "email",


### PR DESCRIPTION
For: 

- https://github.com/hypothesis/product-backlog/issues/1655


Not all LMSes send the middle name in the LTI params, but when they do, we should store it in the database.


Migration over https://github.com/hypothesis/lms/pull/7104


## Testing 

- Login into BB as `blackboardteacher`
- Launch https://aunltd-test.blackboard.com/webapps/blackboard/content/contentWrapper.jsp?content_id=_2483_1&displayName=LTI+1.3%2C+blackboard+file&course_id=_19_1&navItem=content&href=%2Fwebapps%2Fblackboard%2Fexecute%2Fblti%2FlaunchPlacement%3Fblti_placement_id%3D_148_1%26content_id%3D_2483_1%26course_id%3D_19_1
- Check the DB for middle_name in lms_user


```select * from lms_user where middle_name is not null;```