### PR TITLE
Implement secure URL generation for via_video_url function

### DIFF
--- a/lms/views/helpers/_via.py
+++ b/lms/views/helpers/_via.py
@@ -3,6 +3,7 @@
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from h_vialib import ViaClient
+from h_vialib.secure import ViaSecureURL
 
 __all__ = ["via_url"]
 
@@ -72,7 +73,7 @@ def via_video_url(
     """
 
     via_service_url = urlparse(request.registry.settings["via_url"])
-    return urlunparse(
+    unsigned_url = urlunparse(
         (
             via_service_url.scheme,
             via_service_url.netloc,
@@ -90,3 +91,6 @@ def via_video_url(
             "",
         )
     )
+
+    secure_url = ViaSecureURL(request.registry.settings["via_secret"])
+    return secure_url.create(unsigned_url)

--- a/tests/unit/lms/views/helpers/_via_test.py
+++ b/tests/unit/lms/views/helpers/_via_test.py
@@ -98,6 +98,7 @@ class TestViaVideoURL:
                 "url": canonical_url,
                 "media_url": download_url,
                 "transcript": transcript_url,
+                "via.sec": Any.string(),
             }
         )
 


### PR DESCRIPTION
This pull request updates the way video URLs are generated for the Via service by adding secure signing. The main change is that URLs returned by `via_video_url` are now signed using `ViaSecureURL`, which adds an extra layer of security. A corresponding test update ensures the presence of the security parameter in the generated URLs.

**Enhancements to URL Security:**

* Updated `via_video_url` in `lms/views/helpers/_via.py` to use `ViaSecureURL` for signing generated URLs, ensuring that all video URLs are now securely signed. [[1]](diffhunk://#diff-076c72644f2b077ba89ee4612fc714c3a11f576f55f7c81c116b84e1cd6ae3b6R6) [[2]](diffhunk://#diff-076c72644f2b077ba89ee4612fc714c3a11f576f55f7c81c116b84e1cd6ae3b6L75-R76) [[3]](diffhunk://#diff-076c72644f2b077ba89ee4612fc714c3a11f576f55f7c81c116b84e1cd6ae3b6R94-R96)
* Modified tests in `tests/unit/lms/views/helpers/_via_test.py` to assert that the returned URLs include the `via.sec` security parameter.