### PR TITLE
Extend the prompt for grade max feature to Moodle

### DIFF
--- a/lms/product/d2l/_plugin/misc.py
+++ b/lms/product/d2l/_plugin/misc.py
@@ -1,25 +1,7 @@
-from lms.models import ApplicationInstance
-from lms.product.plugin.misc import MiscPlugin
+from lms.product.plugin.misc import DeepLinkingPromptForGradableMixin, MiscPlugin
 
 
-class D2LMiscPlugin(MiscPlugin):
-    def deep_linking_prompt_for_gradable(
-        self, application_instance: ApplicationInstance
-    ) -> bool:
-        """
-        Whether or not to ask if the new assignment should be gradable.
-
-        We'll only prompt for gradable assignments in D2L if the
-        `HYPOTHESIS_PROMPT_FOR_GRADABLE` setting is enabled and we are in LTI1.3
-        """
-        if application_instance.lti_version == "LTI-1p0":
-            return False
-
-        ai_settings = application_instance.settings
-        return ai_settings.get_setting(
-            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE]
-        )
-
+class D2LMiscPlugin(DeepLinkingPromptForGradableMixin, MiscPlugin):
     def get_ltia_aud_claim(self, lti_registration):  # noqa: ARG002
         # In D2L this value is always the same and different from
         # `lti_registration.token_url` as in other LMS

--- a/lms/product/moodle/_plugin/course_copy.py
+++ b/lms/product/moodle/_plugin/course_copy.py
@@ -1,4 +1,4 @@
-from lms.product.plugin.course_copy import (  # noqa: INP001
+from lms.product.plugin.course_copy import (
     CourseCopyFilesHelper,
     CourseCopyGroupsHelper,
 )

--- a/lms/product/moodle/_plugin/grouping.py
+++ b/lms/product/moodle/_plugin/grouping.py
@@ -1,4 +1,4 @@
-from enum import StrEnum  # noqa: INP001
+from enum import StrEnum
 
 from lms.models import Course, Grouping
 from lms.product.plugin.grouping import GroupError, GroupingPlugin

--- a/lms/product/moodle/_plugin/misc.py
+++ b/lms/product/moodle/_plugin/misc.py
@@ -1,8 +1,12 @@
-from lms.models import Assignment  # noqa: INP001
-from lms.product.plugin.misc import AssignmentConfig, MiscPlugin
+from lms.models import Assignment
+from lms.product.plugin.misc import (
+    AssignmentConfig,
+    DeepLinkingPromptForGradableMixin,
+    MiscPlugin,
+)
 
 
-class MoodleMiscPlugin(MiscPlugin):
+class MoodleMiscPlugin(DeepLinkingPromptForGradableMixin, MiscPlugin):
     def get_assignment_configuration(
         self,
         request,

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict
 from pyramid.request import Request
 
 from lms.js_config_types import AutoGradingConfig
-from lms.models import Assignment, LTIParams
+from lms.models import ApplicationInstance, Assignment, LTIParams
 from lms.services.html_service import strip_html_tags
 
 if TYPE_CHECKING:
@@ -15,6 +15,25 @@ class AssignmentConfig(TypedDict):
     document_url: str | None
     group_set_id: str | None
     auto_grading_config: NotRequired[AutoGradingConfig | None]
+
+
+class DeepLinkingPromptForGradableMixin:
+    def deep_linking_prompt_for_gradable(
+        self, application_instance: ApplicationInstance
+    ) -> bool:
+        """
+        Whether or not to ask if the new assignment should be gradable.
+
+        We'll only prompt for gradable assignments if the
+        `HYPOTHESIS_PROMPT_FOR_GRADABLE` setting is enabled and we are in LTI1.3
+        """
+        if application_instance.lti_version == "LTI-1p0":
+            return False
+
+        ai_settings = application_instance.settings
+        return ai_settings.get_setting(
+            ai_settings.fields[ai_settings.Settings.HYPOTHESIS_PROMPT_FOR_GRADABLE]
+        )
 
 
 class MiscPlugin:

--- a/tests/unit/lms/product/moodle/_plugin/misc_test.py
+++ b/tests/unit/lms/product/moodle/_plugin/misc_test.py
@@ -7,6 +7,24 @@ from tests import factories
 
 
 class TestMoodlePlugin:
+    def test_prompt_for_gradable_returns_false_for_lti_1p0(
+        self, application_instance, plugin
+    ):
+        assert plugin.deep_linking_prompt_for_gradable(application_instance) is False
+
+    @pytest.mark.parametrize("feature_flag", [True, False])
+    def test_prompt_for_gradable_returns_setting_for_lti_13(
+        self, lti_v13_application_instance, feature_flag, plugin
+    ):
+        lti_v13_application_instance.settings.set(
+            "hypothesis", "prompt_for_gradable", feature_flag
+        )
+
+        assert (
+            plugin.deep_linking_prompt_for_gradable(lti_v13_application_instance)
+            == feature_flag
+        )
+
     def test_get_assignment_configuration_outdated_db_info(
         self, plugin, pyramid_request, get_deep_linked_assignment_configuration
     ):


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1669

This extends #7145 to Moodle


#### Testing

- Log in a teacher (I'm using `moodleteacher`) in  https://hypothesisuniversity.moodlecloud.com/course/view.php?id=11

- Make sure you can access https://localhost:48001/ in your browser, that you trust the certificate.

- Toggle edit mode on the top right corner.

- Scroll to the bottom, click the `+` symbol -> `Activity or resources` -> H - localhost LTI1.3

- Select content to launch Hypothesis, pick some content

- You won't see any new controls

- Enable the new FF in http://localhost:8001/admin/instances/109/ 

- Create an assignment again, mark  the assignment as gradable and add max points.

- The UI on Moodle, under "Grade" will have the right value.

- Launch the new assignment, the grading bar should show up and use the right amount of pointes (eg: `Grade (Out of 33)`)

- Test again, create a new assignment but left the field blank, the resulting assignment won't be gradable.