### PR TITLE
New info button to display more information about the max points feature

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Card,
   CardActions,
+  InfoIcon,
   CardContent,
   CardHeader,
   Link,
@@ -10,6 +11,8 @@ import {
   Input,
   Scroll,
   SpinnerOverlay,
+  IconButton,
+  Popover,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
@@ -275,6 +278,13 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   > | null>(null);
 
   const formRef = useRef<HTMLFormElement>(null);
+  const iconRef = useRef<HTMLButtonElement | null>(null);
+
+  /**
+   * Flag indicating whether the popover with information about the
+   * assignment gradable max points input is open.
+   */
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
   const submit = useCallback(
     async (content: Content) => {
@@ -481,6 +491,16 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         <div className="sm:col-span-2 border-b" />
                         <PanelLabel isCurrentStep verticalAlign="center">
                           Max points
+                          <IconButton
+                            icon={InfoIcon}
+                            title="About thumbnail descriptions"
+                            onClick={() => setPopoverOpen(!popoverOpen)}
+                            expanded={popoverOpen}
+                            elementRef={iconRef}
+                            // The icon uses `w-em` for sizing, so this sets the size. Chosen to
+                            // match icons in the AnnotationActionBar.
+                            classes="text-[16px]"
+                          />
                         </PanelLabel>
                         <Input
                           data-testid="gradable-max-input"
@@ -495,6 +515,32 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                             )
                           }
                         />
+                        <Popover
+                          open={popoverOpen}
+                          align="right"
+                          anchorElementRef={iconRef}
+                          onClose={() => setPopoverOpen(false)}
+                          classes={classnames(
+                            // Small gap to create separation between input and
+                            // popover.
+                            'mt-1',
+                            // Align popover towards right side of card.
+                            'w-80 max-w-[100vw]',
+                            'p-2 text-sm',
+                          )}
+                        >
+                          <div className="flex flex-col gap-y-2">
+                            Activating this feature will use the grading options
+                            you set in Hypothesis.
+                            <Link
+                              href="https://example.com"
+                              underline="always"
+                              target="_blank"
+                            >
+                              Learn more about grading options
+                            </Link>
+                          </div>
+                        </Popover>
                       </>
                     )}
 

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -279,12 +279,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
 
   const formRef = useRef<HTMLFormElement>(null);
   const iconRef = useRef<HTMLButtonElement | null>(null);
-
-  /**
-   * Flag indicating whether the popover with information about the
-   * assignment gradable max points input is open.
-   */
-  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [maxPointsPopoverOpen, setMaxPointsPopoverOpen] = useState(false);
 
   const submit = useCallback(
     async (content: Content) => {
@@ -490,17 +485,23 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                       <>
                         <div className="sm:col-span-2 border-b" />
                         <PanelLabel isCurrentStep verticalAlign="center">
-                          Max points
-                          <IconButton
-                            icon={InfoIcon}
-                            title="About thumbnail descriptions"
-                            onClick={() => setPopoverOpen(!popoverOpen)}
-                            expanded={popoverOpen}
-                            elementRef={iconRef}
-                            // The icon uses `w-em` for sizing, so this sets the size. Chosen to
-                            // match icons in the AnnotationActionBar.
-                            classes="text-[16px]"
-                          />
+                          <div className="flex items-center sm:justify-end">
+                            Max points
+                            <IconButton
+                              icon={InfoIcon}
+                              title="About max points"
+                              onClick={() =>
+                                setMaxPointsPopoverOpen(open => !open)
+                              }
+                              expanded={maxPointsPopoverOpen}
+                              elementRef={iconRef}
+                              // Align right side of the icon with the right
+                              // edge of the text labels above and below.
+                              // Do it by setting negative margin that
+                              // compensates for the button's padding.
+                              classes="text-[16px] -mr-2 touch:-mr-[12px]"
+                            />
+                          </div>
                         </PanelLabel>
                         <Input
                           data-testid="gradable-max-input"
@@ -516,24 +517,18 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                           }
                         />
                         <Popover
-                          open={popoverOpen}
-                          align="right"
+                          open={maxPointsPopoverOpen}
                           anchorElementRef={iconRef}
-                          onClose={() => setPopoverOpen(false)}
-                          classes={classnames(
-                            // Small gap to create separation between input and
-                            // popover.
-                            'mt-1',
-                            // Align popover towards right side of card.
-                            'w-80 max-w-[100vw]',
-                            'p-2 text-sm',
-                          )}
+                          onClose={() => setMaxPointsPopoverOpen(false)}
+                          classes="p-2"
+                          placement="above"
+                          arrow
                         >
                           <div className="flex flex-col gap-y-2">
-                            Activating this feature will use the grading options
-                            you set in Hypothesis.
+                            (Optional) Add a Max Points value here instead of
+                            using your LMS grading settings.
                             <Link
-                              href="https://example.com"
+                              href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
                               underline="always"
                               target="_blank"
                             >

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -604,6 +604,23 @@ describe('FilePickerApp', () => {
         },
       });
     });
