### PR TITLE
Round grades to 2 decimal places in the dashboard

### DIFF
--- a/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
+++ b/lms/static/scripts/frontend_apps/components/dashboard/GradeStatusChip.tsx
@@ -9,6 +9,19 @@ export type GradeStatusChipProps = {
 };
 
 /**
+ * Format a grade from 0 to 1 to a string. If the grade is an integer, it
+ * will be returned as an integer string. Otherwise, it will be returned
+ * with two decimal places.
+ */
+function formatGrade(grade: number): string {
+  const scaledGrade = grade * 100;
+
+  return Number.isInteger(scaledGrade)
+    ? scaledGrade.toString()
+    : scaledGrade.toFixed(2);
+}
+
+/**
  * A badge where the corresponding color combination is calculated from a grade
  * from 0 to 1, following the next table:
  *
@@ -36,7 +49,7 @@ export default function GradeStatusChip({ grade }: GradeStatusChipProps) {
         },
       )}
     >
-      {grade * 100}
+      {formatGrade(grade)}
       {!gradeIsInvalid && '%'}
     </div>
   );

--- a/lms/static/scripts/frontend_apps/components/dashboard/test/GradeStatusChip-test.js
+++ b/lms/static/scripts/frontend_apps/components/dashboard/test/GradeStatusChip-test.js
@@ -8,10 +8,18 @@ describe('GradeStatusChip', () => {
     return mount(<GradeStatusChip grade={grade} />);
   }
 
-  [0, 0.2, 0.48, 0.77, 0.92, 1].forEach(grade => {
+  [
+    [0, '0'],
+    [0.2, '20'],
+    [0.33330004, '33.33'],
+    [0.48, '48'],
+    [0.77, '77'],
+    [0.92, '92'],
+    [1, '100'],
+  ].forEach(([grade, expected]) => {
     it('renders valid grades as percentage', () => {
       const wrapper = renderComponent(grade);
-      assert.equal(wrapper.text(), `${grade * 100}%`);
+      assert.equal(wrapper.text(), `${expected}%`);
     });
   });
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/support/issues/190


After the BE started returning grades with more precession we now need to round them explicitly to avoid displaying too many decimal places in the dashboard.



See: https://hypothes-is.slack.com/archives/C2C2U40LW/p1745873532220369