### PR TITLE
Enable image annotations by default

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -173,7 +173,7 @@ class ApplicationSettings(JSONSettings):
         Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION: JSONSetting(
             Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION,
             SettingFormat.TRI_STATE,
-            default=False,
+            default=True,
         ),
     }
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -306,9 +306,10 @@ class TestBasicLaunchViews:
             pyramid_request, context.js_config, assignment
         )
         if mentions_feature and collect_student_emails:
-            context.js_config.enable_client_feature.assert_called_once_with(
-                "at_mentions"
-            )
+            assert context.js_config.enable_client_feature.call_args_list == [
+                mock.call("at_mentions"),
+                mock.call("pdf_image_annotation"),
+            ]
 
         assert result == {}
 


### PR DESCRIPTION
Enable the PDF image annotation feature by default for all LMS users.
