### PR TITLE
Send three decimal places for auto grading scores

### DIFF
--- a/lms/services/auto_grading.py
+++ b/lms/services/auto_grading.py
@@ -143,7 +143,16 @@ class AutoGradingService:
                 raise ValueError("Unknown auto grading configuration")  # noqa: EM101, TRY003
 
         grade = min(1, grade)  # Proportional grades are capped at 1
-        return round(grade, 2)
+        # We round here to avoid "ugly" grades like 0.3333333 but we keep 3 decimal places to have enough precision
+        # for the LMS own rounding.
+        #
+        # For example 0.33 (out of 1) is rounding as
+        # 3 decimal places as this seems
+        # to be the point where the LMS rounding kicks in
+        # For example 0.33 (of 1) becomes 0.99 in Canvas
+        # but
+        # 0.333 (of 1) becomes 1 in Canvas
+        return round(grade, 3)
 
 
 def factory(_context, request):

--- a/tests/unit/lms/services/auto_grading_test.py
+++ b/tests/unit/lms/services/auto_grading_test.py
@@ -113,7 +113,7 @@ class TestAutoGradingService:
         assert last_grades.get(student_2.h_userid).grade == 4
 
     @pytest.mark.parametrize(
-        "grading_type,activity_calculation,required_annotations, required_replies,annotations,replies,expected_grade",
+        "grading_type,activity_calculation,required_annotations,required_replies,annotations,replies,expected_grade",
         [
             ("all_or_nothing", "cumulative", 15, None, 5, 5, 0),
             ("all_or_nothing", "cumulative", 15, None, 10, 6, 1),
@@ -121,9 +121,11 @@ class TestAutoGradingService:
             ("all_or_nothing", "separate", 10, 5, 10, 5, 1),
             ("all_or_nothing", "separate", 10, 0, 9, 4, 0),
             ("all_or_nothing", "separate", 10, None, 9, 4, 0),
-            ("scaled", "cumulative", 15, None, 5, 5, 0.67),
+            ("scaled", "cumulative", 3, None, 1, 0, 0.333),
+            ("scaled", "cumulative", 3, None, 2, 0, 0.667),
+            ("scaled", "cumulative", 15, None, 5, 5, 0.667),
             ("scaled", "cumulative", 15, None, 10, 10, 1),
-            ("scaled", "separate", 10, 5, 8, 2, 0.67),
+            ("scaled", "separate", 10, 5, 8, 2, 0.667),
             ("scaled", "separate", 10, 5, 5, 1, 0.4),
             # In scaled+separate cases, extra annos/replies should be ignored
             ("scaled", "separate", 3, 2, 0, 3, 0.4),


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/190


---


2 vs 3 decimal places seems to be limit to trigger rounding on the LMS side so for example for an assignment with maxScore 3, when sending the grade scaled between 0 and 1

0.33 becomes 0.99
but 0.333 becomes 1.00


### Testing 

#### Canvas 1.3

- Launch https://hypothesis.instructure.com/courses/319/assignments/3308

- In make shell, try sending different grades with:

```
from datetime import datetime

from lms.services.lti_grading.factory import service_factory

ai = db.query(models.ApplicationInstance).order_by(models.ApplicationInstance.updated.desc()).first()
svc = service_factory(None, request, ai)
student = db.query(models.LMSUser).filter_by(display_name="Hypothesis 101 Student").one()
assignment = db.query(models.Assignment).order_by(models.Assignment.updated.desc()).first()
```


then 

```
svc.sync_grade(ai, assignment, datetime.now().isoformat(), student, 0.33)
```

produces `0.99` in the gradebook https://hypothesis.instructure.com/courses/319/gradebook

while 


```
svc.sync_grade(ai, assignment, datetime.now().isoformat(), student, 0.334)
```

produces `1`



#### Canvas 1.1

- Launch https://hypothesis.instructure.com/courses/125/assignments/873

- In LTI1.1 you'll need to launch at somepoitn as the target student: `eng+canvasstudent@hypothes.is`

- Repeat the script in make shell (to fetch the application instance and assignment)


then 

```
svc.sync_grade(ai, assignment, datetime.now().isoformat(), student, 0.33)
```

produces `0.99` in the gradebook 

https://hypothesis.instructure.com/courses/125/gradebook

while 


```
svc.sync_grade(ai, assignment, datetime.now().isoformat(), student, 0.334)
```

produces `1`



### Moodle

### Moodle LTI1.1

- The script now is slightly different, to fetch a different student.

```
from datetime import datetime

from lms.services.lti_grading.factory import service_factory

ai = db.query(models.ApplicationInstance).order_by(models.ApplicationInstance.updated.desc()).first()
svc = service_factory(None, request, ai)
student = db.query(models.LMSUser).filter_by(display_name="ClassClown").order_by(models.LMSUser.updated.desc()).first()

assignment = db.query(models.Assignment).order_by(models.Assignment.updated.desc()).first()
```


- Again, in LTI1.1 you'll need to launch as the student once `moodystudent'

- Launch this assignment https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=1266

- Run the script for .33 vs .334 and check the differences in https://hypothesisuniversity.moodlecloud.com/grade/report/grader/index.php?id=11

#### Moodle LTI1.3

- Same script and process as for LTI1.1
- Use this assignment instead https://hypothesisuniversity.moodlecloud.com/mod/lti/view.php?id=861&forceview=1