+
+    it('opens popover when clicking info button', async () => {
+      const wrapper = renderFilePicker();
+
+      selectContent(wrapper, 'https://example.com');
+      clickContinueButton(wrapper);
+      await waitFor(() => fakeAPICall.called);
+
+      assert.isFalse(wrapper.find('Popover').prop('open'));
+      wrapper.find('IconButton').props().onClick();
+      wrapper.update();
+      assert.isTrue(wrapper.find('Popover').prop('open'));
+
+      wrapper.find('Popover').props().onClose();
+      wrapper.update();
+      assert.isFalse(wrapper.find('Popover').prop('open'));
+    });
   });
 
   context('when editing an existing assignment', () => {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@hypothesis/frontend-build": "^4.0.0",
-    "@hypothesis/frontend-shared": "^9.3.0",
+    "@hypothesis/frontend-shared": "^9.5.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,15 +1885,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.3.0":
-  version: 9.3.0
-  resolution: "@hypothesis/frontend-shared@npm:9.3.0"
+"@hypothesis/frontend-shared@npm:^9.5.1":
+  version: 9.5.1
+  resolution: "@hypothesis/frontend-shared@npm:9.5.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 2ebc0a8f573fc9897648bafd1b57007d7a9ddd9b982c374e0807cd9599aa977b037375e09063c328f0444b88251c4c9d9e500dada37603e60648e76841913044
+  checksum: 4f8396226dc48be3c010cd4769b06b1b76d1bfb4d085b2f6790e57b080902c8174c46ad085ee7cefffebc1b67dad6385c92eb5deeb744029f7c3e377878d0bed
   languageName: node
   linkType: hard
 
@@ -6357,7 +6357,7 @@ __metadata:
     "@babel/preset-react": ^7.27.1
     "@babel/preset-typescript": ^7.27.1
     "@hypothesis/frontend-build": ^4.0.0
-    "@hypothesis/frontend-shared": ^9.3.0
+    "@hypothesis/frontend-shared": ^9.5.1
     "@hypothesis/frontend-testing": ^1.7.1
     "@rollup/plugin-babel": ^6.0.4
     "@rollup/plugin-commonjs": ^28.0.3


### PR DESCRIPTION
For:

- https://github.com/hypothesis/product-backlog/issues/1664


This is how this look at the moment:


https://github.com/user-attachments/assets/24b218c2-c939-49c9-91ca-cf2b8f062029


#### Testing

(copied from https://github.com/hypothesis/lms/pull/7145)

- Log in a teacher in https://aunltd.brightspacedemo.com/d2l/le/content/6782/Home
- Make sure you can access https://localhost:48001/ in your browser, that you trust the certificate.
- Enable the new FF in http://localhost:8001/admin/instances/106/ (Prompt for gradable on creation)
- Click "Existing activities" and "Hypothesis link (localhost)"
- Select any content to see the new control

### Todo

- [x] Set proper KB link in Popover, and verify content is correct (see https://hypothes-is.slack.com/archives/C2C2U40LW/p1750674535824379).