### PR TITLE
Add Sentry Logs

### DIFF
--- a/lms/sentry.py
+++ b/lms/sentry.py
@@ -1,12 +1,24 @@
 """Sentry crash reporting integration."""
 
+from sentry_sdk.types import Hint, Log
+
 from lms._version import get_version
+
+
+def before_send_log(log: Log, _hint: Hint) -> Log | None:
+    """Filter out log messages that we don't want to send to Sentry Logs."""
+
+    if log.get("attributes", {}).get("logger.name") == "gunicorn.access":
+        return None
+
+    return log
 
 
 def includeme(config):
     config.add_settings(
         {
             "h_pyramid_sentry.retry_support": True,
+            "h_pyramid_sentry.celery_support": True,
             "h_pyramid_sentry.sqlalchemy_support": True,
             # Enable Sentry's "Releases" feature, see:
             # https://docs.sentry.io/platforms/python/configuration/options/#release
@@ -18,6 +30,8 @@ def includeme(config):
             # For the full list of options that sentry_sdk.init() supports see:
             # https://docs.sentry.io/platforms/python/configuration/options/
             "h_pyramid_sentry.init.release": get_version(),
+            "h_pyramid_sentry.init.enable_logs": True,
+            "h_pyramid_sentry.init.before_send_log": before_send_log,
         }
     )
     config.include("h_pyramid_sentry")

--- a/tests/unit/lms/sentry_test.py
+++ b/tests/unit/lms/sentry_test.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import pytest
+
+from lms.sentry import before_send_log
+
+
+class TestBeforeSendLog:
+    @pytest.mark.parametrize(
+        "log,should_be_filtered_out",
+        [
+            ({"attributes": {"logger.name": "gunicorn.access"}}, True),
+            ({"attributes": {"logger.name": "foo"}}, False),
+            ({}, False),
+        ],
+    )
+    def test_it(self, log, should_be_filtered_out):
+        result = before_send_log(log, mock.sentinel.hint)
+
+        if should_be_filtered_out:
+            assert result is None
+        else:
+            assert result == log


### PR DESCRIPTION
This should send logs to Sentry from both the web and Celery worker processes, and should filter out Gunicorn access logs.