### PR TITLE
hide and reveal frontend

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
@@ -1,0 +1,63 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+
+/**
+ * The kind of assignment being created.
+ *
+ * - `reading`: a standard "Social annotation" reading assignment.
+ * - `hide_and_reveal`: "Guided Social annotation" — students' annotations are
+ *   hidden from each other until an instructor reveals them (internally also
+ *   referred to as "Hide & Reveal" / checkpoints).
+ */
+export type AssignmentType = 'reading' | 'hide_and_reveal';
+
+/** Human-readable label shown in the selector for each assignment type. */
+const ASSIGNMENT_TYPE_LABELS: Record<AssignmentType, string> = {
+  reading: 'Social annotation',
+  hide_and_reveal: 'Guided Social annotation',
+};
+
+export type AssignmentTypeSelectorProps = {
+  /**
+   * Assignment types the instructor can choose from, in display order. Decided
+   * by the backend. A new type also needs an entry in the `AssignmentType`
+   * union and in `ASSIGNMENT_TYPE_LABELS` to render with a proper label.
+   */
+  types: AssignmentType[];
+  selected: AssignmentType;
+  onChange: (type: AssignmentType) => void;
+};
+
+/**
+ * First step of the assignment-type workflow: lets instructors choose which
+ * kind of assignment they are creating among the available `types`.
+ */
+export default function AssignmentTypeSelector({
+  types,
+  selected,
+  onChange,
+}: AssignmentTypeSelectorProps) {
+  return (
+    <div>
+      <RadioGroup
+        data-testid="assignment-type-radio-group"
+        aria-label="Assignment mode"
+        direction="vertical"
+        selected={selected}
+        onChange={onChange}
+      >
+        {types.map(type => {
+          // Fall back to the raw key if the backend sends a type this frontend
+          // build doesn't know yet (deploy ordering), so the radio is never
+          // blank. Statically unreachable, but `type` is backend JSON at runtime.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          const label = ASSIGNMENT_TYPE_LABELS[type] ?? type;
+          return (
+            <RadioGroup.Radio key={type} value={type}>
+              {label}
+            </RadioGroup.Radio>
+          );
+        })}
+      </RadioGroup>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/CheckpointSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/CheckpointSelector.tsx
@@ -1,0 +1,69 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+import { useId } from 'preact/hooks';
+
+/**
+ * The kind of checkpoint that controls when hidden annotations are revealed.
+ *
+ * For now only `manual` is functional (the instructor reveals annotations
+ * themselves); more options (e.g. a calendar/date-driven checkpoint) are
+ * planned.
+ */
+export type CheckpointType = 'manual';
+
+/** Values rendered as radios, including not-yet-available options. */
+type CheckpointOption = CheckpointType | 'more';
+
+export type CheckpointSelectorProps = {
+  selected: CheckpointType;
+  onChange: (type: CheckpointType) => void;
+};
+
+/**
+ * Second step of the "Hide & Reveal" workflow: lets instructors choose how the
+ * checkpoint (the point at which hidden annotations are revealed) works.
+ */
+export default function CheckpointSelector({
+  selected,
+  onChange,
+}: CheckpointSelectorProps) {
+  const headingId = useId();
+
+  // The note below is specific to the "manual" reveal, so it only shows for that
+  // option. `selected` is currently always 'manual' (the only enabled option),
+  // but this keeps the association explicit for when more types are added.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const showManualNote = selected === 'manual';
+
+  return (
+    <div className="space-y-2">
+      <h3 id={headingId} className="uppercase font-medium text-slate-600">
+        Checkpoint
+      </h3>
+      <RadioGroup<CheckpointOption>
+        data-testid="checkpoint-radio-group"
+        aria-labelledby={headingId}
+        direction="vertical"
+        selected={selected}
+        onChange={option => {
+          // Ignore the disabled "coming soon" placeholder; anything else is a
+          // real CheckpointType. Adding a new type needs no change here.
+          if (option !== 'more') {
+            onChange(option);
+          }
+        }}
+      >
+        <RadioGroup.Radio value="manual">Manual</RadioGroup.Radio>
+        <RadioGroup.Radio value="more" disabled>
+          More coming soon
+        </RadioGroup.Radio>
+      </RadioGroup>
+      {showManualNote && (
+        // No color class: inherits the base text color (black) per design.
+        <p>
+          Students will see when the settings have changed from
+          &ldquo;Hide&rdquo; to &ldquo;Reveal&rdquo; in their notifications.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
@@ -1,0 +1,66 @@
+import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
+import { useId, useRef, useState } from 'preact/hooks';
+
+export type DueDateSelectorProps = {
+  /** Currently selected due date as an ISO date string (`YYYY-MM-DD`), or null. */
+  dueDate: string | null;
+  onChange: (dueDate: string | null) => void;
+};
+
+/**
+ * Third step of the "Hide & Reveal" workflow: lets instructors pick the due
+ * date, the point at which annotations are no longer tallied in auto grading.
+ */
+export default function DueDateSelector({
+  dueDate,
+  onChange,
+}: DueDateSelectorProps) {
+  const headingId = useId();
+
+  // Explanation of the due date, shown in a tooltip (anchored to the info icon)
+  // rather than inline. Mirrors the "Max points" popover in FilePickerApp.
+  const infoIconRef = useRef<HTMLButtonElement | null>(null);
+  const [infoPopoverOpen, setInfoPopoverOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-x-1">
+        <h3 id={headingId} className="uppercase font-medium text-slate-600">
+          Due Date
+        </h3>
+        <IconButton
+          icon={InfoIcon}
+          title="About due date"
+          onClick={() => setInfoPopoverOpen(open => !open)}
+          expanded={infoPopoverOpen}
+          elementRef={infoIconRef}
+          classes="text-[16px]"
+        />
+        <Popover
+          open={infoPopoverOpen}
+          anchorElementRef={infoIconRef}
+          onClose={() => setInfoPopoverOpen(false)}
+          classes="p-2"
+          placement="above"
+          arrow
+        >
+          The point where annotations are no longer tallied in auto grading.
+        </Popover>
+      </div>
+      <input
+        type="date"
+        data-testid="due-date-input"
+        aria-labelledby={headingId}
+        // The shared `Input` component does not support `type="date"`, so this
+        // mirrors its base classes (`inputStyles`) to stay visually consistent,
+        // including `touch:text-at-least-16px` which prevents iOS zoom-on-focus.
+        className="focus-visible:ring focus-visible:outline-none ring-inset border rounded w-full p-2 bg-grey-0 focus:bg-white disabled:bg-grey-1 placeholder:text-grey-6 disabled:placeholder:text-grey-7 touch:text-at-least-16px"
+        value={dueDate ?? ''}
+        onChange={e => {
+          const { value } = e.target as HTMLInputElement;
+          onChange(value === '' ? null : value);
+        }}
+      />
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -32,9 +32,14 @@ import { apiCall } from '../utils/api';
 import type { Content, URLContent } from '../utils/content-item';
 import { truncateURL } from '../utils/format';
 import { useUniqueId } from '../utils/hooks';
+import type { AssignmentType } from './AssignmentTypeSelector';
+import AssignmentTypeSelector from './AssignmentTypeSelector';
 import type { AutoGradingConfig } from './AutoGradingConfigurator';
 import AutoGradingConfigurator from './AutoGradingConfigurator';
+import type { CheckpointType } from './CheckpointSelector';
+import CheckpointSelector from './CheckpointSelector';
 import ContentSelector from './ContentSelector';
+import DueDateSelector from './DueDateSelector';
 import ErrorModal from './ErrorModal';
 import FilePickerFormFields from './FilePickerFormFields';
 import GroupConfigSelector from './GroupConfigSelector';
@@ -53,10 +58,26 @@ export type FilePickerAppProps = {
 
 /* A step or 'screen' of the assignment configuration */
 type PickerStep =
+  // First screen (only shown when more than one assignment type is available)
+  // where the instructor picks the type of assignment they are creating.
+  | 'assignment-type'
+  // "Hide & Reveal" screens, only shown when that assignment type is chosen.
+  | 'checkpoint'
+  | 'due-date'
   | 'content-selection'
   // Final screen where the settings for the assignment are shown, and also
   // additional settings which don't need a whole screen.
   | 'details';
+
+/**
+ * Sub-steps of the assignment-type workflow shown before the regular file
+ * picker flow. These are the `PickerStep`s that precede content selection, plus
+ * `done`, which means the workflow has been completed (or skipped) and the
+ * regular flow takes over. Derived from `PickerStep` so the two stay in sync.
+ */
+type WorkflowStep =
+  | Exclude<PickerStep, 'content-selection' | 'details'>
+  | 'done';
 
 /**
  * For URL content, show the most meaningful explanation of the content we can
@@ -188,6 +209,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     assignment,
     filePicker: {
       autoGradingEnabled,
+      assignmentTypes,
       deepLinkingAPI,
       formAction,
       formFields,
@@ -195,6 +217,19 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       promptForGradable,
     },
   } = useConfig(['api', 'filePicker']);
+
+  // Assignment types the instructor can choose from. `reading` is always
+  // available; other types (e.g. `hide_and_reveal`) are gated by the backend
+  // via a per-install feature flag. Until the backend sends `assignmentTypes`,
+  // we fall back to `reading` only, which keeps the type workflow dormant.
+  const availableAssignmentTypes = assignmentTypes ?? ['reading'];
+
+  // The multi-step type workflow (type selection + any type-specific sub-steps)
+  // is only worth showing when there is more than one type to pick from. With a
+  // single type there is nothing to choose, so we skip straight to the regular
+  // flow. This intentionally does *not* depend on any single type being enabled,
+  // so adding a new type keeps the workflow working without changes here.
+  const enableTypeWorkflow = availableAssignmentTypes.length > 1;
 
   // Currently selected content for assignment.
   const [content, setContent] = useState<Content | null>(
@@ -231,6 +266,53 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // True if we are editing an existing assignment configuration.
   const isEditing = !!assignment;
 
+  // Type of assignment being created, chosen in the first ("assignment-type")
+  // step of the workflow. Defaults to the first available type so it is always
+  // one the backend actually offers. Only relevant when `enableTypeWorkflow`.
+  const [assignmentType, setAssignmentType] = useState<AssignmentType>(
+    availableAssignmentTypes[0] ?? 'reading',
+  );
+  // Checkpoint configuration for "Hide & Reveal" assignments.
+  const [checkpointType, setCheckpointType] =
+    useState<CheckpointType>('manual');
+  const [dueDate, setDueDate] = useState<string | null>(null);
+  // Current sub-step of the assignment-type workflow. When the workflow isn't
+  // enabled we start as `done` so it is skipped entirely.
+  const [workflowStep, setWorkflowStep] = useState<WorkflowStep>(
+    enableTypeWorkflow ? 'assignment-type' : 'done',
+  );
+
+  // Advance to the next sub-step of the workflow. Only "hide_and_reveal" has
+  // further steps (checkpoint, due-date); other types go straight to the
+  // regular flow.
+  const goToNextWorkflowStep = () => {
+    setWorkflowStep(step => {
+      switch (step) {
+        case 'assignment-type':
+          return assignmentType === 'hide_and_reveal' ? 'checkpoint' : 'done';
+        case 'checkpoint':
+          return 'due-date';
+        default:
+          return 'done';
+      }
+    });
+  };
+
+  // Go back to the previous sub-step of the workflow. Only ever invoked from
+  // the 'checkpoint' and 'due-date' steps (the "Back" button is
+  // hidden on the first step). Selections made in later steps are kept in state,
+  // so they survive going back and forth.
+  const goToPreviousWorkflowStep = () => {
+    setWorkflowStep(step =>
+      step === 'due-date' ? 'checkpoint' : 'assignment-type',
+    );
+  };
+
+  // Jump straight back to the assignment-mode selection from anywhere in the
+  // Guided ("Hide & Reveal") sub-steps, via the close button in the card header.
+  // Selections made so far are kept in state.
+  const returnToModeSelection = () => setWorkflowStep('assignment-type');
+
   // Whether there are additional configuration options to present after the
   // user has selected the content for the assignment.
   const showDetailsScreen =
@@ -240,7 +322,11 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     autoGradingEnabled;
 
   let currentStep: PickerStep;
-  if (editingContent) {
+  if (enableTypeWorkflow && workflowStep !== 'done' && !isEditing) {
+    // While the assignment-type workflow is in progress, its current sub-step
+    // (which is a subset of PickerStep) is the active step.
+    currentStep = workflowStep;
+  } else if (editingContent) {
     currentStep = 'content-selection';
   } else if (isEditing) {
     currentStep = 'details';
@@ -248,6 +334,28 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     currentStep =
       content && showDetailsScreen ? 'details' : 'content-selection';
   }
+
+  // Whether the current step belongs to the assignment-type workflow shown
+  // before the regular file picker flow.
+  const inTypeWorkflow =
+    currentStep === 'assignment-type' ||
+    currentStep === 'checkpoint' ||
+    currentStep === 'due-date';
+
+  // The first workflow step has nothing before it, so "Back" is only offered on
+  // later steps.
+  const canGoBackInWorkflow =
+    currentStep === 'checkpoint' || currentStep === 'due-date';
+
+  // Title shown in the card header, which changes depending on the current step.
+  const stepTitles: Record<PickerStep, string> = {
+    'assignment-type': 'Assignment mode',
+    checkpoint: 'Guided Social Annotation',
+    'due-date': 'Guided Social Annotation',
+    'content-selection': 'Assignment details',
+    details: 'Assignment details',
+  };
+  const cardTitle = stepTitles[currentStep];
 
   const [groupConfig, setGroupConfig] = useState<GroupConfig>({
     useGroupSet: !!assignment?.group_set_id,
@@ -421,158 +529,209 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         )}
         {/* Card constrains overflow-scroll children to height constraints */}
         <Card classes="flex flex-col min-h-0 overflow-hidden">
-          <CardHeader variant="secondary" title="Assignment details" />
+          <CardHeader
+            variant="secondary"
+            title={cardTitle}
+            // Offer a close ("x") button to return to mode selection from the
+            // Guided sub-steps (checkpoint / due-date), but not from the mode
+            // selection step itself or the regular flow.
+            onClose={canGoBackInWorkflow ? returnToModeSelection : undefined}
+          />
           <Scroll>
             <CardContent size="lg">
-              {/* 1-col grid for very narrow screens; 2-col for everyone else */}
-              <div className="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-6 gap-y-3">
-                <PanelLabel
-                  description={<p>Select content for your assignment</p>}
-                  isCurrentStep={currentStep === 'content-selection'}
-                >
-                  Assignment content
-                </PanelLabel>
-
-                <div data-testid="content-selector-container">
-                  {content && currentStep !== 'content-selection' ? (
-                    <div className="flex gap-x-2 items-start">
-                      <span
-                        className="break-words italic"
-                        data-testid="content-summary"
-                      >
-                        {contentDescription(content)}
-                      </span>
-                      <LinkButton
-                        onClick={() => setEditingContent(true)}
-                        data-testid="edit-content"
-                        title="Change assignment content"
-                        underline="always"
-                      >
-                        Change
-                      </LinkButton>
-                    </div>
-                  ) : (
-                    <ContentSelector
-                      initialContent={content ?? undefined}
-                      onSelectContent={selectContent}
-                      onError={setErrorInfo}
+              {inTypeWorkflow ? (
+                <div className="space-y-4">
+                  {currentStep === 'assignment-type' && (
+                    <AssignmentTypeSelector
+                      types={availableAssignmentTypes}
+                      selected={assignmentType}
+                      onChange={setAssignmentType}
                     />
                   )}
+                  {currentStep === 'checkpoint' && (
+                    <CheckpointSelector
+                      selected={checkpointType}
+                      onChange={setCheckpointType}
+                    />
+                  )}
+                  {currentStep === 'due-date' && (
+                    <DueDateSelector dueDate={dueDate} onChange={setDueDate} />
+                  )}
                 </div>
-                {currentStep === 'details' && (
-                  <>
-                    {typeof title === 'string' && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep verticalAlign="center">
-                          Title
-                        </PanelLabel>
-                        <Input
-                          data-testid="title-input"
-                          id={titleInputId}
-                          // Max length is based on what D2L supports, which is the first LMS that
-                          // supported setting a title in assignment configuration.
-                          maxLength={150}
-                          onInput={(e: Event) =>
-                            setTitle((e.target as HTMLInputElement).value)
-                          }
-                          required
-                          value={title}
-                        />
-                      </>
+              ) : (
+                /* 1-col grid for very narrow screens; 2-col for everyone else */
+                <div className="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-6 gap-y-3">
+                  <PanelLabel
+                    description={<p>Select content for your assignment</p>}
+                    isCurrentStep={currentStep === 'content-selection'}
+                  >
+                    Assignment content
+                  </PanelLabel>
+
+                  <div data-testid="content-selector-container">
+                    {content && currentStep !== 'content-selection' ? (
+                      <div className="flex gap-x-2 items-start">
+                        <span
+                          className="break-words italic"
+                          data-testid="content-summary"
+                        >
+                          {contentDescription(content)}
+                        </span>
+                        <LinkButton
+                          onClick={() => setEditingContent(true)}
+                          data-testid="edit-content"
+                          title="Change assignment content"
+                          underline="always"
+                        >
+                          Change
+                        </LinkButton>
+                      </div>
+                    ) : (
+                      <ContentSelector
+                        initialContent={content ?? undefined}
+                        onSelectContent={selectContent}
+                        onError={setErrorInfo}
+                      />
                     )}
-                    {promptForGradable && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep verticalAlign="center">
-                          <div className="flex items-center sm:justify-end">
-                            Max points
-                            <IconButton
-                              icon={InfoIcon}
-                              title="About max points"
-                              onClick={() =>
-                                setMaxPointsPopoverOpen(open => !open)
-                              }
-                              expanded={maxPointsPopoverOpen}
-                              elementRef={iconRef}
-                              // Align right side of the icon with the right
-                              // edge of the text labels above and below.
-                              // Do it by setting negative margin that
-                              // compensates for the button's padding.
-                              classes="text-[16px] -mr-2 touch:-mr-[12px]"
+                  </div>
+                  {currentStep === 'details' && (
+                    <>
+                      {typeof title === 'string' && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep verticalAlign="center">
+                            Title
+                          </PanelLabel>
+                          <Input
+                            data-testid="title-input"
+                            id={titleInputId}
+                            // Max length is based on what D2L supports, which is the first LMS that
+                            // supported setting a title in assignment configuration.
+                            maxLength={150}
+                            onInput={(e: Event) =>
+                              setTitle((e.target as HTMLInputElement).value)
+                            }
+                            required
+                            value={title}
+                          />
+                        </>
+                      )}
+                      {promptForGradable && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep verticalAlign="center">
+                            <div className="flex items-center sm:justify-end">
+                              Max points
+                              <IconButton
+                                icon={InfoIcon}
+                                title="About max points"
+                                onClick={() =>
+                                  setMaxPointsPopoverOpen(open => !open)
+                                }
+                                expanded={maxPointsPopoverOpen}
+                                elementRef={iconRef}
+                                // Align right side of the icon with the right
+                                // edge of the text labels above and below.
+                                // Do it by setting negative margin that
+                                // compensates for the button's padding.
+                                classes="text-[16px] -mr-2 touch:-mr-[12px]"
+                              />
+                            </div>
+                          </PanelLabel>
+                          <Input
+                            data-testid="gradable-max-input"
+                            id={gradableMaxInputId}
+                            type="number"
+                            placeholder={'ex: 100'}
+                            min={0}
+                            value={assignmentGradableMaxPoints}
+                            onChange={e =>
+                              setAssignmentGradableMaxPoints(
+                                (e.target as HTMLInputElement).value,
+                              )
+                            }
+                          />
+                          <Popover
+                            open={maxPointsPopoverOpen}
+                            anchorElementRef={iconRef}
+                            onClose={() => setMaxPointsPopoverOpen(false)}
+                            classes="p-2"
+                            placement="above"
+                            arrow
+                          >
+                            <div className="flex flex-col gap-y-2">
+                              Optionally add a max points value here instead of
+                              using your LMS grading settings.
+                              <Link
+                                href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
+                                underline="always"
+                                target="_blank"
+                              >
+                                Learn more about our max points feature
+                              </Link>
+                            </div>
+                          </Popover>
+                        </>
+                      )}
+
+                      {autoGradingEnabled && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep>Auto grading</PanelLabel>
+                          <AutoGradingConfigurator
+                            config={autoGradingConfig}
+                            onChange={setAutoGradingConfig}
+                          />
+                        </>
+                      )}
+                      {enableGroupConfig && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep>
+                            Group assignment
+                          </PanelLabel>
+                          <div
+                            className={classnames(
+                              // Set a height on this container to give the group
+                              // <select> element room when it renders (avoid
+                              // changing the height of the Card later)
+                              'h-28',
+                            )}
+                          >
+                            <GroupConfigSelector
+                              groupConfig={groupConfig}
+                              onChangeGroupConfig={setGroupConfig}
                             />
                           </div>
-                        </PanelLabel>
-                        <Input
-                          data-testid="gradable-max-input"
-                          id={gradableMaxInputId}
-                          type="number"
-                          placeholder={'ex: 100'}
-                          min={0}
-                          value={assignmentGradableMaxPoints}
-                          onChange={e =>
-                            setAssignmentGradableMaxPoints(
-                              (e.target as HTMLInputElement).value,
-                            )
-                          }
-                        />
-                        <Popover
-                          open={maxPointsPopoverOpen}
-                          anchorElementRef={iconRef}
-                          onClose={() => setMaxPointsPopoverOpen(false)}
-                          classes="p-2"
-                          placement="above"
-                          arrow
-                        >
-                          <div className="flex flex-col gap-y-2">
-                            Optionally add a max points value here instead of
-                            using your LMS grading settings.
-                            <Link
-                              href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
-                              underline="always"
-                              target="_blank"
-                            >
-                              Learn more about our max points feature
-                            </Link>
-                          </div>
-                        </Popover>
-                      </>
-                    )}
-
-                    {autoGradingEnabled && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep>Auto grading</PanelLabel>
-                        <AutoGradingConfigurator
-                          config={autoGradingConfig}
-                          onChange={setAutoGradingConfig}
-                        />
-                      </>
-                    )}
-                    {enableGroupConfig && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep>Group assignment</PanelLabel>
-                        <div
-                          className={classnames(
-                            // Set a height on this container to give the group
-                            // <select> element room when it renders (avoid
-                            // changing the height of the Card later)
-                            'h-28',
-                          )}
-                        >
-                          <GroupConfigSelector
-                            groupConfig={groupConfig}
-                            onChangeGroupConfig={setGroupConfig}
-                          />
-                        </div>
-                      </>
-                    )}
-                  </>
-                )}
-              </div>
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Scroll>
+          {inTypeWorkflow && (
+            <CardContent size="lg">
+              <CardActions>
+                {canGoBackInWorkflow && (
+                  <Button
+                    data-testid="workflow-back-button"
+                    onClick={goToPreviousWorkflowStep}
+                  >
+                    Back
+                  </Button>
+                )}
+                <Button
+                  data-testid="workflow-next-button"
+                  variant="primary"
+                  onClick={goToNextWorkflowStep}
+                >
+                  Next
+                </Button>
+              </CardActions>
+            </CardContent>
+          )}
           {
             // See comments in `selectContent` about auto-submitting form.
             (editingContent || currentStep === 'details') && (

--- a/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
@@ -1,0 +1,65 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import AssignmentTypeSelector from '../AssignmentTypeSelector';
+
+describe('AssignmentTypeSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(
+    selected = 'reading',
+    types = ['reading', 'hide_and_reveal'],
+  ) {
+    return mount(
+      <AssignmentTypeSelector
+        types={types}
+        selected={selected}
+        onChange={fakeOnChange}
+      />,
+    );
+  }
+
+  it('reflects the selected assignment type', () => {
+    const wrapper = createComponent('hide_and_reveal');
+    assert.equal(
+      wrapper.find('RadioGroup').prop('selected'),
+      'hide_and_reveal',
+    );
+  });
+
+  it('renders a radio option for each available type', () => {
+    const wrapper = createComponent('reading', ['reading', 'hide_and_reveal']);
+    const values = wrapper
+      .find(RadioGroup.Radio)
+      .map(radio => radio.prop('value'));
+    assert.deepEqual(values, ['reading', 'hide_and_reveal']);
+  });
+
+  it('only renders the available types', () => {
+    const wrapper = createComponent('reading', ['reading']);
+    const values = wrapper
+      .find(RadioGroup.Radio)
+      .map(radio => radio.prop('value'));
+    assert.deepEqual(values, ['reading']);
+  });
+
+  it('invokes onChange when a different type is selected', () => {
+    const wrapper = createComponent('reading');
+
+    act(() => wrapper.find('RadioGroup').props().onChange('hide_and_reveal'));
+
+    assert.calledWith(fakeOnChange, 'hide_and_reveal');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/CheckpointSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/CheckpointSelector-test.js
@@ -1,0 +1,76 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import CheckpointSelector from '../CheckpointSelector';
+
+describe('CheckpointSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(selected = 'manual') {
+    return mount(
+      <CheckpointSelector selected={selected} onChange={fakeOnChange} />,
+    );
+  }
+
+  it('reflects the selected checkpoint type', () => {
+    const wrapper = createComponent('manual');
+    assert.equal(wrapper.find('RadioGroup').prop('selected'), 'manual');
+  });
+
+  it('invokes onChange when "manual" is selected', () => {
+    const wrapper = createComponent();
+
+    act(() => wrapper.find('RadioGroup').props().onChange('manual'));
+
+    assert.calledWith(fakeOnChange, 'manual');
+  });
+
+  it('ignores selection of not-yet-available options', () => {
+    const wrapper = createComponent();
+
+    act(() => wrapper.find('RadioGroup').props().onChange('more'));
+
+    assert.notCalled(fakeOnChange);
+  });
+
+  it('passes through any real (non-placeholder) checkpoint type', () => {
+    const wrapper = createComponent();
+
+    // A future CheckpointType (anything other than the "more" placeholder)
+    // should propagate without changing the guard.
+    act(() => wrapper.find('RadioGroup').props().onChange('automatic'));
+
+    assert.calledWith(fakeOnChange, 'automatic');
+  });
+
+  it('shows the reveal note when "manual" is selected', () => {
+    const wrapper = createComponent('manual');
+
+    assert.include(
+      wrapper.text(),
+      'Students will see when the settings have changed',
+    );
+  });
+
+  it('hides the reveal note when a non-manual option is selected', () => {
+    // `selected` is typed `'manual'` today (the only option), so this exercises
+    // the conditional that will matter once more checkpoint types exist.
+    const wrapper = createComponent('more');
+
+    assert.notInclude(
+      wrapper.text(),
+      'Students will see when the settings have changed',
+    );
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
@@ -1,0 +1,87 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import DueDateSelector from '../DueDateSelector';
+
+describe('DueDateSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(dueDate = null) {
+    return mount(
+      <DueDateSelector dueDate={dueDate} onChange={fakeOnChange} />,
+      // Connect to the DOM so the info `Popover` (which uses the native popover
+      // API) can toggle.
+      { connected: true },
+    );
+  }
+
+  const dateInput = wrapper =>
+    wrapper.find('input[data-testid="due-date-input"]');
+
+  it('reflects the selected due date', () => {
+    const wrapper = createComponent('2026-06-11');
+    assert.equal(dateInput(wrapper).prop('value'), '2026-06-11');
+  });
+
+  it('renders an empty value when no due date is set', () => {
+    const wrapper = createComponent(null);
+    assert.equal(dateInput(wrapper).prop('value'), '');
+  });
+
+  it('invokes onChange with the selected date', () => {
+    const wrapper = createComponent();
+
+    act(() =>
+      dateInput(wrapper)
+        .props()
+        .onChange({ target: { value: '2026-06-11' } }),
+    );
+
+    assert.calledWith(fakeOnChange, '2026-06-11');
+  });
+
+  it('invokes onChange with null when the date is cleared', () => {
+    const wrapper = createComponent('2026-06-11');
+
+    act(() =>
+      dateInput(wrapper)
+        .props()
+        .onChange({ target: { value: '' } }),
+    );
+
+    assert.calledWith(fakeOnChange, null);
+  });
+
+  it('shows the due date explanation in a popover instead of inline', () => {
+    const wrapper = createComponent();
+    const popover = () => wrapper.find('Popover');
+    const explanation =
+      'The point where annotations are no longer tallied in auto grading.';
+
+    // The explanation is not rendered inline, only inside the (closed) popover.
+    assert.isFalse(popover().prop('open'));
+
+    // Clicking the info icon opens the popover with the explanation.
+    act(() => wrapper.find('IconButton').props().onClick());
+    wrapper.update();
+
+    assert.isTrue(popover().prop('open'));
+    assert.include(popover().text(), explanation);
+
+    // The popover can be dismissed.
+    act(() => popover().props().onClose());
+    wrapper.update();
+    assert.isFalse(popover().prop('open'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -53,6 +53,7 @@ describe('FilePickerApp', () => {
         formFields: { hidden_field: 'hidden_value' },
         promptForTitle: false,
         promptForGradable: false,
+        assignmentTypes: ['reading'],
       },
     };
 
@@ -110,6 +111,169 @@ describe('FilePickerApp', () => {
   it('renders content selector when content has not yet been selected', () => {
     const wrapper = renderFilePicker();
     assert.isTrue(wrapper.exists('ContentSelector'));
+  });
+
+  describe('assignment-type workflow', () => {
+    function clickNext(wrapper) {
+      interact(wrapper, () => {
+        wrapper
+          .find('Button[data-testid="workflow-next-button"]')
+          .props()
+          .onClick();
+      });
+    }
+
+    function clickBack(wrapper) {
+      interact(wrapper, () => {
+        wrapper
+          .find('Button[data-testid="workflow-back-button"]')
+          .props()
+          .onClick();
+      });
+    }
+
+    function selectAssignmentType(wrapper, type) {
+      interact(wrapper, () => {
+        wrapper.find('AssignmentTypeSelector').props().onChange(type);
+      });
+    }
+
+    it('does not show the workflow when only one type is available', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading'];
+      const wrapper = renderFilePicker();
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('shows the assignment-type step first when several types are available', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      // The content selector is not shown until the workflow is complete.
+      assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    it('skips to content selection for a "reading" assignment', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // The default assignment type is "reading".
+      clickNext(wrapper);
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('walks through checkpoint and due-date steps for "Hide & Reveal"', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper);
+
+      // Checkpoint step.
+      assert.isTrue(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+      clickNext(wrapper);
+
+      // Due-date step.
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+      clickNext(wrapper);
+
+      // Regular flow takes over.
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('does not offer a "Back" button on the first step', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(
+        wrapper.exists('Button[data-testid="workflow-back-button"]'),
+      );
+    });
+
+    it('goes back through the "Hide & Reveal" steps', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      clickBack(wrapper); // -> checkpoint
+      assert.isTrue(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+
+      clickBack(wrapper); // -> assignment-type
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+    });
+
+    it('shows a step-specific card title', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+      const cardTitle = () => wrapper.find('CardHeader').prop('title');
+
+      // Assignment-type step.
+      assert.equal(cardTitle(), 'Assignment mode');
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      assert.equal(cardTitle(), 'Guided Social Annotation');
+
+      clickNext(wrapper); // -> due-date
+      assert.equal(cardTitle(), 'Guided Social Annotation');
+
+      clickNext(wrapper); // -> regular flow
+      assert.equal(cardTitle(), 'Assignment details');
+    });
+
+    it('returns to the assignment-type step via the header close button', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // The mode-selection step itself offers no close button.
+      assert.isNotOk(wrapper.find('CardHeader').prop('onClose'));
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      // The header exposes a close handler during the Guided sub-steps.
+      const onClose = wrapper.find('CardHeader').prop('onClose');
+      assert.isFunction(onClose);
+      interact(wrapper, () => onClose());
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+    });
+
+    it('recomputes the branch when the type is changed after going back', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // Enter the Hide & Reveal branch...
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickBack(wrapper); // -> assignment-type
+
+      // ...then switch to a regular reading assignment.
+      selectAssignmentType(wrapper, 'reading');
+      clickNext(wrapper); // -> done (skips checkpoint/due-date)
+
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
   });
 
   function selectContent(wrapper, content) {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -2,6 +2,7 @@ import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 
 import type { AutoGradingConfig } from './api-types';
+import type { AssignmentType } from './components/AssignmentTypeSelector';
 import type { AppLaunchServerErrorCode, OAuthServerErrorCode } from './errors';
 
 /**
@@ -87,6 +88,15 @@ export type FilePickerConfig = {
   promptForTitle: boolean;
   promptForGradable: boolean;
   autoGradingEnabled: boolean;
+  /**
+   * The assignment types the instructor can choose from when configuring this
+   * assignment. The backend decides availability (e.g. via feature flags);
+   * `reading` is always present. When more than one type is offered, the file
+   * picker shows an initial "assignment type" selection step before the regular
+   * flow; with a single type that step is skipped. The backend that sets this
+   * is still pending, so it is optional for now.
+   */
+  assignmentTypes?: AssignmentType[];
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;
   blackboard: {


### PR DESCRIPTION
## Hide & Reveal — frontend (assignment-type workflow)

  Adds the UI for the new "Hide & Reveal" (Guided Social annotation) assignment
  workflow to the file picker. The feature is **dormant in production**: it only
  activates once the backend starts sending the `assignmentTypes` contract, which
  lands in a follow-up PR.

  ### What's included 

  - **New components**
    - `AssignmentTypeSelector` — first step: choose the assignment mode
      (Social annotation vs Guided Social annotation), driven by the
      backend-provided list of available types.
    - `CheckpointSelector` — Guided sub-step: how hidden annotations get revealed
      (`manual` for now, with a placeholder for future types).
    - `DueDateSelector` — Guided sub-step: due date, with the explanation shown in
      an info tooltip (mirrors the existing "Max points" popover).
  - **`FilePickerApp`** — a multi-step workflow (type selection → checkpoint →
    due date) shown *before* the regular content/details flow. The existing file
    picker flow is moved verbatim and unchanged; navigation adds Back/Next and a
    header close button to return to mode selection.
  - **`config.ts`** — adds the optional `assignmentTypes` field to
    `FilePickerConfig`.
  
  ### Dormant by design

  When the backend omits `assignmentTypes`, the picker falls back to `['reading']`,
  so `enableTypeWorkflow` is `false` and **the workflow is never shown**. This
  keeps the regular file picker behaviour byte-for-byte identical for all current
  users until the backend opts an install in.

  ### Out of scope (follow-up backend PR)

  - Per-install feature flag + emitting `assignmentTypes` from the backend.
  - Wiring the workflow selections (`assignmentType`, `checkpointType`, `dueDate`)
    into the submission payload — currently collected in state but not submitted.
  - Editing an existing Hide & Reveal assignment.

  ### Testing

  - Unit tests for the three new components and the workflow in `FilePickerApp`.
  - Full frontend suite green (1127 tests), 100% coverage, typecheck clean.