### PR TITLE
Prevent closing tab when Hypothesis client has unsaved changes

### DIFF
--- a/lms/static/scripts/frontend_apps/utils/test/unsaved-changes-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/unsaved-changes-test.js
@@ -1,0 +1,103 @@
+import sinon from 'sinon';
+
+import {
+  hasUnsavedChanges,
+  incrementUnsavedCount,
+  decrementUnsavedCount,
+} from '../unsaved-changes';
+
+describe('unsaved-changes', () => {
+  let addEventListenerStub;
+  let removeEventListenerStub;
+
+  beforeEach(() => {
+    addEventListenerStub = sinon.stub(window, 'addEventListener');
+    removeEventListenerStub = sinon.stub(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    while (hasUnsavedChanges()) {
+      decrementUnsavedCount();
+    }
+    sinon.restore();
+  });
+
+  describe('hasUnsavedChanges', () => {
+    it('returns false initially', () => {
+      assert.isFalse(hasUnsavedChanges());
+    });
+
+    it('returns true after incrementing count', () => {
+      incrementUnsavedCount();
+      assert.isTrue(hasUnsavedChanges());
+    });
+
+    it('returns false after decrementing count to zero', () => {
+      incrementUnsavedCount();
+      decrementUnsavedCount();
+      assert.isFalse(hasUnsavedChanges());
+    });
+  });
+
+  describe('incrementUnsavedCount', () => {
+    it('adds beforeunload listener when count goes from 0 to 1', () => {
+      incrementUnsavedCount();
+      assert.calledOnce(addEventListenerStub);
+      assert.calledWith(addEventListenerStub, 'beforeunload');
+    });
+
+    it('does not add additional listeners when count is already > 0', () => {
+      incrementUnsavedCount();
+      incrementUnsavedCount();
+      assert.calledOnce(addEventListenerStub);
+    });
+  });
+
+  describe('decrementUnsavedCount', () => {
+    it('removes beforeunload listener when count goes to 0', () => {
+      incrementUnsavedCount();
+      decrementUnsavedCount();
+      assert.calledOnce(removeEventListenerStub);
+      assert.calledWith(removeEventListenerStub, 'beforeunload');
+    });
+
+    it('does not remove listener when count is still > 0', () => {
+      incrementUnsavedCount();
+      incrementUnsavedCount();
+      decrementUnsavedCount();
+      assert.notCalled(removeEventListenerStub);
+      assert.isTrue(hasUnsavedChanges());
+    });
+
+    it('does nothing when count is already 0', () => {
+      decrementUnsavedCount();
+      assert.notCalled(removeEventListenerStub);
+      assert.isFalse(hasUnsavedChanges());
+    });
+
+    it('maintains count correctly after multiple operations', () => {
+      incrementUnsavedCount();
+      incrementUnsavedCount();
+      decrementUnsavedCount();
+      assert.isTrue(hasUnsavedChanges());
+      decrementUnsavedCount();
+      assert.isFalse(hasUnsavedChanges());
+    });
+  });
+
+  describe('beforeunload handler', () => {
+    it('prevents default and sets returnValue on beforeunload event', () => {
+      incrementUnsavedCount();
+      const preventUnload = addEventListenerStub.args[0][1];
+      const mockEvent = {
+        preventDefault: sinon.spy(),
+        returnValue: false,
+      };
+
+      preventUnload(mockEvent);
+
+      assert.calledOnce(mockEvent.preventDefault);
+      assert.isTrue(mockEvent.returnValue);
+    });
+  });
+});

--- a/lms/static/scripts/frontend_apps/utils/unsaved-changes.ts
+++ b/lms/static/scripts/frontend_apps/utils/unsaved-changes.ts
@@ -1,0 +1,46 @@
+let unsavedCount = 0;
+
+function preventUnload(e: BeforeUnloadEvent) {
+  // `preventDefault` is the modern API for preventing unload.
+  e.preventDefault();
+
+  // Setting `returnValue` to a truthy value is a legacy method needed for
+  // Firefox. Note that in Chrome, reading `returnValue` will return false
+  // afterwards.
+  e.returnValue = true;
+}
+
+/**
+ * Return true if an alert will currently be triggered if the tab is closed.
+ */
+export function hasUnsavedChanges() {
+  return unsavedCount > 0;
+}
+
+/**
+ * Increment the count of unsaved changes.
+ *
+ * When the count is non-zero, a "beforeunload" event handler is used to trigger
+ * an alert if the user closes the tab.
+ */
+export function incrementUnsavedCount() {
+  unsavedCount += 1;
+  if (unsavedCount === 1) {
+    window.addEventListener('beforeunload', preventUnload);
+  }
+}
+
+/**
+ * Decrement the count of unsaved changes.
+ *
+ * When this count goes to zero, alerts when unloading the tab are disabled.
+ */
+export function decrementUnsavedCount() {
+  if (unsavedCount === 0) {
+    return;
+  }
+  unsavedCount -= 1;
+  if (unsavedCount === 0) {
+    window.removeEventListener('beforeunload', preventUnload);
+  }
+}


### PR DESCRIPTION
This is the LMS side of a workaround for a restriction in desktop Safari that `beforeunload` alerts do not work in cross-origin iframes. When the user has unsaved changes in the client, it sends a notification to the LMS frame which installs a `beforeunload` handler.

See https://github.com/hypothesis/client/pull/7206 for the client changes and https://github.com/hypothesis/support/issues/59#issuecomment-3068704178 for issue context.

**Testing:**

Either test in Safari or comment out calls to the `useUnsavedChanges` hook in the Hypothesis client and test in Chrome or Firefox.

1. Launch a Hypothesis assignment in a new tab. Close the tab. There should be no confirmation dialog.
2. Launch a Hypothesis assignment in a new tab. Create an annotation and enter some tags or text. Try to close the tab. There should be a confirmation dialog.
3. Repeat step (2) but before closing the tab, save or cancel editing the annotation, then close the tab. There should be no confirmation dialog. 