### PR TITLE
Update phrasing in max points popover text

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -525,14 +525,14 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                           arrow
                         >
                           <div className="flex flex-col gap-y-2">
-                            (Optional) Add a Max Points value here instead of
+                            Optionally add a max points value here instead of
                             using your LMS grading settings.
                             <Link
                               href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
                               underline="always"
                               target="_blank"
                             >
-                              Learn more about grading options
+                              Learn more about our max points feature
                             </Link>
                           </div>
                         </Popover>


### PR DESCRIPTION
As discussed in slack https://hypothes-is.slack.com/archives/C2C2U40LW/p1750833437193359?thread_ts=1750674535.824379&cid=C2C2U40LW, update the phrasing of the max points info popover introduced in https://github.com/hypothesis/lms/pull/7161.

Take the opportunity to also fix the casing of "Max Points", which now becomes "max points" when used in the middle of a sentence.

Before:
![image](https://github.com/user-attachments/assets/8cd752e9-bc2a-457e-9b24-52789c6b697e)

After:
![image](https://github.com/user-attachments/assets/805818b4-5a7a-4c91-9fb6-6837ddab9337)
