### PR TITLE
Fix duplicate rlid parameter in LTI Names and Roles Service

### DIFF
--- a/lms/services/lti_names_roles.py
+++ b/lms/services/lti_names_roles.py
@@ -7,6 +7,7 @@ https://www.imsglobal.org/ltiadvantage
 
 import logging
 from typing import Any, TypedDict
+from urllib.parse import parse_qs, urlparse
 
 from lms.models import LTIRegistration
 from lms.services.ltia_http import LTIAHTTPService
@@ -76,6 +77,12 @@ class LTINamesRolesService:
         return members
 
     def _make_request(self, lti_registration, service_url, query):
+        existing_query_params = parse_qs(urlparse(service_url).query)
+        if "rlid" in existing_query_params and "rlid" in query:
+            # Some LMSes include the resource_link_id in the service_url
+            # Avoid adding it again to the query params
+            del query["rlid"]
+
         return self._ltia_service.request(
             lti_registration,
             "GET",


### PR DESCRIPTION
Some LMSes (blackboard) include the rlid in the pagination link provided.

We have to only add the rlid query parameter if it's not already in the URL otherwise we end up duplicating it.

Noticed this while looking at:

https://hypothesis.sentry.io/issues/6261383283/?environment=prod&project=259908&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=3

Note the error message there:

```
:"Unable to parse provided PkId string [_3034743_1,_3034743_1].
```

and the duplicate ID on that list, which shouldn't be a list at all, just one value.