### PR TITLE
Prompt for max points while creating assignment

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Mapping
 from enum import StrEnum
+from typing import Literal
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
@@ -68,6 +69,7 @@ class ApplicationSettings(JSONSettings):
         HYPOTHESIS_COLLECT_STUDENT_EMAILS = "hypothesis.collect_student_emails"
         HYPOTHESIS_MENTIONS = "hypothesis.mentions"
         HYPOTHESIS_PDF_IMAGE_ANNOTATION = "hypothesis.pdf_image_annotation"
+        HYPOTHESIS_PROMPT_FOR_GRADABLE = "hypothesis.prompt_for_gradable"
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
@@ -161,6 +163,11 @@ class ApplicationSettings(JSONSettings):
         ),
         Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING: JSONSetting(
             Settings.HYPOTHESIS_LTI_13_SOURCEDID_FOR_GRADING, SettingFormat.BOOLEAN
+        ),
+        Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE: JSONSetting(
+            Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE,
+            SettingFormat.TRI_STATE,
+            default=False,
         ),
         Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS: JSONSetting(
             Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS,
@@ -347,7 +354,7 @@ class ApplicationInstance(CreatedUpdatedMixin, Base):
             )
 
     @property
-    def lti_version(self) -> str:
+    def lti_version(self) -> Literal["LTI-1p0", "1.3.0"]:
         """
         LTI version of this instance based on the presence of a registration.
 

--- a/lms/product/d2l/_plugin/course_copy.py
+++ b/lms/product/d2l/_plugin/course_copy.py
@@ -1,4 +1,4 @@
-from lms.product.plugin.course_copy import (  # noqa: INP001
+from lms.product.plugin.course_copy import (
     CourseCopyFilesHelper,
     CourseCopyGroupsHelper,
 )

--- a/lms/product/d2l/_plugin/grouping.py
+++ b/lms/product/d2l/_plugin/grouping.py
@@ -1,4 +1,4 @@
-from enum import StrEnum  # noqa: INP001
+from enum import StrEnum
 
 from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin

--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -1,7 +1,25 @@
-from lms.product.plugin.misc import MiscPlugin  # noqa: INP001
+from lms.models import ApplicationInstance
+from lms.product.plugin.misc import MiscPlugin
 
 
 class D2LMiscPlugin(MiscPlugin):
+    def deep_linking_prompt_for_gradable(
+        self, application_instance: ApplicationInstance
+    ) -> bool:
+        """
+        Whether or not to ask if the new assignment should be gradable.
+
+        We'll only prompt for gradable assignments in D2L if the
+        `HYPOTHESIS_PROMPT_FOR_GRADABLE` setting is enabled and we are in LTI1.3
+        """
+        if application_instance.lti_version == "LTI-1p0":
+            return False
+
+        ai_settings = application_instance.settings
+        return ai_settings.get_setting(
+            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE]
+        )
+
     def get_ltia_aud_claim(self, lti_registration):  # noqa: ARG002
         # In D2L this value is always the same and different from
         # `lti_registration.token_url` as in other LMS

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -40,8 +40,9 @@ class MiscPlugin:
     # Whether or not to prompt for an assignment title while deep linking.
     deep_linking_prompt_for_title = True
 
-    # Whether or not to ask if the new assignment should be gradable
-    deep_linking_prompt_for_gradable = False
+    def deep_linking_prompt_for_gradable(self, _application_instance) -> bool:
+        """Whether or not to ask if the new assignment should be gradable."""
+        return False
 
     def post_launch_assignment_hook(
         self, request, js_config, assignment

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -40,6 +40,9 @@ class MiscPlugin:
     # Whether or not to prompt for an assignment title while deep linking.
     deep_linking_prompt_for_title = True
 
+    # Whether or not to ask if the new assignment should be gradable
+    deep_linking_prompt_for_gradable = False
+
     def post_launch_assignment_hook(
         self, request, js_config, assignment
     ):  # pragma: nocover

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -339,13 +339,15 @@ class JSConfig:
             },
         }
 
-    def enable_file_picker_mode(
+    def enable_file_picker_mode(  # noqa: PLR0913
         self,
         form_action,
         form_fields,
         course: Course,
         assignment: Assignment | None = None,
-        prompt_for_title=False,  # noqa: FBT002
+        *,
+        prompt_for_title=False,
+        prompt_for_gradable=False,
     ):
         """
         Put the JavaScript code into "file picker" mode.
@@ -373,6 +375,7 @@ class JSConfig:
                     "formAction": form_action,
                     "formFields": form_fields,
                     "promptForTitle": prompt_for_title,
+                    "promptForGradable": prompt_for_gradable,
                     # Enable auto grading everywhere except in Sakai
                     "autoGradingEnabled": self._application_instance.tool_consumer_info_product_family_code
                     != "sakai",

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -362,6 +362,7 @@ class JSConfig:
         :param course: Currently active course
         :param assignment: Currently active assignment
         :param prompt_for_title: Whether or not to prompt for a title while configuring the assignment
+        :param prompt_for_gradable: Whether or not to prompt for a max score while configuring the assignment
         """
 
         args = self._request, self._application_instance

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -10,6 +10,8 @@ import {
   Input,
   Scroll,
   SpinnerOverlay,
+  Checkbox,
+  CheckboxCheckedFilledIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
@@ -189,6 +191,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       formAction,
       formFields,
       promptForTitle,
+      promptForGradable,
     },
   } = useConfig(['api', 'filePicker']);
 
@@ -230,7 +233,10 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // Whether there are additional configuration options to present after the
   // user has selected the content for the assignment.
   const showDetailsScreen =
-    enableGroupConfig || promptForTitle || autoGradingEnabled;
+    enableGroupConfig ||
+    promptForTitle ||
+    promptForGradable ||
+    autoGradingEnabled;
 
   let currentStep: PickerStep;
   if (editingContent) {
@@ -250,6 +256,12 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   const [title, setTitle] = useState(
     promptForTitle ? 'Hypothesis assignment' : null,
   );
+
+  const [isAssignmentGradable, setIsAssignmentGradable] = useState(false);
+  const [assignmentGradableMaxPoints, setIsAssignmentGradableMaxPoints] =
+    useState(100);
+  const gradableMaxInputId = useUniqueId('gradable-max-input');
+
   const titleInputId = useUniqueId('title-input');
 
   const [errorInfo, setErrorInfo] = useState<ErrorInfo | null>(null);
@@ -290,6 +302,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
+          assignment_gradable_max_points: isAssignmentGradable
+            ? assignmentGradableMaxPoints
+            : null,
         };
         setDeepLinkingFields(
           await apiCall({
@@ -316,6 +331,8 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       groupConfig.useGroupSet,
       title,
       autoGradingConfigToSave,
+      isAssignmentGradable,
+      assignmentGradableMaxPoints,
     ],
   );
 
@@ -462,6 +479,58 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         />
                       </>
                     )}
+                    {promptForGradable && (
+                      <>
+                        <div className="sm:col-span-2 border-b" />
+                        <PanelLabel isCurrentStep>
+                          Gradable assignment
+                        </PanelLabel>
+                        <div className="flex flex-col gap-y-3">
+                          <Checkbox
+                            checked={isAssignmentGradable}
+                            checkedIcon={CheckboxCheckedFilledIcon}
+                            onChange={e =>
+                              setIsAssignmentGradable(
+                                (e.target as HTMLInputElement).checked,
+                              )
+                            }
+                          >
+                            Make this assignment gradable
+                          </Checkbox>
+                          {isAssignmentGradable && (
+                            <>
+                              <div className="flex gap-2 items-center">
+                                <label
+                                  className="grow flex justify-between items-center"
+                                  htmlFor={gradableMaxInputId}
+                                >
+                                  <span className="uppercase font-semibold">
+                                    Points
+                                  </span>
+                                </label>
+
+                                <Input
+                                  id={gradableMaxInputId}
+                                  classes="max-w-14"
+                                  type="number"
+                                  required
+                                  min={0}
+                                  value={assignmentGradableMaxPoints}
+                                  onChange={e =>
+                                    setIsAssignmentGradableMaxPoints(
+                                      Number(
+                                        (e.target as HTMLInputElement).value,
+                                      ),
+                                    )
+                                  }
+                                />
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      </>
+                    )}
+
                     {autoGradingEnabled && (
                       <>
                         <div className="sm:col-span-2 border-b" />

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -10,8 +10,6 @@ import {
   Input,
   Scroll,
   SpinnerOverlay,
-  Checkbox,
-  CheckboxCheckedFilledIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
@@ -257,9 +255,8 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     promptForTitle ? 'Hypothesis assignment' : null,
   );
 
-  const [isAssignmentGradable, setIsAssignmentGradable] = useState(false);
-  const [assignmentGradableMaxPoints, setIsAssignmentGradableMaxPoints] =
-    useState(100);
+  const [assignmentGradableMaxPoints, setAssignmentGradableMaxPoints] =
+    useState('');
   const gradableMaxInputId = useUniqueId('gradable-max-input');
 
   const titleInputId = useUniqueId('title-input');
@@ -302,9 +299,10 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
-          assignment_gradable_max_points: isAssignmentGradable
-            ? assignmentGradableMaxPoints
-            : null,
+          assignment_gradable_max_points:
+            assignmentGradableMaxPoints === ''
+              ? null
+              : Number(assignmentGradableMaxPoints),
         };
         setDeepLinkingFields(
           await apiCall({
@@ -331,7 +329,6 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       groupConfig.useGroupSet,
       title,
       autoGradingConfigToSave,
-      isAssignmentGradable,
       assignmentGradableMaxPoints,
     ],
   );
@@ -482,52 +479,22 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                     {promptForGradable && (
                       <>
                         <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep>
-                          Gradable assignment
+                        <PanelLabel isCurrentStep verticalAlign="center">
+                          Max points
                         </PanelLabel>
-                        <div className="flex flex-col gap-y-3">
-                          <Checkbox
-                            checked={isAssignmentGradable}
-                            checkedIcon={CheckboxCheckedFilledIcon}
-                            onChange={e =>
-                              setIsAssignmentGradable(
-                                (e.target as HTMLInputElement).checked,
-                              )
-                            }
-                          >
-                            Make this assignment gradable
-                          </Checkbox>
-                          {isAssignmentGradable && (
-                            <>
-                              <div className="flex gap-2 items-center">
-                                <label
-                                  className="grow flex justify-between items-center"
-                                  htmlFor={gradableMaxInputId}
-                                >
-                                  <span className="uppercase font-semibold">
-                                    Max points
-                                  </span>
-                                </label>
-
-                                <Input
-                                  id={gradableMaxInputId}
-                                  classes="max-w-14"
-                                  type="number"
-                                  required
-                                  min={0}
-                                  value={assignmentGradableMaxPoints}
-                                  onChange={e =>
-                                    setIsAssignmentGradableMaxPoints(
-                                      Number(
-                                        (e.target as HTMLInputElement).value,
-                                      ),
-                                    )
-                                  }
-                                />
-                              </div>
-                            </>
-                          )}
-                        </div>
+                        <Input
+                          data-testid="gradable-max-input"
+                          id={gradableMaxInputId}
+                          type="number"
+                          placeholder={'ex: 100'}
+                          min={0}
+                          value={assignmentGradableMaxPoints}
+                          onChange={e =>
+                            setAssignmentGradableMaxPoints(
+                              (e.target as HTMLInputElement).value,
+                            )
+                          }
+                        />
                       </>
                     )}
 

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -505,7 +505,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                                   htmlFor={gradableMaxInputId}
                                 >
                                   <span className="uppercase font-semibold">
-                                    Points
+                                    Max points
                                   </span>
                                 </label>
 

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -85,6 +85,7 @@ export type FilePickerConfig = {
   formAction: string;
   formFields: Record<string, string>;
   promptForTitle: boolean;
+  promptForGradable: boolean;
   autoGradingEnabled: boolean;
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -132,6 +132,12 @@
                             {{ tri_state_settings_checkbox("PDF image annotation", fields[Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION]) }}
                         </fieldset>
                         <fieldset class="box">
+                            <legend class="label has-text-centered">Grading settings</legend>
+                            {{ settings_checkbox("Use alternative parameter for LTI1.3 grading", "hypothesis", "lti_13_sourcedid_for_grading", default=False) }}
+                            {{ tri_state_settings_checkbox("Prompt for gradable on creation", fields[Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE]) }}
+                        </fieldset>
+ 
+                        <fieldset class="box">
                             <legend class="label has-text-centered">Canvas settings</legend>
                             {{ macros.disabled_text_field("API domain", instance.custom_canvas_api_domain) }}
                             {# Note the mismatch between canvas nomenclature and ours #}

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -84,7 +84,9 @@ def deep_linking_launch(context, request):
         },
         course=course,
         prompt_for_title=request.product.plugin.misc.deep_linking_prompt_for_title,
-        prompt_for_gradable=request.product.plugin.misc.deep_linking_prompt_for_gradable,
+        prompt_for_gradable=request.product.plugin.misc.deep_linking_prompt_for_gradable(
+            request.lti_user.application_instance
+        ),
     )
 
     context.js_config.add_deep_linking_api()

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -99,8 +99,7 @@ class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     group_set = fields.Str(required=False, allow_none=True)
 
     title = fields.Str(required=False, allow_none=True)
-    assignment_gradable_max_points = fields.Int(required=False, allow_none=True)
-
+    assignment_gradable_max_points = fields.Float(required=False, allow_none=True)
     auto_grading_config = fields.Nested(
         AutoGradingConfigSchema, required=False, allow_none=True
     )

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -84,6 +84,7 @@ def deep_linking_launch(context, request):
         },
         course=course,
         prompt_for_title=request.product.plugin.misc.deep_linking_prompt_for_title,
+        prompt_for_gradable=request.product.plugin.misc.deep_linking_prompt_for_gradable,
     )
 
     context.js_config.add_deep_linking_api()
@@ -94,7 +95,9 @@ class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     content_item_return_url = fields.Str(required=True)
     content = fields.Dict(required=True)
     group_set = fields.Str(required=False, allow_none=True)
+
     title = fields.Str(required=False, allow_none=True)
+    assignment_gradable_max_points = fields.Int(required=False, allow_none=True)
 
     auto_grading_config = fields.Nested(
         AutoGradingConfigSchema, required=False, allow_none=True
@@ -144,6 +147,9 @@ class DeepLinkingFieldsViews:
         }
         if title := assignment_configuration.get("title"):
             content_item["title"] = title
+
+        if gradable_max_points := assignment_configuration.get("gradable_max_points"):
+            content_item["lineItem"] = {"scoreMaximum": gradable_max_points}
 
         now = datetime.utcnow()  # noqa: DTZ003
         message = {
@@ -263,6 +269,11 @@ class DeepLinkingFieldsViews:
 
         if title := request.parsed_params.get("title"):
             params["title"] = title
+
+        if gradable_max_points := request.parsed_params.get(
+            "assignment_gradable_max_points"
+        ):
+            params["gradable_max_points"] = gradable_max_points
 
         if auto_grading_config := request.parsed_params.get("auto_grading_config"):
             # Custom params must be str, encode these settings as JSON

--- a/tests/functional/views/lti/deep_linking_test.py
+++ b/tests/functional/views/lti/deep_linking_test.py
@@ -69,6 +69,7 @@ class TestDeepLinkingLaunch:
             },
             "moodle": {"enabled": False, "pagesEnabled": False},
             "promptForTitle": True,
+            "promptForGradable": False,
             "vitalSource": {"enabled": False},
             "youtube": {"enabled": Any()},
         }

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -172,6 +172,12 @@ class TestApplicationSettings:
             ),
             (
                 "hypothesis",
+                "prompt_for_gradable",
+                "hypothesis.prompt_for_gradable",
+                SettingFormat.TRI_STATE,
+            ),
+            (
+                "hypothesis",
                 "collect_student_emails",
                 "hypothesis.collect_student_emails",
                 SettingFormat.TRI_STATE,

--- a/tests/unit/lms/product/d2l/_plugin/misc_test.py
+++ b/tests/unit/lms/product/d2l/_plugin/misc_test.py
@@ -6,6 +6,24 @@ from lms.product.d2l._plugin.misc import D2LMiscPlugin
 
 
 class TestD2LMiscPlugin:
+    def test_prompt_for_gradable_returns_false_for_lti_1p0(self, application_instance):
+        plugin = D2LMiscPlugin()
+        assert plugin.deep_linking_prompt_for_gradable(application_instance) is False
+
+    @pytest.mark.parametrize("feature_flag", [True, False])
+    def test_prompt_for_gradable_returns_setting_for_lti_13(
+        self, lti_v13_application_instance, feature_flag
+    ):
+        lti_v13_application_instance.settings.set(
+            "hypothesis", "prompt_for_gradable", feature_flag
+        )
+        plugin = D2LMiscPlugin()
+
+        assert (
+            plugin.deep_linking_prompt_for_gradable(lti_v13_application_instance)
+            == feature_flag
+        )
+
     def test_deep_linking_prompt_for_title(self, plugin):
         assert plugin.deep_linking_prompt_for_title
 

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -12,6 +12,11 @@ class TestMiscPlugin:
     def test_deep_linking_prompt_for_title(self, plugin):
         assert plugin.deep_linking_prompt_for_title
 
+    def test_deep_linking_prompt_for_gradable(self, plugin):
+        assert not plugin.deep_linking_prompt_for_gradable(
+            sentinel.application_instance
+        )
+
     @pytest.mark.parametrize(
         "service_url,expected", [(None, False), (sentinel.service_url, True)]
     )

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -106,7 +106,7 @@ class TestDeepLinkingLaunch:
             },
             course=course_service.get_from_launch.return_value,
             prompt_for_title=misc_plugin.deep_linking_prompt_for_title,
-            prompt_for_gradable=misc_plugin.deep_linking_prompt_for_gradable,
+            prompt_for_gradable=misc_plugin.deep_linking_prompt_for_gradable.return_value,
         )
         context.js_config.add_deep_linking_api.assert_called_once()
 


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1664

This PR adds the minimum UI  to able to further test this in production. 


#### Testing

- Log in a teacher in https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home
- Make sure you can access https://localhost:48001/ in your browser, that you trust the certificate.

- Click "Existing activities" and "Hypothesis link (localhost)"

- You won't see any new controls

- Enable the new FF in http://localhost:8001/admin/instances/106/ 


- Create an assignment again, mark  the assignment as gradable and add max points.

- Launch the new assignment, the grading bar should show up and use the right amount of pointes (eg: `Grade (Out of 33)`)

- Test again, create a new assignment but left the field blank, the resulting assignment won't be gradable.