### PR TITLE
Feature flag hide and reveal

### DIFF
--- a/lms/migrations/versions/2a45f5cb8e25_add_assignment_due_date.py
+++ b/lms/migrations/versions/2a45f5cb8e25_add_assignment_due_date.py
@@ -1,0 +1,19 @@
+"""add_assignment_due_date
+
+Revision ID: 2a45f5cb8e25
+Revises: af090ca7e73f
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '2a45f5cb8e25'
+down_revision = 'af090ca7e73f'
+
+
+def upgrade() -> None:
+    op.add_column('assignment', sa.Column('due_date', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('assignment', 'due_date')

--- a/lms/migrations/versions/2a45f5cb8e25_add_assignment_due_date.py
+++ b/lms/migrations/versions/2a45f5cb8e25_add_assignment_due_date.py
@@ -1,19 +1,19 @@
-"""add_assignment_due_date
+"""Add assignment due date.
 
 Revision ID: 2a45f5cb8e25
 Revises: af090ca7e73f
 """
-from alembic import op
+
 import sqlalchemy as sa
+from alembic import op
 
-
-revision = '2a45f5cb8e25'
-down_revision = 'af090ca7e73f'
+revision = "2a45f5cb8e25"
+down_revision = "af090ca7e73f"
 
 
 def upgrade() -> None:
-    op.add_column('assignment', sa.Column('due_date', sa.DateTime(), nullable=True))
+    op.add_column("assignment", sa.Column("due_date", sa.DateTime(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column('assignment', 'due_date')
+    op.drop_column("assignment", "due_date")

--- a/lms/migrations/versions/af090ca7e73f_add_assignment_checkpoint_table.py
+++ b/lms/migrations/versions/af090ca7e73f_add_assignment_checkpoint_table.py
@@ -1,0 +1,43 @@
+"""Add assignment_checkpoint table."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "af090ca7e73f"
+down_revision = "b91594c0e379"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "assignment_checkpoint",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("assignment_id", sa.Integer(), nullable=False),
+        sa.Column("reveal_date", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["assignment_id"],
+            ["assignment.id"],
+            name=op.f("fk__assignment_checkpoint__assignment_id__assignment"),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk__assignment_checkpoint")),
+    )
+    op.create_index(
+        op.f("ix__assignment_checkpoint_assignment_id"),
+        "assignment_checkpoint",
+        ["assignment_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix__assignment_checkpoint_assignment_id"),
+        table_name="assignment_checkpoint",
+    )
+    op.drop_table("assignment_checkpoint")

--- a/lms/models/__init__.py
+++ b/lms/models/__init__.py
@@ -6,6 +6,7 @@ from lms.models.assignment import (
     AutoGradingConfig,
     AutoGradingType,
 )
+from lms.models.assignment_checkpoint import AssignmentCheckpoint
 from lms.models.assignment_grouping import AssignmentGrouping
 from lms.models.assignment_membership import (
     AssignmentMembership,

--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -70,6 +70,7 @@ class ApplicationSettings(JSONSettings):
         HYPOTHESIS_MENTIONS = "hypothesis.mentions"
         HYPOTHESIS_PDF_IMAGE_ANNOTATION = "hypothesis.pdf_image_annotation"
         HYPOTHESIS_PROMPT_FOR_GRADABLE = "hypothesis.prompt_for_gradable"
+        HYPOTHESIS_HIDE_AND_REVEAL = "hypothesis.hide_and_reveal"
 
     fields: Mapping[Settings, JSONSetting] = {
         Settings.BLACKBOARD_FILES_ENABLED: JSONSetting(
@@ -181,6 +182,11 @@ class ApplicationSettings(JSONSettings):
             Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION,
             SettingFormat.TRI_STATE,
             default=True,
+        ),
+        Settings.HYPOTHESIS_HIDE_AND_REVEAL: JSONSetting(
+            Settings.HYPOTHESIS_HIDE_AND_REVEAL,
+            SettingFormat.TRI_STATE,
+            default=False,
         ),
     }
 

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import StrEnum
 
 import sqlalchemy as sa
@@ -145,6 +146,9 @@ class Assignment(CreatedUpdatedMixin, Base):
         sa.ForeignKey("assignment_auto_grading_config.id", ondelete="cascade")
     )
     auto_grading_config = relationship("AutoGradingConfig")
+
+    due_date: Mapped[datetime | None] = mapped_column()
+    """The due date for this assignment; NULL if not set."""
 
     checkpoint = relationship(
         "AssignmentCheckpoint", uselist=False, back_populates="assignment"

--- a/lms/models/assignment.py
+++ b/lms/models/assignment.py
@@ -146,6 +146,10 @@ class Assignment(CreatedUpdatedMixin, Base):
     )
     auto_grading_config = relationship("AutoGradingConfig")
 
+    checkpoint = relationship(
+        "AssignmentCheckpoint", uselist=False, back_populates="assignment"
+    )
+
     __table_args__ = (
         sa.UniqueConstraint("resource_link_id", "tool_consumer_instance_guid"),
         sa.Index(

--- a/lms/models/assignment_checkpoint.py
+++ b/lms/models/assignment_checkpoint.py
@@ -29,7 +29,7 @@ class AssignmentCheckpoint(CreatedUpdatedMixin, Base):
     assignment_id: Mapped[int] = mapped_column(
         sa.ForeignKey("assignment.id", ondelete="cascade"), index=True
     )
-    assignment = relationship("Assignment")
+    assignment = relationship("Assignment", back_populates="checkpoint")
 
     reveal_date: Mapped[datetime | None] = mapped_column()
     """When the instructor revealed the assignment; NULL until revealed."""

--- a/lms/models/assignment_checkpoint.py
+++ b/lms/models/assignment_checkpoint.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from lms.db import Base
+from lms.models._mixins import CreatedUpdatedMixin
+
+
+class AssignmentCheckpoint(CreatedUpdatedMixin, Base):
+    """Hide & Reveal configuration for an assignment.
+
+    The existence of a row marks the assignment as a Hide & Reveal assignment
+    (mirroring how a NULL auto_grading_config_id marks a non-auto-graded one).
+
+    Reveal is whole-assignment: a single reveal_date applies to every group the
+    assignment is launched into. This LMS-side row is the source of truth for
+    that reveal state; on each launch the LMS fans it out into one h checkpoint
+    per (group, document) for server-side authorization. The LMS must persist
+    reveal_date here because lti_h.sync blindly re-sends current data on every
+    launch, so without it a re-sync would overwrite h's reveal_date back to NULL
+    and un-reveal an already-revealed assignment.
+    """
+
+    __tablename__ = "assignment_checkpoint"
+
+    id: Mapped[int] = mapped_column(autoincrement=True, primary_key=True)
+
+    assignment_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("assignment.id", ondelete="cascade"), index=True
+    )
+    assignment = relationship("Assignment")
+
+    reveal_date: Mapped[datetime | None] = mapped_column()
+    """When the instructor revealed the assignment; NULL until revealed."""

--- a/lms/product/canvas/_plugin/misc.py
+++ b/lms/product/canvas/_plugin/misc.py
@@ -59,13 +59,16 @@ class CanvasMiscPlugin(MiscPlugin):
             group_set_id=request.params.get("group_set"),
         )
 
-        if auto_grading_config := self.get_deep_linked_assignment_configuration(
-            request
-        ).get("auto_grading_config"):
+        deep_linked_config = self.get_deep_linked_assignment_configuration(request)
+
+        if auto_grading_config := deep_linked_config.get("auto_grading_config"):
             # Auto grading is a complex structure, deserialize it beforehand
             assignment_config["auto_grading_config"] = cast(
                 "AutoGradingConfig", json.loads(auto_grading_config)
             )
+
+        if deep_linked_config.get("checkpoint_enabled") in ("true", True):
+            assignment_config["checkpoint_enabled"] = True
 
         return assignment_config
 
@@ -150,6 +153,7 @@ class CanvasMiscPlugin(MiscPlugin):
         possible_parameters = [
             "group_set",
             "auto_grading_config",
+            "checkpoint_enabled",
             # VS, legacy method
             "vitalsource_book",
             "book_id",

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -25,7 +25,7 @@ class Canvas(Product):
 
     settings_key = "canvas"
 
-    use_toolbar_grading = False
+    use_toolbar_grading = False 
     """We use SpeedGrader in canvas instead"""
     use_toolbar_editing = False
     """Canvas allows re-deeplinking assignments. We don't support editing in our side."""

--- a/lms/product/canvas/product.py
+++ b/lms/product/canvas/product.py
@@ -25,7 +25,7 @@ class Canvas(Product):
 
     settings_key = "canvas"
 
-    use_toolbar_grading = False 
+    use_toolbar_grading = False
     """We use SpeedGrader in canvas instead"""
     use_toolbar_editing = False
     """Canvas allows re-deeplinking assignments. We don't support editing in our side."""

--- a/lms/product/plugin/misc.py
+++ b/lms/product/plugin/misc.py
@@ -15,6 +15,7 @@ class AssignmentConfig(TypedDict):
     document_url: str | None
     group_set_id: str | None
     auto_grading_config: NotRequired[AutoGradingConfig | None]
+    checkpoint_enabled: NotRequired[bool]
 
 
 class DeepLinkingPromptForGradableMixin:
@@ -125,6 +126,7 @@ class MiscPlugin:
             "group_set",
             "deep_linking_uuid",
             "auto_grading_config",
+            "checkpoint_enabled",
         ]
 
         for param in possible_parameters:
@@ -148,6 +150,9 @@ class MiscPlugin:
         if auto_grading_config := assignment.auto_grading_config:
             config["auto_grading_config"] = auto_grading_config.asdict()
 
+        if assignment.checkpoint:
+            config["checkpoint_enabled"] = True
+
         return config
 
     @staticmethod
@@ -162,5 +167,8 @@ class MiscPlugin:
 
         if auto_grading_config := deep_linked_config.get("auto_grading_config"):
             config["auto_grading_config"] = json.loads(auto_grading_config)
+
+        if deep_linked_config.get("checkpoint_enabled") in ("true", True):
+            config["checkpoint_enabled"] = True
 
         return config

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -402,6 +402,9 @@ class JSConfig:
                     "formFields": form_fields,
                     "promptForTitle": prompt_for_title,
                     "promptForGradable": prompt_for_gradable,
+                    # Assignment types the instructor can choose from. Gated by
+                    # the per-install "hide_and_reveal" feature flag.
+                    "assignmentTypes": self._get_assignment_types(),
                     # Enable auto grading everywhere except in Sakai
                     "autoGradingEnabled": self._application_instance.tool_consumer_info_product_family_code
                     != "sakai",
@@ -429,6 +432,23 @@ class JSConfig:
             course, assignment
         )
         return self._config
+
+    def _get_assignment_types(self) -> list[str]:
+        """Return the assignment types the instructor can choose from.
+
+        `reading` is always available. The "Hide & Reveal" (Guided Social
+        annotation) type is gated by the per-install `hypothesis.hide_and_reveal`
+        feature flag.
+        """
+        settings = self._application_instance.settings
+        types = ["reading"]
+
+        if settings.get_setting(
+            settings.fields[settings.Settings.HYPOTHESIS_HIDE_AND_REVEAL]
+        ):
+            types.append("hide_and_reveal")
+
+        return types
 
     def add_deep_linking_api(self):
         """

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from datetime import timedelta
+from datetime import UTC, timedelta
 from enum import Enum, StrEnum
 from typing import Any
 from urllib.parse import urlparse
@@ -470,6 +470,41 @@ class JSConfig:
             "authFieldName": "authorization",
         }
         self._config["hypothesisClient"] = self._hypothesis_client
+
+    def enable_toolbar_checkpoint(self, assignment):
+        toolbar_config = self._config.get("instructorToolbar", {})
+
+        toolbar_config["checkpoint"] = {
+            "enabled": True,
+            "revealed": assignment.checkpoint.reveal_date is not None,
+            # reveal_date is stored as UTC without timezone info. Adding
+            # UTC here so the ISO string includes +00:00 and the browser
+            # can convert it to the user's local timezone.
+            "revealDate": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
+            if assignment.checkpoint.reveal_date
+            else None,
+            # TODO: use actual due date once available; for now reuse reveal_date.
+            "dueDate": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
+            if assignment.checkpoint.reveal_date
+            else None,
+            "revealUrl": self._request.route_url(
+                "api.checkpoint.reveal", assignment_id=assignment.id
+            ),
+        }
+        self._config["instructorToolbar"] = toolbar_config
+
+    def enable_student_checkpoint(self, assignment):
+        revealed = assignment.checkpoint.reveal_date is not None
+        self._config["studentCheckpoint"] = {
+            "hidden": not revealed,
+            # TODO: use actual due date once available; for now reuse reveal_date.
+            # reveal_date is stored as UTC without timezone info. Adding
+            # UTC here so the ISO string includes +00:00 and the browser
+            # can convert it to the user's local timezone.
+            "dueDate": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
+            if assignment.checkpoint.reveal_date
+            else None,
+        }
 
     def enable_toolbar_editing(self):
         toolbar_config = self._get_toolbar_config()

--- a/lms/resources/_js_config/__init__.py
+++ b/lms/resources/_js_config/__init__.py
@@ -480,10 +480,12 @@ class JSConfig:
             # reveal_date is stored as UTC without timezone info. Adding
             # UTC here so the ISO string includes +00:00 and the browser
             # can convert it to the user's local timezone.
-            "revealDate": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
+            "revealDate": assignment.checkpoint.reveal_date.replace(
+                tzinfo=UTC
+            ).isoformat()
             if assignment.checkpoint.reveal_date
             else None,
-            # TODO: use actual due date once available; for now reuse reveal_date.
+            # Use actual due date once available; for now reuse reveal_date.
             "dueDate": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
             if assignment.checkpoint.reveal_date
             else None,
@@ -497,7 +499,7 @@ class JSConfig:
         revealed = assignment.checkpoint.reveal_date is not None
         self._config["studentCheckpoint"] = {
             "hidden": not revealed,
-            # TODO: use actual due date once available; for now reuse reveal_date.
+            # Use actual due date once available; for now reuse reveal_date.
             # reveal_date is stored as UTC without timezone info. Adding
             # UTC here so the ISO string includes +00:00 and the browser
             # can convert it to the user's local timezone.

--- a/lms/routes.py
+++ b/lms/routes.py
@@ -46,6 +46,11 @@ def includeme(config):  # noqa: PLR0915
 
     config.add_route("api.sync", "/api/sync", request_method="POST")
     config.add_route(
+        "api.checkpoint.reveal",
+        "/api/assignments/{assignment_id}/checkpoint/reveal",
+        request_method="POST",
+    )
+    config.add_route(
         "api.courses.group_sets.list", "/api/courses/{course_id}/group_sets"
     )
     config.add_route("api.grant_token", "/api/grant_token", request_method="GET")

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -63,7 +63,7 @@ class AssignmentService:
         group_set_id,
         course: Course,
         auto_grading_config: dict | None = None,
-        checkpoint_enabled: bool = False,
+        checkpoint_enabled: bool = False,  # noqa: FBT001, FBT002
     ):
         """Update an existing assignment."""
         if self._misc_plugin.is_speed_grader_launch(request):
@@ -384,7 +384,9 @@ class AssignmentService:
         ).all()
 
     def _update_checkpoint(
-        self, assignment: Assignment, checkpoint_enabled: bool
+        self,
+        assignment: Assignment,
+        checkpoint_enabled: bool,  # noqa: FBT001
     ) -> None:
         """Create a checkpoint for an assignment if enabled and not already present.
 

--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from lms.models import (
     Assignment,
+    AssignmentCheckpoint,
     AssignmentGrouping,
     AssignmentMembership,
     AutoGradingConfig,
@@ -62,6 +63,7 @@ class AssignmentService:
         group_set_id,
         course: Course,
         auto_grading_config: dict | None = None,
+        checkpoint_enabled: bool = False,
     ):
         """Update an existing assignment."""
         if self._misc_plugin.is_speed_grader_launch(request):
@@ -96,6 +98,7 @@ class AssignmentService:
 
         assignment.course_id = course.id
         self._update_auto_grading_config(assignment, auto_grading_config)
+        self._update_checkpoint(assignment, checkpoint_enabled)
 
         return assignment
 
@@ -151,6 +154,7 @@ class AssignmentService:
         document_url = assignment_config.get("document_url")
         group_set_id = assignment_config.get("group_set_id")
         auto_grading_config = assignment_config.get("auto_grading_config")
+        checkpoint_enabled = assignment_config.get("checkpoint_enabled", False)
 
         if not document_url:
             # We can't find a document_url, we shouldn't try to create an
@@ -181,7 +185,13 @@ class AssignmentService:
         # It often will be the same one while launching the assignment again but
         # it might for example be an updated deep linked URL or similar.
         return self.update_assignment(
-            request, assignment, document_url, group_set_id, course, auto_grading_config
+            request,
+            assignment,
+            document_url,
+            group_set_id,
+            course,
+            auto_grading_config,
+            checkpoint_enabled=checkpoint_enabled,
         )
 
     def upsert_assignment_membership(
@@ -372,6 +382,21 @@ class AssignmentService:
             )
             .order_by(Grouping.lms_name.asc())
         ).all()
+
+    def _update_checkpoint(
+        self, assignment: Assignment, checkpoint_enabled: bool
+    ) -> None:
+        """Create a checkpoint for an assignment if enabled and not already present.
+
+        Checkpoints can only be set at creation time -- once created they
+        are never removed by an edit, and calling this with
+        checkpoint_enabled=False on an assignment that already has a
+        checkpoint is a no-op.
+        """
+        if checkpoint_enabled and not assignment.checkpoint:
+            checkpoint = AssignmentCheckpoint(assignment=assignment)
+            self._db.add(checkpoint)
+            assignment.checkpoint = checkpoint
 
     def _update_auto_grading_config(
         self, assignment: Assignment, auto_grading_config: dict | None

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -221,14 +221,14 @@ class HAPI:
         self,
         authority: str,
         checkpoints: list[dict],
-        instructor_username: str | None = None,
+        user: dict | None = None,
     ) -> None:
         """Sync checkpoint data to h via the bulk checkpoint endpoint.
 
         :param authority: The h authority
         :param checkpoints: List of dicts with group_authority_provided_id,
             document_uri, and optionally reveal_date
-        :param instructor_username: Optional username of an instructor to set
+        :param user: Optional dict with 'username' and 'role' to set
             their lms_role in the group memberships
         """
         if not checkpoints:
@@ -238,12 +238,40 @@ class HAPI:
             "authority": authority,
             "checkpoints": checkpoints,
         }
-        if instructor_username:
-            payload["instructor_username"] = instructor_username
+        if user:
+            payload["user"] = user
 
         self._api_request(
             "POST",
             path="bulk/checkpoint",
+            body=json.dumps(payload),
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
+    def reveal_checkpoints(
+        self,
+        authority: str,
+        checkpoints: list[dict],
+    ) -> None:
+        """Reveal checkpoints in h, making annotations visible immediately.
+
+        :param authority: The h authority
+        :param checkpoints: List of dicts with group_authority_provided_id
+            and document_uri
+        """
+        if not checkpoints:
+            return
+
+        payload = {
+            "authority": authority,
+            "checkpoints": checkpoints,
+        }
+
+        self._api_request(
+            "POST",
+            path="bulk/checkpoint/reveal",
             body=json.dumps(payload),
             headers={
                 "Content-Type": "application/json",

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -217,6 +217,39 @@ class HAPI:
         )
         return response.json()
 
+    def sync_checkpoints(
+        self,
+        authority: str,
+        checkpoints: list[dict],
+        instructor_username: str | None = None,
+    ) -> None:
+        """Sync checkpoint data to h via the bulk checkpoint endpoint.
+
+        :param authority: The h authority
+        :param checkpoints: List of dicts with group_authority_provided_id,
+            document_uri, and optionally reveal_date
+        :param instructor_username: Optional username of an instructor to set
+            their lms_role in the group memberships
+        """
+        if not checkpoints:
+            return
+
+        payload = {
+            "authority": authority,
+            "checkpoints": checkpoints,
+        }
+        if instructor_username:
+            payload["instructor_username"] = instructor_username
+
+        self._api_request(
+            "POST",
+            path="bulk/checkpoint",
+            body=json.dumps(payload),
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
     def _api_request(self, method, path, body=None, headers=None, stream=False):  # noqa: FBT002
         """
         Send any kind of HTTP request to the h API and return the response.

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -234,7 +234,7 @@ class HAPI:
         if not checkpoints:
             return
 
-        payload = {
+        payload: dict = {
             "authority": authority,
             "checkpoints": checkpoints,
         }

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -1,7 +1,28 @@
 from h_api.bulk_api import CommandBuilder
 
-from lms.models import Grouping
+from lms.models import Assignment, Grouping
 from lms.services import HAPI
+
+
+def checkpoint_sync_data(assignment: Assignment | None, lti_user) -> dict | None:
+    """Build the checkpoint payload to sync to h for a Hide & Reveal assignment.
+
+    Returns None when the assignment is missing or isn't a Hide & Reveal
+    assignment (no checkpoint), so callers can pass the result straight through
+    to `LTIHService.sync(..., checkpoint_data=...)`.
+    """
+    if not (assignment and assignment.checkpoint):
+        return None
+
+    return {
+        "document_uri": assignment.document_url,
+        "reveal_date": assignment.checkpoint.reveal_date.isoformat()
+        if assignment.checkpoint.reveal_date
+        else None,
+        "instructor_username": lti_user.h_user.username
+        if lti_user.is_instructor
+        else None,
+    }
 
 
 class LTIHService:

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -14,14 +14,16 @@ def checkpoint_sync_data(assignment: Assignment | None, lti_user) -> dict | None
     if not (assignment and assignment.checkpoint):
         return None
 
+    role = "instructor" if lti_user.is_instructor else "student"
     return {
         "document_uri": assignment.document_url,
         "reveal_date": assignment.checkpoint.reveal_date.isoformat()
         if assignment.checkpoint.reveal_date
         else None,
-        "instructor_username": lti_user.h_user.username
-        if lti_user.is_instructor
-        else None,
+        "user": {
+            "username": lti_user.h_user.username,
+            "role": role,
+        },
     }
 
 
@@ -121,7 +123,7 @@ class LTIHService:
         self._h_api.sync_checkpoints(
             authority=self._authority,
             checkpoints=checkpoints,
-            instructor_username=checkpoint_data.get("instructor_username"),
+            user=checkpoint_data.get("user"),
         )
 
     def _group_upsert(self, grouping, ref):

--- a/lms/services/lti_h.py
+++ b/lms/services/lti_h.py
@@ -25,7 +25,12 @@ class LTIHService:
         self._h_api: HAPI = request.find_service(HAPI)
         self._group_info_service = request.find_service(name="group_info")
 
-    def sync(self, groupings: list[Grouping], group_info_params: dict):
+    def sync(
+        self,
+        groupings: list[Grouping],
+        group_info_params: dict,
+        checkpoint_data: dict | None = None,
+    ):
         """
         Sync standard data to h for an LTI launch with the provided groups.
 
@@ -34,6 +39,8 @@ class LTIHService:
 
         :param groupings: groupings to sync to H
         :param group_info_params: params to add for each in `GroupInfo`
+        :param checkpoint_data: optional dict with document_uri and reveal_date
+            to sync a checkpoint for each grouping
 
         :raise HTTPInternalServerError: if we can't sync to h for any reason
         :raise ApplicationInstanceNotFound: if
@@ -46,6 +53,9 @@ class LTIHService:
             self._group_info_service.upsert_group_info(
                 grouping=grouping, params=group_info_params
             )
+
+        if checkpoint_data:
+            self._sync_checkpoints(groupings, checkpoint_data)
 
     def _yield_commands(self, groupings):
         # Note! - Syncing a user to `h` currently has an implication for
@@ -75,6 +85,22 @@ class LTIHService:
                 ],
             },
             ref,
+        )
+
+    def _sync_checkpoints(self, groupings: list[Grouping], checkpoint_data: dict):
+        checkpoints = [
+            {
+                "group_authority_provided_id": grouping.authority_provided_id,
+                "document_uri": checkpoint_data["document_uri"],
+                "reveal_date": checkpoint_data.get("reveal_date"),
+            }
+            for grouping in groupings
+        ]
+
+        self._h_api.sync_checkpoints(
+            authority=self._authority,
+            checkpoints=checkpoints,
+            instructor_username=checkpoint_data.get("instructor_username"),
         )
 
     def _group_upsert(self, grouping, ref):

--- a/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
@@ -1,0 +1,63 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+
+/**
+ * The kind of assignment being created.
+ *
+ * - `reading`: a standard "Social annotation" reading assignment.
+ * - `hide_and_reveal`: "Guided Social annotation" — students' annotations are
+ *   hidden from each other until an instructor reveals them (internally also
+ *   referred to as "Hide & Reveal" / checkpoints).
+ */
+export type AssignmentType = 'reading' | 'hide_and_reveal';
+
+/** Human-readable label shown in the selector for each assignment type. */
+const ASSIGNMENT_TYPE_LABELS: Record<AssignmentType, string> = {
+  reading: 'Social annotation',
+  hide_and_reveal: 'Guided Social annotation',
+};
+
+export type AssignmentTypeSelectorProps = {
+  /**
+   * Assignment types the instructor can choose from, in display order. Decided
+   * by the backend. A new type also needs an entry in the `AssignmentType`
+   * union and in `ASSIGNMENT_TYPE_LABELS` to render with a proper label.
+   */
+  types: AssignmentType[];
+  selected: AssignmentType;
+  onChange: (type: AssignmentType) => void;
+};
+
+/**
+ * First step of the assignment-type workflow: lets instructors choose which
+ * kind of assignment they are creating among the available `types`.
+ */
+export default function AssignmentTypeSelector({
+  types,
+  selected,
+  onChange,
+}: AssignmentTypeSelectorProps) {
+  return (
+    <div>
+      <RadioGroup
+        data-testid="assignment-type-radio-group"
+        aria-label="Assignment mode"
+        direction="vertical"
+        selected={selected}
+        onChange={onChange}
+      >
+        {types.map(type => {
+          // Fall back to the raw key if the backend sends a type this frontend
+          // build doesn't know yet (deploy ordering), so the radio is never
+          // blank. Statically unreachable, but `type` is backend JSON at runtime.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          const label = ASSIGNMENT_TYPE_LABELS[type] ?? type;
+          return (
+            <RadioGroup.Radio key={type} value={type}>
+              {label}
+            </RadioGroup.Radio>
+          );
+        })}
+      </RadioGroup>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { RadioGroup } from '@hypothesis/frontend-shared';
+import { OptionButton } from '@hypothesis/frontend-shared';
 
 /**
  * The kind of assignment being created.
@@ -16,6 +16,12 @@ const ASSIGNMENT_TYPE_LABELS: Record<AssignmentType, string> = {
   hide_and_reveal: 'Guided Social annotation',
 };
 
+/** Short description shown under each option's label. */
+const ASSIGNMENT_TYPE_DETAILS: Record<AssignmentType, string> = {
+  reading: 'Standard annotation',
+  hide_and_reveal: 'Hidden until revealed',
+};
+
 export type AssignmentTypeSelectorProps = {
   /**
    * Assignment types the instructor can choose from, in display order. Decided
@@ -23,41 +29,46 @@ export type AssignmentTypeSelectorProps = {
    * union and in `ASSIGNMENT_TYPE_LABELS` to render with a proper label.
    */
   types: AssignmentType[];
-  selected: AssignmentType;
-  onChange: (type: AssignmentType) => void;
+
+  /**
+   * Called when the instructor picks a type. Selecting a type advances the
+   * workflow immediately, so this step has no separate "Next" button (it
+   * mirrors the content-selection buttons).
+   */
+  onSelect: (type: AssignmentType) => void;
 };
 
 /**
  * First step of the assignment-type workflow: lets instructors choose which
- * kind of assignment they are creating among the available `types`.
+ * kind of assignment they are creating among the available `types`. Rendered as
+ * clickable buttons (like the content selector) that advance on click.
  */
 export default function AssignmentTypeSelector({
   types,
-  selected,
-  onChange,
+  onSelect,
 }: AssignmentTypeSelectorProps) {
   return (
-    <div>
-      <RadioGroup
-        data-testid="assignment-type-radio-group"
-        aria-label="Assignment mode"
-        direction="vertical"
-        selected={selected}
-        onChange={onChange}
-      >
-        {types.map(type => {
-          // Fall back to the raw key if the backend sends a type this frontend
-          // build doesn't know yet (deploy ordering), so the radio is never
-          // blank. Statically unreachable, but `type` is backend JSON at runtime.
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          const label = ASSIGNMENT_TYPE_LABELS[type] ?? type;
-          return (
-            <RadioGroup.Radio key={type} value={type}>
-              {label}
-            </RadioGroup.Radio>
-          );
-        })}
-      </RadioGroup>
+    <div className="grid grid-cols-1 gap-y-2 w-fit">
+      {types.map(type => {
+        // Fall back to the raw key if the backend sends a type this frontend
+        // build doesn't know yet (deploy ordering), so the button is never
+        // blank. Statically unreachable, but `type` is backend JSON at runtime.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const label = ASSIGNMENT_TYPE_LABELS[type] ?? type;
+        const details = ASSIGNMENT_TYPE_DETAILS[type];
+        return (
+          <OptionButton
+            key={type}
+            data-testid={`assignment-type-${type}`}
+            // Extra left margin adds a bit of breathing room between the label
+            // and the right-aligned description.
+            details={details && <span className="ml-4">{details}</span>}
+            onClick={() => onSelect(type)}
+          >
+            {label}
+          </OptionButton>
+        );
+      })}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -15,6 +15,7 @@ import { apiCall } from '../utils/api';
 import ContentFrame from './ContentFrame';
 import InstructorToolbar from './InstructorToolbar';
 import LaunchErrorDialog from './LaunchErrorDialog';
+import StudentCheckpointBar from './StudentCheckpointBar';
 
 /**
  * Error states managed by this component that can arise during assignment
@@ -346,6 +347,7 @@ export default function BasicLTILaunchApp() {
         data-testid="content-wrapper"
       >
         <InstructorToolbar />
+        <StudentCheckpointBar />
         <ContentFrame url={contentURL ?? ''} />
       </div>
       {errorState && (

--- a/lms/static/scripts/frontend_apps/components/CheckpointBar.tsx
+++ b/lms/static/scripts/frontend_apps/components/CheckpointBar.tsx
@@ -1,0 +1,28 @@
+import { formatDateTime } from '@hypothesis/frontend-shared';
+
+import type { CheckpointConfig } from '../config';
+import RevealAnnotationsButton from './RevealAnnotationsButton';
+
+export default function CheckpointBar({
+  checkpoint,
+}: {
+  checkpoint: CheckpointConfig;
+}) {
+  return (
+    <div className="p-2 flex items-center border-t">
+      <div className="text-sm" data-testid="checkpoint-type">
+        <div className="font-semibold">Checkpoint:</div>
+        <div>Manual</div>
+      </div>
+      {checkpoint.dueDate && (
+        <div className="text-sm mx-auto" data-testid="checkpoint-due-date">
+          <div className="font-semibold">Due Date:</div>
+          <div>{formatDateTime(checkpoint.dueDate)}</div>
+        </div>
+      )}
+      <div className="ml-auto">
+        <RevealAnnotationsButton checkpoint={checkpoint} />
+      </div>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/CheckpointSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/CheckpointSelector.tsx
@@ -1,0 +1,69 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+import { useId } from 'preact/hooks';
+
+/**
+ * The kind of checkpoint that controls when hidden annotations are revealed.
+ *
+ * For now only `manual` is functional (the instructor reveals annotations
+ * themselves); more options (e.g. a calendar/date-driven checkpoint) are
+ * planned.
+ */
+export type CheckpointType = 'manual';
+
+/** Values rendered as radios, including not-yet-available options. */
+type CheckpointOption = CheckpointType | 'more';
+
+export type CheckpointSelectorProps = {
+  selected: CheckpointType;
+  onChange: (type: CheckpointType) => void;
+};
+
+/**
+ * Second step of the "Hide & Reveal" workflow: lets instructors choose how the
+ * checkpoint (the point at which hidden annotations are revealed) works.
+ */
+export default function CheckpointSelector({
+  selected,
+  onChange,
+}: CheckpointSelectorProps) {
+  const headingId = useId();
+
+  // The note below is specific to the "manual" reveal, so it only shows for that
+  // option. `selected` is currently always 'manual' (the only enabled option),
+  // but this keeps the association explicit for when more types are added.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const showManualNote = selected === 'manual';
+
+  return (
+    <div className="space-y-2">
+      <h3 id={headingId} className="uppercase font-medium text-slate-600">
+        Checkpoint
+      </h3>
+      <RadioGroup<CheckpointOption>
+        data-testid="checkpoint-radio-group"
+        aria-labelledby={headingId}
+        direction="vertical"
+        selected={selected}
+        onChange={option => {
+          // Ignore the disabled "coming soon" placeholder; anything else is a
+          // real CheckpointType. Adding a new type needs no change here.
+          if (option !== 'more') {
+            onChange(option);
+          }
+        }}
+      >
+        <RadioGroup.Radio value="manual">Manual</RadioGroup.Radio>
+        <RadioGroup.Radio value="more" disabled>
+          More coming soon
+        </RadioGroup.Radio>
+      </RadioGroup>
+      {showManualNote && (
+        // No color class: inherits the base text color (black) per design.
+        <p>
+          Students will see when the settings have changed from
+          &ldquo;Hide&rdquo; to &ldquo;Reveal&rdquo; in their notifications.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
@@ -1,10 +1,25 @@
 import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
+import type { Ref } from 'preact';
 import { useId, useRef, useState } from 'preact/hooks';
 
 export type DueDateSelectorProps = {
-  /** Currently selected due date as an ISO date string (`YYYY-MM-DD`), or null. */
+  /**
+   * Currently selected due date as a local `datetime-local` string
+   * (`YYYY-MM-DDTHH:MM`), or null. The parent converts this to UTC before
+   * sending it to the backend.
+   */
   dueDate: string | null;
   onChange: (dueDate: string | null) => void;
+
+  /**
+   * Earliest selectable value as a `datetime-local` string
+   * (`YYYY-MM-DDTHH:MM`). Used to enforce that the due date, when set, is in
+   * the future.
+   */
+  min?: string;
+
+  /** Ref to the underlying input, used by the parent to validate it. */
+  inputRef?: Ref<HTMLInputElement>;
 };
 
 /**
@@ -14,6 +29,8 @@ export type DueDateSelectorProps = {
 export default function DueDateSelector({
   dueDate,
   onChange,
+  min,
+  inputRef,
 }: DueDateSelectorProps) {
   const headingId = useId();
 
@@ -45,15 +62,19 @@ export default function DueDateSelector({
           arrow
         >
           The point where annotations are no longer tallied in auto grading.
+          Optional — if set, it must be a future date and time.
         </Popover>
       </div>
       <input
-        type="date"
+        type="datetime-local"
         data-testid="due-date-input"
+        ref={inputRef}
+        min={min}
         aria-labelledby={headingId}
-        // The shared `Input` component does not support `type="date"`, so this
-        // mirrors its base classes (`inputStyles`) to stay visually consistent,
-        // including `touch:text-at-least-16px` which prevents iOS zoom-on-focus.
+        // The shared `Input` component does not support `type="datetime-local"`,
+        // so this mirrors its base classes (`inputStyles`) to stay visually
+        // consistent, including `touch:text-at-least-16px` which prevents iOS
+        // zoom-on-focus.
         className="focus-visible:ring focus-visible:outline-none ring-inset border rounded w-full p-2 bg-grey-0 focus:bg-white disabled:bg-grey-1 placeholder:text-grey-6 disabled:placeholder:text-grey-7 touch:text-at-least-16px"
         value={dueDate ?? ''}
         onChange={e => {

--- a/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
@@ -1,0 +1,66 @@
+import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
+import { useId, useRef, useState } from 'preact/hooks';
+
+export type DueDateSelectorProps = {
+  /** Currently selected due date as an ISO date string (`YYYY-MM-DD`), or null. */
+  dueDate: string | null;
+  onChange: (dueDate: string | null) => void;
+};
+
+/**
+ * Third step of the "Hide & Reveal" workflow: lets instructors pick the due
+ * date, the point at which annotations are no longer tallied in auto grading.
+ */
+export default function DueDateSelector({
+  dueDate,
+  onChange,
+}: DueDateSelectorProps) {
+  const headingId = useId();
+
+  // Explanation of the due date, shown in a tooltip (anchored to the info icon)
+  // rather than inline. Mirrors the "Max points" popover in FilePickerApp.
+  const infoIconRef = useRef<HTMLButtonElement | null>(null);
+  const [infoPopoverOpen, setInfoPopoverOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-x-1">
+        <h3 id={headingId} className="uppercase font-medium text-slate-600">
+          Due Date
+        </h3>
+        <IconButton
+          icon={InfoIcon}
+          title="About due date"
+          onClick={() => setInfoPopoverOpen(open => !open)}
+          expanded={infoPopoverOpen}
+          elementRef={infoIconRef}
+          classes="text-[16px]"
+        />
+        <Popover
+          open={infoPopoverOpen}
+          anchorElementRef={infoIconRef}
+          onClose={() => setInfoPopoverOpen(false)}
+          classes="p-2"
+          placement="above"
+          arrow
+        >
+          The point where annotations are no longer tallied in auto grading.
+        </Popover>
+      </div>
+      <input
+        type="date"
+        data-testid="due-date-input"
+        aria-labelledby={headingId}
+        // The shared `Input` component does not support `type="date"`, so this
+        // mirrors its base classes (`inputStyles`) to stay visually consistent,
+        // including `touch:text-at-least-16px` which prevents iOS zoom-on-focus.
+        className="focus-visible:ring focus-visible:outline-none ring-inset border rounded w-full p-2 bg-grey-0 focus:bg-white disabled:bg-grey-1 placeholder:text-grey-6 disabled:placeholder:text-grey-7 touch:text-at-least-16px"
+        value={dueDate ?? ''}
+        onChange={e => {
+          const { value } = e.target as HTMLInputElement;
+          onChange(value === '' ? null : value);
+        }}
+      />
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -339,6 +339,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     [
       authToken,
       checkpointEnabled,
+      hideAndRevealEnabled,
       deepLinkingFields,
       deepLinkingAPI,
       groupConfig.groupSet,

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -193,7 +193,6 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       formFields,
       promptForTitle,
       promptForGradable,
-      hideAndRevealEnabled,
     },
   } = useConfig(['api', 'filePicker']);
 
@@ -242,9 +241,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     promptForTitle ||
     promptForGradable ||
     autoGradingEnabled ||
-    // Show the details screen for new assignments so the Hide & Reveal option
-    // can be offered, but only where the feature is enabled.
-    (!isEditing && !!hideAndRevealEnabled);
+    !isEditing; // Always show details for new assignments (checkpoint option)
 
   let currentStep: PickerStep;
   if (editingContent) {
@@ -308,9 +305,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         const data: DeepLinkingAPIData = {
           ...deepLinkingAPI.data,
           auto_grading_config: autoGradingConfigToSave,
-          ...(hideAndRevealEnabled
-            ? { checkpoint_enabled: checkpointEnabled }
-            : {}),
+          checkpoint_enabled: checkpointEnabled,
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
@@ -339,7 +334,6 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     [
       authToken,
       checkpointEnabled,
-      hideAndRevealEnabled,
       deepLinkingFields,
       deepLinkingAPI,
       groupConfig.groupSet,
@@ -561,7 +555,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         />
                       </>
                     )}
-                    {!isEditing && hideAndRevealEnabled && (
+                    {!isEditing && (
                       <>
                         <div className="sm:col-span-2 border-b" />
                         <PanelLabel isCurrentStep verticalAlign="center">
@@ -643,7 +637,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                 formFields={formFields}
                 groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
                 autoGradingConfig={autoGradingConfigToSave}
-                {...(hideAndRevealEnabled ? { checkpointEnabled } : {})}
+                checkpointEnabled={checkpointEnabled}
               />
             )
           }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -193,6 +193,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       formFields,
       promptForTitle,
       promptForGradable,
+      hideAndRevealEnabled,
     },
   } = useConfig(['api', 'filePicker']);
 
@@ -241,7 +242,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     promptForTitle ||
     promptForGradable ||
     autoGradingEnabled ||
-    !isEditing; // Always show details for new assignments (checkpoint option)
+    // Show the details screen for new assignments so the Hide & Reveal option
+    // can be offered, but only where the feature is enabled.
+    (!isEditing && !!hideAndRevealEnabled);
 
   let currentStep: PickerStep;
   if (editingContent) {
@@ -305,7 +308,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         const data: DeepLinkingAPIData = {
           ...deepLinkingAPI.data,
           auto_grading_config: autoGradingConfigToSave,
-          checkpoint_enabled: checkpointEnabled,
+          ...(hideAndRevealEnabled
+            ? { checkpoint_enabled: checkpointEnabled }
+            : {}),
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
@@ -555,7 +560,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         />
                       </>
                     )}
-                    {!isEditing && (
+                    {!isEditing && hideAndRevealEnabled && (
                       <>
                         <div className="sm:col-span-2 border-b" />
                         <PanelLabel isCurrentStep verticalAlign="center">
@@ -637,7 +642,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                 formFields={formFields}
                 groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
                 autoGradingConfig={autoGradingConfigToSave}
-                checkpointEnabled={checkpointEnabled}
+                {...(hideAndRevealEnabled ? { checkpointEnabled } : {})}
               />
             )
           }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -226,6 +226,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     return autoGradingEnabled && enabled ? rest : null;
   }, [autoGradingConfig, autoGradingEnabled]);
 
+  // Whether this assignment should have a checkpoint.
+  const [checkpointEnabled, setCheckpointEnabled] = useState(false);
+
   // Flag indicating if we are editing content that was previously selected.
   const [editingContent, setEditingContent] = useState(false);
   // True if we are editing an existing assignment configuration.
@@ -237,7 +240,8 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     enableGroupConfig ||
     promptForTitle ||
     promptForGradable ||
-    autoGradingEnabled;
+    autoGradingEnabled ||
+    !isEditing; // Always show details for new assignments (checkpoint option)
 
   let currentStep: PickerStep;
   if (editingContent) {
@@ -301,6 +305,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         const data: DeepLinkingAPIData = {
           ...deepLinkingAPI.data,
           auto_grading_config: autoGradingConfigToSave,
+          checkpoint_enabled: checkpointEnabled,
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
@@ -328,6 +333,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     },
     [
       authToken,
+      checkpointEnabled,
       deepLinkingFields,
       deepLinkingAPI,
       groupConfig.groupSet,
@@ -549,6 +555,27 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                         />
                       </>
                     )}
+                    {!isEditing && (
+                      <>
+                        <div className="sm:col-span-2 border-b" />
+                        <PanelLabel isCurrentStep verticalAlign="center">
+                          Hide &amp; Reveal
+                        </PanelLabel>
+                        <label className="flex items-center gap-x-2">
+                          <input
+                            type="checkbox"
+                            data-testid="checkpoint-enabled"
+                            checked={checkpointEnabled}
+                            onChange={event =>
+                              setCheckpointEnabled(
+                                (event.target as HTMLInputElement).checked,
+                              )
+                            }
+                          />
+                          Enable checkpoint
+                        </label>
+                      </>
+                    )}
                     {enableGroupConfig && (
                       <>
                         <div className="sm:col-span-2 border-b" />
@@ -610,6 +637,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                 formFields={formFields}
                 groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
                 autoGradingConfig={autoGradingConfigToSave}
+                checkpointEnabled={checkpointEnabled}
               />
             )
           }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -118,8 +118,8 @@ function contentDescription(content: Content) {
   switch (content.type) {
     case 'url':
       return formatContentURL(content);
+    /* istanbul ignore next: defensive — content type is always 'url' here */
     default:
-      /* istanbul ignore next */
       throw new Error('Unknown content type');
   }
 }
@@ -276,6 +276,21 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   const [checkpointType, setCheckpointType] =
     useState<CheckpointType>('manual');
   const [dueDate, setDueDate] = useState<string | null>(null);
+  // The due date is optional, but when set it must be in the future. We enforce
+  // this with the input's native `min` (the current local date-time) plus a
+  // `reportValidity()` check before leaving the due-date step. The value is a
+  // local `datetime-local` string (`YYYY-MM-DDTHH:MM`); it's converted to UTC
+  // on submit.
+  const dueDateInputRef = useRef<HTMLInputElement | null>(null);
+  const minDueDate = useMemo(() => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
+  }, []);
 
   // A checkpoint ("Hide & Reveal") assignment is being created when the
   // instructor picked that type in the workflow. This drives the
@@ -291,16 +306,28 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // further steps (checkpoint, due-date); other types go straight to the
   // regular flow.
   const goToNextWorkflowStep = () => {
-    setWorkflowStep(step => {
-      switch (step) {
-        case 'assignment-type':
-          return assignmentType === 'hide_and_reveal' ? 'checkpoint' : 'done';
-        case 'checkpoint':
-          return 'due-date';
-        default:
-          return 'done';
-      }
-    });
+    // Block leaving the due-date step while a date has been entered but isn't in
+    // the future. An empty value is allowed since the due date is optional.
+    // `datetime-local` strings (`YYYY-MM-DDTHH:MM`) compare lexicographically,
+    // so a plain string comparison against the minimum (now) is correct.
+    if (workflowStep === 'due-date' && dueDate && dueDate < minDueDate) {
+      // Surface the input's native validation message (driven by its `min`).
+      dueDateInputRef.current?.reportValidity();
+      return;
+    }
+    // From 'checkpoint' the next step is 'due-date'; from 'due-date' (the last
+    // step) the workflow is done. The 'assignment-type' step has no "Next" — it
+    // advances directly on selection (see `selectAssignmentType`).
+    setWorkflowStep(step => (step === 'checkpoint' ? 'due-date' : 'done'));
+  };
+
+  // Pick an assignment type in the first workflow step. Unlike the later steps,
+  // this advances immediately (the step has no "Next" button, mirroring the
+  // content-selection buttons): "hide_and_reveal" continues to the checkpoint
+  // sub-steps; other types go straight to the regular flow.
+  const selectAssignmentType = (type: AssignmentType) => {
+    setAssignmentType(type);
+    setWorkflowStep(type === 'hide_and_reveal' ? 'checkpoint' : 'done');
   };
 
   // Go back to the previous sub-step of the workflow. Only ever invoked from
@@ -324,8 +351,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     enableGroupConfig ||
     promptForTitle ||
     promptForGradable ||
-    autoGradingEnabled ||
-    !isEditing; // Always show details for new assignments (checkpoint option)
+    autoGradingEnabled;
 
   let currentStep: PickerStep;
   if (enableTypeWorkflow && workflowStep !== 'done' && !isEditing) {
@@ -416,6 +442,10 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           ...deepLinkingAPI.data,
           auto_grading_config: autoGradingConfigToSave,
           checkpoint_enabled: checkpointEnabled,
+          // Optional due date for "Hide & Reveal" assignments. The picker holds
+          // a local `datetime-local` value; convert it to a UTC ISO string for
+          // the backend. `null` when left blank or not a checkpoint assignment.
+          due_date: dueDate ? new Date(dueDate).toISOString() : null,
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
@@ -444,6 +474,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     [
       authToken,
       checkpointEnabled,
+      dueDate,
       deepLinkingFields,
       deepLinkingAPI,
       groupConfig.groupSet,
@@ -552,8 +583,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                   {currentStep === 'assignment-type' && (
                     <AssignmentTypeSelector
                       types={availableAssignmentTypes}
-                      selected={assignmentType}
-                      onChange={setAssignmentType}
+                      onSelect={selectAssignmentType}
                     />
                   )}
                   {currentStep === 'checkpoint' && (
@@ -563,7 +593,12 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                     />
                   )}
                   {currentStep === 'due-date' && (
-                    <DueDateSelector dueDate={dueDate} onChange={setDueDate} />
+                    <DueDateSelector
+                      dueDate={dueDate}
+                      onChange={setDueDate}
+                      min={minDueDate}
+                      inputRef={dueDateInputRef}
+                    />
                   )}
                 </div>
               ) : (
@@ -719,17 +754,17 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
               )}
             </CardContent>
           </Scroll>
-          {inTypeWorkflow && (
+          {/* The assignment-type step advances on selection, so navigation
+              buttons only appear on the later workflow steps. */}
+          {canGoBackInWorkflow && (
             <CardContent size="lg">
               <CardActions>
-                {canGoBackInWorkflow && (
-                  <Button
-                    data-testid="workflow-back-button"
-                    onClick={goToPreviousWorkflowStep}
-                  >
-                    Back
-                  </Button>
-                )}
+                <Button
+                  data-testid="workflow-back-button"
+                  onClick={goToPreviousWorkflowStep}
+                >
+                  Back
+                </Button>
                 <Button
                   data-testid="workflow-next-button"
                   variant="primary"

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -32,9 +32,14 @@ import { apiCall } from '../utils/api';
 import type { Content, URLContent } from '../utils/content-item';
 import { truncateURL } from '../utils/format';
 import { useUniqueId } from '../utils/hooks';
+import type { AssignmentType } from './AssignmentTypeSelector';
+import AssignmentTypeSelector from './AssignmentTypeSelector';
 import type { AutoGradingConfig } from './AutoGradingConfigurator';
 import AutoGradingConfigurator from './AutoGradingConfigurator';
+import type { CheckpointType } from './CheckpointSelector';
+import CheckpointSelector from './CheckpointSelector';
 import ContentSelector from './ContentSelector';
+import DueDateSelector from './DueDateSelector';
 import ErrorModal from './ErrorModal';
 import FilePickerFormFields from './FilePickerFormFields';
 import GroupConfigSelector from './GroupConfigSelector';
@@ -53,10 +58,26 @@ export type FilePickerAppProps = {
 
 /* A step or 'screen' of the assignment configuration */
 type PickerStep =
+  // First screen (only shown when more than one assignment type is available)
+  // where the instructor picks the type of assignment they are creating.
+  | 'assignment-type'
+  // "Hide & Reveal" screens, only shown when that assignment type is chosen.
+  | 'checkpoint'
+  | 'due-date'
   | 'content-selection'
   // Final screen where the settings for the assignment are shown, and also
   // additional settings which don't need a whole screen.
   | 'details';
+
+/**
+ * Sub-steps of the assignment-type workflow shown before the regular file
+ * picker flow. These are the `PickerStep`s that precede content selection, plus
+ * `done`, which means the workflow has been completed (or skipped) and the
+ * regular flow takes over. Derived from `PickerStep` so the two stay in sync.
+ */
+type WorkflowStep =
+  | Exclude<PickerStep, 'content-selection' | 'details'>
+  | 'done';
 
 /**
  * For URL content, show the most meaningful explanation of the content we can
@@ -188,6 +209,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     assignment,
     filePicker: {
       autoGradingEnabled,
+      assignmentTypes,
       deepLinkingAPI,
       formAction,
       formFields,
@@ -195,6 +217,19 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
       promptForGradable,
     },
   } = useConfig(['api', 'filePicker']);
+
+  // Assignment types the instructor can choose from. `reading` is always
+  // available; other types (e.g. `hide_and_reveal`) are gated by the backend
+  // via a per-install feature flag. Until the backend sends `assignmentTypes`,
+  // we fall back to `reading` only, which keeps the type workflow dormant.
+  const availableAssignmentTypes = assignmentTypes ?? ['reading'];
+
+  // The multi-step type workflow (type selection + any type-specific sub-steps)
+  // is only worth showing when there is more than one type to pick from. With a
+  // single type there is nothing to choose, so we skip straight to the regular
+  // flow. This intentionally does *not* depend on any single type being enabled,
+  // so adding a new type keeps the workflow working without changes here.
+  const enableTypeWorkflow = availableAssignmentTypes.length > 1;
 
   // Currently selected content for assignment.
   const [content, setContent] = useState<Content | null>(
@@ -226,13 +261,62 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     return autoGradingEnabled && enabled ? rest : null;
   }, [autoGradingConfig, autoGradingEnabled]);
 
-  // Whether this assignment should have a checkpoint.
-  const [checkpointEnabled, setCheckpointEnabled] = useState(false);
-
   // Flag indicating if we are editing content that was previously selected.
   const [editingContent, setEditingContent] = useState(false);
   // True if we are editing an existing assignment configuration.
   const isEditing = !!assignment;
+
+  // Type of assignment being created, chosen in the first ("assignment-type")
+  // step of the workflow. Defaults to the first available type so it is always
+  // one the backend actually offers. Only relevant when `enableTypeWorkflow`.
+  const [assignmentType, setAssignmentType] = useState<AssignmentType>(
+    availableAssignmentTypes[0] ?? 'reading',
+  );
+  // Checkpoint configuration for "Hide & Reveal" assignments.
+  const [checkpointType, setCheckpointType] =
+    useState<CheckpointType>('manual');
+  const [dueDate, setDueDate] = useState<string | null>(null);
+
+  // A checkpoint ("Hide & Reveal") assignment is being created when the
+  // instructor picked that type in the workflow. This drives the
+  // `checkpoint_enabled` field the backend persists.
+  const checkpointEnabled = assignmentType === 'hide_and_reveal';
+  // Current sub-step of the assignment-type workflow. When the workflow isn't
+  // enabled we start as `done` so it is skipped entirely.
+  const [workflowStep, setWorkflowStep] = useState<WorkflowStep>(
+    enableTypeWorkflow ? 'assignment-type' : 'done',
+  );
+
+  // Advance to the next sub-step of the workflow. Only "hide_and_reveal" has
+  // further steps (checkpoint, due-date); other types go straight to the
+  // regular flow.
+  const goToNextWorkflowStep = () => {
+    setWorkflowStep(step => {
+      switch (step) {
+        case 'assignment-type':
+          return assignmentType === 'hide_and_reveal' ? 'checkpoint' : 'done';
+        case 'checkpoint':
+          return 'due-date';
+        default:
+          return 'done';
+      }
+    });
+  };
+
+  // Go back to the previous sub-step of the workflow. Only ever invoked from
+  // the 'checkpoint' and 'due-date' steps (the "Back" button is
+  // hidden on the first step). Selections made in later steps are kept in state,
+  // so they survive going back and forth.
+  const goToPreviousWorkflowStep = () => {
+    setWorkflowStep(step =>
+      step === 'due-date' ? 'checkpoint' : 'assignment-type',
+    );
+  };
+
+  // Jump straight back to the assignment-mode selection from anywhere in the
+  // Guided ("Hide & Reveal") sub-steps, via the close button in the card header.
+  // Selections made so far are kept in state.
+  const returnToModeSelection = () => setWorkflowStep('assignment-type');
 
   // Whether there are additional configuration options to present after the
   // user has selected the content for the assignment.
@@ -244,7 +328,11 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     !isEditing; // Always show details for new assignments (checkpoint option)
 
   let currentStep: PickerStep;
-  if (editingContent) {
+  if (enableTypeWorkflow && workflowStep !== 'done' && !isEditing) {
+    // While the assignment-type workflow is in progress, its current sub-step
+    // (which is a subset of PickerStep) is the active step.
+    currentStep = workflowStep;
+  } else if (editingContent) {
     currentStep = 'content-selection';
   } else if (isEditing) {
     currentStep = 'details';
@@ -252,6 +340,28 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     currentStep =
       content && showDetailsScreen ? 'details' : 'content-selection';
   }
+
+  // Whether the current step belongs to the assignment-type workflow shown
+  // before the regular file picker flow.
+  const inTypeWorkflow =
+    currentStep === 'assignment-type' ||
+    currentStep === 'checkpoint' ||
+    currentStep === 'due-date';
+
+  // The first workflow step has nothing before it, so "Back" is only offered on
+  // later steps.
+  const canGoBackInWorkflow =
+    currentStep === 'checkpoint' || currentStep === 'due-date';
+
+  // Title shown in the card header, which changes depending on the current step.
+  const stepTitles: Record<PickerStep, string> = {
+    'assignment-type': 'Assignment mode',
+    checkpoint: 'Guided Social Annotation',
+    'due-date': 'Guided Social Annotation',
+    'content-selection': 'Assignment details',
+    details: 'Assignment details',
+  };
+  const cardTitle = stepTitles[currentStep];
 
   const [groupConfig, setGroupConfig] = useState<GroupConfig>({
     useGroupSet: !!assignment?.group_set_id,
@@ -427,179 +537,209 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
         )}
         {/* Card constrains overflow-scroll children to height constraints */}
         <Card classes="flex flex-col min-h-0 overflow-hidden">
-          <CardHeader variant="secondary" title="Assignment details" />
+          <CardHeader
+            variant="secondary"
+            title={cardTitle}
+            // Offer a close ("x") button to return to mode selection from the
+            // Guided sub-steps (checkpoint / due-date), but not from the mode
+            // selection step itself or the regular flow.
+            onClose={canGoBackInWorkflow ? returnToModeSelection : undefined}
+          />
           <Scroll>
             <CardContent size="lg">
-              {/* 1-col grid for very narrow screens; 2-col for everyone else */}
-              <div className="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-6 gap-y-3">
-                <PanelLabel
-                  description={<p>Select content for your assignment</p>}
-                  isCurrentStep={currentStep === 'content-selection'}
-                >
-                  Assignment content
-                </PanelLabel>
-
-                <div data-testid="content-selector-container">
-                  {content && currentStep !== 'content-selection' ? (
-                    <div className="flex gap-x-2 items-start">
-                      <span
-                        className="break-words italic"
-                        data-testid="content-summary"
-                      >
-                        {contentDescription(content)}
-                      </span>
-                      <LinkButton
-                        onClick={() => setEditingContent(true)}
-                        data-testid="edit-content"
-                        title="Change assignment content"
-                        underline="always"
-                      >
-                        Change
-                      </LinkButton>
-                    </div>
-                  ) : (
-                    <ContentSelector
-                      initialContent={content ?? undefined}
-                      onSelectContent={selectContent}
-                      onError={setErrorInfo}
+              {inTypeWorkflow ? (
+                <div className="space-y-4">
+                  {currentStep === 'assignment-type' && (
+                    <AssignmentTypeSelector
+                      types={availableAssignmentTypes}
+                      selected={assignmentType}
+                      onChange={setAssignmentType}
                     />
                   )}
+                  {currentStep === 'checkpoint' && (
+                    <CheckpointSelector
+                      selected={checkpointType}
+                      onChange={setCheckpointType}
+                    />
+                  )}
+                  {currentStep === 'due-date' && (
+                    <DueDateSelector dueDate={dueDate} onChange={setDueDate} />
+                  )}
                 </div>
-                {currentStep === 'details' && (
-                  <>
-                    {typeof title === 'string' && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep verticalAlign="center">
-                          Title
-                        </PanelLabel>
-                        <Input
-                          data-testid="title-input"
-                          id={titleInputId}
-                          // Max length is based on what D2L supports, which is the first LMS that
-                          // supported setting a title in assignment configuration.
-                          maxLength={150}
-                          onInput={(e: Event) =>
-                            setTitle((e.target as HTMLInputElement).value)
-                          }
-                          required
-                          value={title}
-                        />
-                      </>
-                    )}
-                    {promptForGradable && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep verticalAlign="center">
-                          <div className="flex items-center sm:justify-end">
-                            Max points
-                            <IconButton
-                              icon={InfoIcon}
-                              title="About max points"
-                              onClick={() =>
-                                setMaxPointsPopoverOpen(open => !open)
-                              }
-                              expanded={maxPointsPopoverOpen}
-                              elementRef={iconRef}
-                              // Align right side of the icon with the right
-                              // edge of the text labels above and below.
-                              // Do it by setting negative margin that
-                              // compensates for the button's padding.
-                              classes="text-[16px] -mr-2 touch:-mr-[12px]"
-                            />
-                          </div>
-                        </PanelLabel>
-                        <Input
-                          data-testid="gradable-max-input"
-                          id={gradableMaxInputId}
-                          type="number"
-                          placeholder={'ex: 100'}
-                          min={0}
-                          value={assignmentGradableMaxPoints}
-                          onChange={e =>
-                            setAssignmentGradableMaxPoints(
-                              (e.target as HTMLInputElement).value,
-                            )
-                          }
-                        />
-                        <Popover
-                          open={maxPointsPopoverOpen}
-                          anchorElementRef={iconRef}
-                          onClose={() => setMaxPointsPopoverOpen(false)}
-                          classes="p-2"
-                          placement="above"
-                          arrow
-                        >
-                          <div className="flex flex-col gap-y-2">
-                            Optionally add a max points value here instead of
-                            using your LMS grading settings.
-                            <Link
-                              href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
-                              underline="always"
-                              target="_blank"
-                            >
-                              Learn more about our max points feature
-                            </Link>
-                          </div>
-                        </Popover>
-                      </>
-                    )}
+              ) : (
+                /* 1-col grid for very narrow screens; 2-col for everyone else */
+                <div className="grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-6 gap-y-3">
+                  <PanelLabel
+                    description={<p>Select content for your assignment</p>}
+                    isCurrentStep={currentStep === 'content-selection'}
+                  >
+                    Assignment content
+                  </PanelLabel>
 
-                    {autoGradingEnabled && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep>Auto grading</PanelLabel>
-                        <AutoGradingConfigurator
-                          config={autoGradingConfig}
-                          onChange={setAutoGradingConfig}
-                        />
-                      </>
+                  <div data-testid="content-selector-container">
+                    {content && currentStep !== 'content-selection' ? (
+                      <div className="flex gap-x-2 items-start">
+                        <span
+                          className="break-words italic"
+                          data-testid="content-summary"
+                        >
+                          {contentDescription(content)}
+                        </span>
+                        <LinkButton
+                          onClick={() => setEditingContent(true)}
+                          data-testid="edit-content"
+                          title="Change assignment content"
+                          underline="always"
+                        >
+                          Change
+                        </LinkButton>
+                      </div>
+                    ) : (
+                      <ContentSelector
+                        initialContent={content ?? undefined}
+                        onSelectContent={selectContent}
+                        onError={setErrorInfo}
+                      />
                     )}
-                    {!isEditing && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep verticalAlign="center">
-                          Hide &amp; Reveal
-                        </PanelLabel>
-                        <label className="flex items-center gap-x-2">
-                          <input
-                            type="checkbox"
-                            data-testid="checkpoint-enabled"
-                            checked={checkpointEnabled}
-                            onChange={event =>
-                              setCheckpointEnabled(
-                                (event.target as HTMLInputElement).checked,
+                  </div>
+                  {currentStep === 'details' && (
+                    <>
+                      {typeof title === 'string' && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep verticalAlign="center">
+                            Title
+                          </PanelLabel>
+                          <Input
+                            data-testid="title-input"
+                            id={titleInputId}
+                            // Max length is based on what D2L supports, which is the first LMS that
+                            // supported setting a title in assignment configuration.
+                            maxLength={150}
+                            onInput={(e: Event) =>
+                              setTitle((e.target as HTMLInputElement).value)
+                            }
+                            required
+                            value={title}
+                          />
+                        </>
+                      )}
+                      {promptForGradable && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep verticalAlign="center">
+                            <div className="flex items-center sm:justify-end">
+                              Max points
+                              <IconButton
+                                icon={InfoIcon}
+                                title="About max points"
+                                onClick={() =>
+                                  setMaxPointsPopoverOpen(open => !open)
+                                }
+                                expanded={maxPointsPopoverOpen}
+                                elementRef={iconRef}
+                                // Align right side of the icon with the right
+                                // edge of the text labels above and below.
+                                // Do it by setting negative margin that
+                                // compensates for the button's padding.
+                                classes="text-[16px] -mr-2 touch:-mr-[12px]"
+                              />
+                            </div>
+                          </PanelLabel>
+                          <Input
+                            data-testid="gradable-max-input"
+                            id={gradableMaxInputId}
+                            type="number"
+                            placeholder={'ex: 100'}
+                            min={0}
+                            value={assignmentGradableMaxPoints}
+                            onChange={e =>
+                              setAssignmentGradableMaxPoints(
+                                (e.target as HTMLInputElement).value,
                               )
                             }
                           />
-                          Enable checkpoint
-                        </label>
-                      </>
-                    )}
-                    {enableGroupConfig && (
-                      <>
-                        <div className="sm:col-span-2 border-b" />
-                        <PanelLabel isCurrentStep>Group assignment</PanelLabel>
-                        <div
-                          className={classnames(
-                            // Set a height on this container to give the group
-                            // <select> element room when it renders (avoid
-                            // changing the height of the Card later)
-                            'h-28',
-                          )}
-                        >
-                          <GroupConfigSelector
-                            groupConfig={groupConfig}
-                            onChangeGroupConfig={setGroupConfig}
+                          <Popover
+                            open={maxPointsPopoverOpen}
+                            anchorElementRef={iconRef}
+                            onClose={() => setMaxPointsPopoverOpen(false)}
+                            classes="p-2"
+                            placement="above"
+                            arrow
+                          >
+                            <div className="flex flex-col gap-y-2">
+                              Optionally add a max points value here instead of
+                              using your LMS grading settings.
+                              <Link
+                                href="https://web.hypothes.is/help/max-points-in-hypothesis-enabled-readings/"
+                                underline="always"
+                                target="_blank"
+                              >
+                                Learn more about our max points feature
+                              </Link>
+                            </div>
+                          </Popover>
+                        </>
+                      )}
+
+                      {autoGradingEnabled && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep>Auto grading</PanelLabel>
+                          <AutoGradingConfigurator
+                            config={autoGradingConfig}
+                            onChange={setAutoGradingConfig}
                           />
-                        </div>
-                      </>
-                    )}
-                  </>
-                )}
-              </div>
+                        </>
+                      )}
+                      {enableGroupConfig && (
+                        <>
+                          <div className="sm:col-span-2 border-b" />
+                          <PanelLabel isCurrentStep>
+                            Group assignment
+                          </PanelLabel>
+                          <div
+                            className={classnames(
+                              // Set a height on this container to give the group
+                              // <select> element room when it renders (avoid
+                              // changing the height of the Card later)
+                              'h-28',
+                            )}
+                          >
+                            <GroupConfigSelector
+                              groupConfig={groupConfig}
+                              onChangeGroupConfig={setGroupConfig}
+                            />
+                          </div>
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Scroll>
+          {inTypeWorkflow && (
+            <CardContent size="lg">
+              <CardActions>
+                {canGoBackInWorkflow && (
+                  <Button
+                    data-testid="workflow-back-button"
+                    onClick={goToPreviousWorkflowStep}
+                  >
+                    Back
+                  </Button>
+                )}
+                <Button
+                  data-testid="workflow-next-button"
+                  variant="primary"
+                  onClick={goToNextWorkflowStep}
+                >
+                  Next
+                </Button>
+              </CardActions>
+            </CardContent>
+          )}
           {
             // See comments in `selectContent` about auto-submitting form.
             (editingContent || currentStep === 'details') && (

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -24,6 +24,9 @@ export type FilePickerFormFieldsProps = {
 
   /** Auto-grading configuration for assignments where it is enabled */
   autoGradingConfig: AutoGradingConfig | null;
+
+  /** Whether hide & reveal checkpoint is enabled for this assignment */
+  checkpointEnabled: boolean;
 };
 
 /**
@@ -38,6 +41,7 @@ export default function FilePickerFormFields({
   formFields,
   groupSet,
   autoGradingConfig,
+  checkpointEnabled,
 }: FilePickerFormFieldsProps) {
   return (
     <>
@@ -57,6 +61,9 @@ export default function FilePickerFormFields({
           name="auto_grading_config"
           value={JSON.stringify(autoGradingConfig)}
         />
+      )}
+      {checkpointEnabled && (
+        <input type="hidden" name="checkpoint_enabled" value="true" />
       )}
     </>
   );

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -26,7 +26,7 @@ export type FilePickerFormFieldsProps = {
   autoGradingConfig: AutoGradingConfig | null;
 
   /** Whether hide & reveal checkpoint is enabled for this assignment */
-  checkpointEnabled?: boolean;
+  checkpointEnabled: boolean;
 };
 
 /**
@@ -41,7 +41,7 @@ export default function FilePickerFormFields({
   formFields,
   groupSet,
   autoGradingConfig,
-  checkpointEnabled = false,
+  checkpointEnabled,
 }: FilePickerFormFieldsProps) {
   return (
     <>

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -26,7 +26,7 @@ export type FilePickerFormFieldsProps = {
   autoGradingConfig: AutoGradingConfig | null;
 
   /** Whether hide & reveal checkpoint is enabled for this assignment */
-  checkpointEnabled: boolean;
+  checkpointEnabled?: boolean;
 };
 
 /**
@@ -41,7 +41,7 @@ export default function FilePickerFormFields({
   formFields,
   groupSet,
   autoGradingConfig,
-  checkpointEnabled,
+  checkpointEnabled = false,
 }: FilePickerFormFieldsProps) {
   return (
     <>

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { Link as RouterLink } from 'wouter-preact';
 
 import { useConfig } from '../config';
+import CheckpointBar from './CheckpointBar';
 import GradingControls from './GradingControls';
 
 /**
@@ -24,63 +25,68 @@ export default function InstructorToolbar() {
     gradingEnabled,
     scoreMaximum,
     acceptGradingComments,
+    checkpoint,
   } = instructorToolbar;
 
   const withGradingControls = gradingEnabled && !!students;
 
   return (
-    <header
-      className={classnames(
-        'p-2',
-        // Default and narrower screens: content is stacked vertically
-        'grid grid-cols-1 items-center gap-x-4 gap-y-2',
-        // Wider screens: assignment metadata and grading controls side by side
-        'md:grid-cols-[1fr_auto] md:py-1',
-      )}
-    >
-      <div className="space-y-1">
-        <div
-          className={classnames(
-            // lays out assignment name and edit button
-            'flex gap-x-2 items-center',
-          )}
-        >
-          <h1
-            className="text-lg font-semibold leading-none"
-            data-testid="assignment-name"
+    <>
+      <header
+        className={classnames(
+          'p-2',
+          // Default and narrower screens: content is stacked vertically
+          'grid grid-cols-1 items-center gap-x-4 gap-y-2',
+          // Wider screens: assignment metadata and grading controls side by side
+          'md:grid-cols-[1fr_auto] md:py-1',
+        )}
+      >
+        <div className="space-y-1">
+          <div
+            className={classnames(
+              // lays out assignment name and edit button
+              'flex gap-x-2 items-center',
+            )}
           >
-            {assignmentName}
-          </h1>
-          {editingEnabled && (
-            <RouterLink href="/app/content-item-selection" asChild>
-              <Link
-                classes="text-xs"
-                data-testid="edit"
-                title="Edit assignment settings"
-                underline="always"
-              >
-                Edit
-              </Link>
-            </RouterLink>
-          )}
+            <h1
+              className="text-lg font-semibold leading-none"
+              data-testid="assignment-name"
+            >
+              {assignmentName}
+            </h1>
+            {editingEnabled && (
+              <RouterLink href="/app/content-item-selection" asChild>
+                <Link
+                  classes="text-xs"
+                  data-testid="edit"
+                  title="Edit assignment settings"
+                  underline="always"
+                >
+                  Edit
+                </Link>
+              </RouterLink>
+            )}
+          </div>
+          <h2
+            className="text-sm font-normal text-color-text-light leading-none"
+            data-testid="course-name"
+          >
+            {courseName}
+          </h2>
         </div>
-        <h2
-          className="text-sm font-normal text-color-text-light leading-none"
-          data-testid="course-name"
-        >
-          {courseName}
-        </h2>
-      </div>
 
-      {withGradingControls ? (
-        <GradingControls
-          students={students}
-          scoreMaximum={scoreMaximum ?? undefined}
-          acceptComments={acceptGradingComments}
-        />
-      ) : (
-        <div />
-      )}
-    </header>
+        {withGradingControls ? (
+          <GradingControls
+            students={students}
+            scoreMaximum={scoreMaximum ?? undefined}
+            acceptComments={acceptGradingComments}
+          />
+        ) : (
+          <div />
+        )}
+      </header>
+
+      {checkpoint?.enabled && <CheckpointBar checkpoint={checkpoint} />}
+    </>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
@@ -1,0 +1,110 @@
+import {
+  Button,
+  ModalDialog,
+  formatDateTime,
+} from '@hypothesis/frontend-shared';
+import { useCallback, useRef, useState } from 'preact/hooks';
+
+import type { CheckpointConfig } from '../config';
+import { useConfig } from '../config';
+import { apiCall } from '../utils/api';
+
+export type RevealAnnotationsButtonProps = {
+  checkpoint: CheckpointConfig;
+};
+
+/**
+ * Button and confirmation modal for revealing checkpoint annotations.
+ * When the instructor clicks "Reveal annotations", a confirmation modal warns
+ * that this action cannot be undone. On confirm, it calls the reveal API and
+ * updates the local state.
+ */
+export default function RevealAnnotationsButton({
+  checkpoint,
+}: RevealAnnotationsButtonProps) {
+  const {
+    api: { authToken },
+  } = useConfig(['api']);
+
+  const [showModal, setShowModal] = useState(false);
+  const [revealed, setRevealed] = useState(checkpoint.revealed);
+  const [revealDate, setRevealDate] = useState<string | null>(
+    checkpoint.revealDate,
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const revealButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleReveal = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await apiCall<{ reveal_date: string }>({
+        authToken,
+        path: checkpoint.revealUrl,
+        data: {},
+      });
+      setRevealed(true);
+      setRevealDate(result.reveal_date);
+      setShowModal(false);
+    } catch {
+      setError('Failed to reveal annotations. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }, [authToken, checkpoint.revealUrl]);
+
+  if (revealed) {
+    return (
+      <span
+        className="text-sm text-color-text-light italic whitespace-nowrap"
+        data-testid="checkpoint-revealed"
+      >
+        Annotations revealed on {revealDate ? formatDateTime(revealDate) : ''}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        onClick={() => setShowModal(true)}
+        data-testid="reveal-annotations-button"
+      >
+        Reveal annotations
+      </Button>
+
+      {showModal && (
+        <ModalDialog
+          title="This action cannot be undone"
+          onClose={() => setShowModal(false)}
+          initialFocus={revealButtonRef}
+          buttons={
+            <Button
+              elementRef={revealButtonRef}
+              variant="primary"
+              onClick={handleReveal}
+              disabled={busy}
+              data-testid="confirm-reveal-button"
+            >
+              Reveal
+            </Button>
+          }
+        >
+          <p className="text-sm">
+            Student annotations and instructor replies that are currently hidden
+            will be revealed and cannot be hidden again.
+          </p>
+          {error && (
+            <p
+              className="text-sm text-red-error mt-2"
+              data-testid="reveal-error"
+            >
+              {error}
+            </p>
+          )}
+        </ModalDialog>
+      )}
+    </>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/StudentCheckpointBar.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentCheckpointBar.tsx
@@ -1,0 +1,25 @@
+import { formatDateTime } from '@hypothesis/frontend-shared';
+
+import { useConfig } from '../config';
+
+export default function StudentCheckpointBar() {
+  const { studentCheckpoint } = useConfig();
+  if (!studentCheckpoint) {
+    return null;
+  }
+
+  return (
+    <header className="p-2 flex items-center">
+      <div className="text-sm" data-testid="student-checkpoint-status">
+        <div className="font-semibold">Checkpoint:</div>
+        <div>{studentCheckpoint.hidden ? 'Annotations are hidden' : 'Annotations are visible'}</div>
+      </div>
+      {studentCheckpoint.dueDate && (
+        <div className="text-sm ml-auto" data-testid="student-checkpoint-due-date">
+          <div className="font-semibold">Assignment Due Date:</div>
+          <div>{formatDateTime(studentCheckpoint.dueDate)}</div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/StudentCheckpointBar.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentCheckpointBar.tsx
@@ -12,10 +12,17 @@ export default function StudentCheckpointBar() {
     <header className="p-2 flex items-center">
       <div className="text-sm" data-testid="student-checkpoint-status">
         <div className="font-semibold">Checkpoint:</div>
-        <div>{studentCheckpoint.hidden ? 'Annotations are hidden' : 'Annotations are visible'}</div>
+        <div>
+          {studentCheckpoint.hidden
+            ? 'Annotations are hidden'
+            : 'Annotations are visible'}
+        </div>
       </div>
       {studentCheckpoint.dueDate && (
-        <div className="text-sm ml-auto" data-testid="student-checkpoint-due-date">
+        <div
+          className="text-sm ml-auto"
+          data-testid="student-checkpoint-due-date"
+        >
           <div className="font-semibold">Assignment Due Date:</div>
           <div>{formatDateTime(studentCheckpoint.dueDate)}</div>
         </div>

--- a/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
@@ -1,59 +1,54 @@
-import { RadioGroup } from '@hypothesis/frontend-shared';
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import AssignmentTypeSelector from '../AssignmentTypeSelector';
 
 describe('AssignmentTypeSelector', () => {
-  let fakeOnChange;
+  let fakeOnSelect;
 
   beforeEach(() => {
-    fakeOnChange = sinon.stub();
+    fakeOnSelect = sinon.stub();
   });
 
-  function createComponent(
-    selected = 'reading',
-    types = ['reading', 'hide_and_reveal'],
-  ) {
+  function createComponent(types = ['reading', 'hide_and_reveal']) {
     return mount(
-      <AssignmentTypeSelector
-        types={types}
-        selected={selected}
-        onChange={fakeOnChange}
-      />,
+      <AssignmentTypeSelector types={types} onSelect={fakeOnSelect} />,
     );
   }
 
-  it('reflects the selected assignment type', () => {
-    const wrapper = createComponent('hide_and_reveal');
-    assert.equal(
-      wrapper.find('RadioGroup').prop('selected'),
-      'hide_and_reveal',
-    );
-  });
+  function optionTestIds(wrapper) {
+    return wrapper.find('Button').map(button => button.prop('data-testid'));
+  }
 
-  it('renders a radio option for each available type', () => {
-    const wrapper = createComponent('reading', ['reading', 'hide_and_reveal']);
-    const values = wrapper
-      .find(RadioGroup.Radio)
-      .map(radio => radio.prop('value'));
-    assert.deepEqual(values, ['reading', 'hide_and_reveal']);
+  it('renders a button for each available type', () => {
+    const wrapper = createComponent(['reading', 'hide_and_reveal']);
+    assert.deepEqual(optionTestIds(wrapper), [
+      'assignment-type-reading',
+      'assignment-type-hide_and_reveal',
+    ]);
   });
 
   it('only renders the available types', () => {
-    const wrapper = createComponent('reading', ['reading']);
-    const values = wrapper
-      .find(RadioGroup.Radio)
-      .map(radio => radio.prop('value'));
-    assert.deepEqual(values, ['reading']);
+    const wrapper = createComponent(['reading']);
+    assert.deepEqual(optionTestIds(wrapper), ['assignment-type-reading']);
   });
 
-  it('invokes onChange when a different type is selected', () => {
-    const wrapper = createComponent('reading');
+  it('falls back to the raw key for unknown types', () => {
+    const wrapper = createComponent(['mystery']);
+    assert.deepEqual(optionTestIds(wrapper), ['assignment-type-mystery']);
+  });
 
-    act(() => wrapper.find('RadioGroup').props().onChange('hide_and_reveal'));
+  it('invokes onSelect when a type is clicked', () => {
+    const wrapper = createComponent();
 
-    assert.calledWith(fakeOnChange, 'hide_and_reveal');
+    act(() =>
+      wrapper
+        .find('Button[data-testid="assignment-type-hide_and_reveal"]')
+        .props()
+        .onClick(),
+    );
+
+    assert.calledWith(fakeOnSelect, 'hide_and_reveal');
   });
 
   it(

--- a/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/AssignmentTypeSelector-test.js
@@ -1,0 +1,65 @@
+import { RadioGroup } from '@hypothesis/frontend-shared';
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import AssignmentTypeSelector from '../AssignmentTypeSelector';
+
+describe('AssignmentTypeSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(
+    selected = 'reading',
+    types = ['reading', 'hide_and_reveal'],
+  ) {
+    return mount(
+      <AssignmentTypeSelector
+        types={types}
+        selected={selected}
+        onChange={fakeOnChange}
+      />,
+    );
+  }
+
+  it('reflects the selected assignment type', () => {
+    const wrapper = createComponent('hide_and_reveal');
+    assert.equal(
+      wrapper.find('RadioGroup').prop('selected'),
+      'hide_and_reveal',
+    );
+  });
+
+  it('renders a radio option for each available type', () => {
+    const wrapper = createComponent('reading', ['reading', 'hide_and_reveal']);
+    const values = wrapper
+      .find(RadioGroup.Radio)
+      .map(radio => radio.prop('value'));
+    assert.deepEqual(values, ['reading', 'hide_and_reveal']);
+  });
+
+  it('only renders the available types', () => {
+    const wrapper = createComponent('reading', ['reading']);
+    const values = wrapper
+      .find(RadioGroup.Radio)
+      .map(radio => radio.prop('value'));
+    assert.deepEqual(values, ['reading']);
+  });
+
+  it('invokes onChange when a different type is selected', () => {
+    const wrapper = createComponent('reading');
+
+    act(() => wrapper.find('RadioGroup').props().onChange('hide_and_reveal'));
+
+    assert.calledWith(fakeOnChange, 'hide_and_reveal');
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/CheckpointSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/CheckpointSelector-test.js
@@ -1,0 +1,76 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import CheckpointSelector from '../CheckpointSelector';
+
+describe('CheckpointSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(selected = 'manual') {
+    return mount(
+      <CheckpointSelector selected={selected} onChange={fakeOnChange} />,
+    );
+  }
+
+  it('reflects the selected checkpoint type', () => {
+    const wrapper = createComponent('manual');
+    assert.equal(wrapper.find('RadioGroup').prop('selected'), 'manual');
+  });
+
+  it('invokes onChange when "manual" is selected', () => {
+    const wrapper = createComponent();
+
+    act(() => wrapper.find('RadioGroup').props().onChange('manual'));
+
+    assert.calledWith(fakeOnChange, 'manual');
+  });
+
+  it('ignores selection of not-yet-available options', () => {
+    const wrapper = createComponent();
+
+    act(() => wrapper.find('RadioGroup').props().onChange('more'));
+
+    assert.notCalled(fakeOnChange);
+  });
+
+  it('passes through any real (non-placeholder) checkpoint type', () => {
+    const wrapper = createComponent();
+
+    // A future CheckpointType (anything other than the "more" placeholder)
+    // should propagate without changing the guard.
+    act(() => wrapper.find('RadioGroup').props().onChange('automatic'));
+
+    assert.calledWith(fakeOnChange, 'automatic');
+  });
+
+  it('shows the reveal note when "manual" is selected', () => {
+    const wrapper = createComponent('manual');
+
+    assert.include(
+      wrapper.text(),
+      'Students will see when the settings have changed',
+    );
+  });
+
+  it('hides the reveal note when a non-manual option is selected', () => {
+    // `selected` is typed `'manual'` today (the only option), so this exercises
+    // the conditional that will matter once more checkpoint types exist.
+    const wrapper = createComponent('more');
+
+    assert.notInclude(
+      wrapper.text(),
+      'Students will see when the settings have changed',
+    );
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
@@ -1,0 +1,87 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import DueDateSelector from '../DueDateSelector';
+
+describe('DueDateSelector', () => {
+  let fakeOnChange;
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+  });
+
+  function createComponent(dueDate = null) {
+    return mount(
+      <DueDateSelector dueDate={dueDate} onChange={fakeOnChange} />,
+      // Connect to the DOM so the info `Popover` (which uses the native popover
+      // API) can toggle.
+      { connected: true },
+    );
+  }
+
+  const dateInput = wrapper =>
+    wrapper.find('input[data-testid="due-date-input"]');
+
+  it('reflects the selected due date', () => {
+    const wrapper = createComponent('2026-06-11');
+    assert.equal(dateInput(wrapper).prop('value'), '2026-06-11');
+  });
+
+  it('renders an empty value when no due date is set', () => {
+    const wrapper = createComponent(null);
+    assert.equal(dateInput(wrapper).prop('value'), '');
+  });
+
+  it('invokes onChange with the selected date', () => {
+    const wrapper = createComponent();
+
+    act(() =>
+      dateInput(wrapper)
+        .props()
+        .onChange({ target: { value: '2026-06-11' } }),
+    );
+
+    assert.calledWith(fakeOnChange, '2026-06-11');
+  });
+
+  it('invokes onChange with null when the date is cleared', () => {
+    const wrapper = createComponent('2026-06-11');
+
+    act(() =>
+      dateInput(wrapper)
+        .props()
+        .onChange({ target: { value: '' } }),
+    );
+
+    assert.calledWith(fakeOnChange, null);
+  });
+
+  it('shows the due date explanation in a popover instead of inline', () => {
+    const wrapper = createComponent();
+    const popover = () => wrapper.find('Popover');
+    const explanation =
+      'The point where annotations are no longer tallied in auto grading.';
+
+    // The explanation is not rendered inline, only inside the (closed) popover.
+    assert.isFalse(popover().prop('open'));
+
+    // Clicking the info icon opens the popover with the explanation.
+    act(() => wrapper.find('IconButton').props().onClick());
+    wrapper.update();
+
+    assert.isTrue(popover().prop('open'));
+    assert.include(popover().text(), explanation);
+
+    // The popover can be dismissed.
+    act(() => popover().props().onClose());
+    wrapper.update();
+    assert.isFalse(popover().prop('open'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
+});

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -53,6 +53,7 @@ describe('FilePickerApp', () => {
         formFields: { hidden_field: 'hidden_value' },
         promptForTitle: false,
         promptForGradable: false,
+        assignmentTypes: ['reading'],
       },
     };
 
@@ -110,6 +111,169 @@ describe('FilePickerApp', () => {
   it('renders content selector when content has not yet been selected', () => {
     const wrapper = renderFilePicker();
     assert.isTrue(wrapper.exists('ContentSelector'));
+  });
+
+  describe('assignment-type workflow', () => {
+    function clickNext(wrapper) {
+      interact(wrapper, () => {
+        wrapper
+          .find('Button[data-testid="workflow-next-button"]')
+          .props()
+          .onClick();
+      });
+    }
+
+    function clickBack(wrapper) {
+      interact(wrapper, () => {
+        wrapper
+          .find('Button[data-testid="workflow-back-button"]')
+          .props()
+          .onClick();
+      });
+    }
+
+    function selectAssignmentType(wrapper, type) {
+      interact(wrapper, () => {
+        wrapper.find('AssignmentTypeSelector').props().onChange(type);
+      });
+    }
+
+    it('does not show the workflow when only one type is available', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading'];
+      const wrapper = renderFilePicker();
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('shows the assignment-type step first when several types are available', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      // The content selector is not shown until the workflow is complete.
+      assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    it('skips to content selection for a "reading" assignment', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // The default assignment type is "reading".
+      clickNext(wrapper);
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('walks through checkpoint and due-date steps for "Hide & Reveal"', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper);
+
+      // Checkpoint step.
+      assert.isTrue(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+      clickNext(wrapper);
+
+      // Due-date step.
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+      clickNext(wrapper);
+
+      // Regular flow takes over.
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('does not offer a "Back" button on the first step', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(
+        wrapper.exists('Button[data-testid="workflow-back-button"]'),
+      );
+    });
+
+    it('goes back through the "Hide & Reveal" steps', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      clickBack(wrapper); // -> checkpoint
+      assert.isTrue(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+
+      clickBack(wrapper); // -> assignment-type
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+    });
+
+    it('shows a step-specific card title', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+      const cardTitle = () => wrapper.find('CardHeader').prop('title');
+
+      // Assignment-type step.
+      assert.equal(cardTitle(), 'Assignment mode');
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      assert.equal(cardTitle(), 'Guided Social Annotation');
+
+      clickNext(wrapper); // -> due-date
+      assert.equal(cardTitle(), 'Guided Social Annotation');
+
+      clickNext(wrapper); // -> regular flow
+      assert.equal(cardTitle(), 'Assignment details');
+    });
+
+    it('returns to the assignment-type step via the header close button', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // The mode-selection step itself offers no close button.
+      assert.isNotOk(wrapper.find('CardHeader').prop('onClose'));
+
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      // The header exposes a close handler during the Guided sub-steps.
+      const onClose = wrapper.find('CardHeader').prop('onClose');
+      assert.isFunction(onClose);
+      interact(wrapper, () => onClose());
+
+      assert.isTrue(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+    });
+
+    it('recomputes the branch when the type is changed after going back', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      // Enter the Hide & Reveal branch...
+      selectAssignmentType(wrapper, 'hide_and_reveal');
+      clickNext(wrapper); // -> checkpoint
+      clickBack(wrapper); // -> assignment-type
+
+      // ...then switch to a regular reading assignment.
+      selectAssignmentType(wrapper, 'reading');
+      clickNext(wrapper); // -> done (skips checkpoint/due-date)
+
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
   });
 
   function selectContent(wrapper, content) {

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -75,6 +75,7 @@ describe('FilePickerApp', () => {
       formFields = {},
       title = null,
       autoGradingConfig = null,
+      checkpointEnabled = false,
     },
   ) {
     const fieldsComponent = wrapper.find('FilePickerFormFields');
@@ -85,6 +86,7 @@ describe('FilePickerApp', () => {
       groupSet,
       title,
       autoGradingConfig,
+      checkpointEnabled,
     });
   }
 
@@ -132,14 +134,53 @@ describe('FilePickerApp', () => {
       });
     }
 
+    // Selecting a type advances the workflow immediately (no "Next" on the
+    // first step).
     function selectAssignmentType(wrapper, type) {
       interact(wrapper, () => {
-        wrapper.find('AssignmentTypeSelector').props().onChange(type);
+        wrapper.find('AssignmentTypeSelector').props().onSelect(type);
       });
+    }
+
+    function setDueDate(wrapper, date) {
+      interact(wrapper, () => {
+        wrapper.find('DueDateSelector').props().onChange(date);
+      });
+    }
+
+    /**
+     * Local `datetime-local` string (`YYYY-MM-DDTHH:MM`) `days` from now
+     * (negative for the past).
+     */
+    function dueDateFromNow(days) {
+      const date = new Date();
+      date.setDate(date.getDate() + days);
+      const pad = n => String(n).padStart(2, '0');
+      return (
+        `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+        `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+      );
     }
 
     it('does not show the workflow when only one type is available', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading'];
+      const wrapper = renderFilePicker();
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('falls back to "reading" when no assignment types are provided', () => {
+      fakeConfig.filePicker.assignmentTypes = undefined;
+      const wrapper = renderFilePicker();
+
+      // A single implicit "reading" type keeps the workflow dormant.
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('falls back to "reading" when the assignment types list is empty', () => {
+      fakeConfig.filePicker.assignmentTypes = [];
       const wrapper = renderFilePicker();
 
       assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
@@ -159,8 +200,7 @@ describe('FilePickerApp', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();
 
-      // The default assignment type is "reading".
-      clickNext(wrapper);
+      selectAssignmentType(wrapper, 'reading');
 
       assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
       assert.isFalse(wrapper.exists('CheckpointSelector'));
@@ -171,8 +211,8 @@ describe('FilePickerApp', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();
 
+      // Selecting "hide_and_reveal" advances straight to the checkpoint step.
       selectAssignmentType(wrapper, 'hide_and_reveal');
-      clickNext(wrapper);
 
       // Checkpoint step.
       assert.isTrue(wrapper.exists('CheckpointSelector'));
@@ -185,6 +225,35 @@ describe('FilePickerApp', () => {
       clickNext(wrapper);
 
       // Regular flow takes over.
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
+    });
+
+    it('blocks the due-date step when the date is not in the future', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      // A past date is rejected: navigation is blocked.
+      setDueDate(wrapper, dueDateFromNow(-1));
+      clickNext(wrapper);
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    it('leaves the due-date step when the date is in the future', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+
+      // A future date is accepted: the regular flow takes over.
+      setDueDate(wrapper, dueDateFromNow(7));
+      clickNext(wrapper);
       assert.isFalse(wrapper.exists('DueDateSelector'));
       assert.isTrue(wrapper.exists('ContentSelector'));
     });
@@ -203,8 +272,7 @@ describe('FilePickerApp', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();
 
-      selectAssignmentType(wrapper, 'hide_and_reveal');
-      clickNext(wrapper); // -> checkpoint
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
       clickNext(wrapper); // -> due-date
       assert.isTrue(wrapper.exists('DueDateSelector'));
 
@@ -225,8 +293,7 @@ describe('FilePickerApp', () => {
       // Assignment-type step.
       assert.equal(cardTitle(), 'Assignment mode');
 
-      selectAssignmentType(wrapper, 'hide_and_reveal');
-      clickNext(wrapper); // -> checkpoint
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
       assert.equal(cardTitle(), 'Guided Social Annotation');
 
       clickNext(wrapper); // -> due-date
@@ -243,8 +310,7 @@ describe('FilePickerApp', () => {
       // The mode-selection step itself offers no close button.
       assert.isNotOk(wrapper.find('CardHeader').prop('onClose'));
 
-      selectAssignmentType(wrapper, 'hide_and_reveal');
-      clickNext(wrapper); // -> checkpoint
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
       clickNext(wrapper); // -> due-date
       assert.isTrue(wrapper.exists('DueDateSelector'));
 
@@ -262,13 +328,11 @@ describe('FilePickerApp', () => {
       const wrapper = renderFilePicker();
 
       // Enter the Hide & Reveal branch...
-      selectAssignmentType(wrapper, 'hide_and_reveal');
-      clickNext(wrapper); // -> checkpoint
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
       clickBack(wrapper); // -> assignment-type
 
       // ...then switch to a regular reading assignment.
-      selectAssignmentType(wrapper, 'reading');
-      clickNext(wrapper); // -> done (skips checkpoint/due-date)
+      selectAssignmentType(wrapper, 'reading'); // -> done (skips checkpoint/due-date)
 
       assert.isFalse(wrapper.exists('CheckpointSelector'));
       assert.isFalse(wrapper.exists('DueDateSelector'));
@@ -370,6 +434,8 @@ describe('FilePickerApp', () => {
           group_set: null,
           auto_grading_config: null,
           assignment_gradable_max_points: null,
+          checkpoint_enabled: false,
+          due_date: null,
         },
       });
 
@@ -378,6 +444,80 @@ describe('FilePickerApp', () => {
       wrapper.update();
       checkHiddenFormFields(wrapper, {
         fields: fakeFormFields,
+      });
+    });
+
+    it('includes the selected group set in the deep linking API data', async () => {
+      fakeConfig.product.settings.groupsEnabled = true;
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      selectContent(wrapper, 'https://example.com');
+      selectGroupConfig(wrapper, { useGroupSet: true, groupSet: 'groupSet1' });
+      clickContinueButton(wrapper);
+
+      await waitFor(() => fakeAPICall.called);
+      assert.calledWith(fakeAPICall, {
+        authToken: 'DUMMY_AUTH_TOKEN',
+        path: deepLinkingAPIPath,
+        data: {
+          ...deepLinkingAPIData,
+          content: { type: 'url', url: 'https://example.com' },
+          title: null,
+          group_set: 'groupSet1',
+          auto_grading_config: null,
+          assignment_gradable_max_points: null,
+          checkpoint_enabled: false,
+          due_date: null,
+        },
+      });
+    });
+
+    it('sends the due date as a UTC datetime for "Hide & Reveal"', async () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      const clickNext = () =>
+        interact(wrapper, () => {
+          wrapper
+            .find('Button[data-testid="workflow-next-button"]')
+            .props()
+            .onClick();
+        });
+
+      // Walk the Hide & Reveal workflow, picking a future due date. The picker
+      // value is local wall-clock time; the backend receives it as UTC.
+      interact(wrapper, () => {
+        // Selecting the type advances straight to the checkpoint step.
+        wrapper
+          .find('AssignmentTypeSelector')
+          .props()
+          .onSelect('hide_and_reveal');
+      });
+      clickNext(); // -> due-date
+      const localDueDate = '2035-01-15T10:30';
+      interact(wrapper, () => {
+        wrapper.find('DueDateSelector').props().onChange(localDueDate);
+      });
+      clickNext(); // -> content selection
+
+      selectContent(wrapper, 'https://example.com');
+
+      await waitFor(() => fakeAPICall.called);
+      assert.calledWith(fakeAPICall, {
+        authToken: 'DUMMY_AUTH_TOKEN',
+        path: deepLinkingAPIPath,
+        data: {
+          ...deepLinkingAPIData,
+          content: { type: 'url', url: 'https://example.com' },
+          title: null,
+          group_set: null,
+          auto_grading_config: null,
+          assignment_gradable_max_points: null,
+          checkpoint_enabled: true,
+          due_date: new Date(localDueDate).toISOString(),
+        },
       });
     });
 
@@ -396,6 +536,23 @@ describe('FilePickerApp', () => {
 
       await waitFor(() => fakeAPICall.called);
       await waitFor(() => onSubmit.called);
+    });
+
+    it('ignores implicit form submission when the form cannot be submitted', () => {
+      // A group set is required but none is selected, so `canSubmit` is false.
+      fakeConfig.product.settings.groupsEnabled = true;
+
+      const onSubmit = sinon.stub().callsFake(e => e.preventDefault());
+      const wrapper = renderFilePicker({ onSubmit });
+
+      selectContent(wrapper, 'https://example.com');
+      selectGroupConfig(wrapper, { useGroupSet: true, groupSet: null });
+
+      // Simulate implicit form submission, as if pressing Enter.
+      wrapper.find('form').getDOMNode().requestSubmit();
+
+      // Nothing is submitted while the form is incomplete.
+      assert.notCalled(fakeAPICall);
     });
 
     it('shows an error if the deepLinkingAPI call fails', async () => {
@@ -735,6 +892,8 @@ describe('FilePickerApp', () => {
           group_set: null,
           auto_grading_config: null,
           assignment_gradable_max_points: 10,
+          checkpoint_enabled: false,
+          due_date: null,
         },
       });
 
@@ -765,6 +924,8 @@ describe('FilePickerApp', () => {
           group_set: null,
           auto_grading_config: null,
           assignment_gradable_max_points: null,
+          checkpoint_enabled: false,
+          due_date: null,
         },
       });
     });
@@ -812,6 +973,19 @@ describe('FilePickerApp', () => {
       const wrapper = renderFilePicker();
       const saveButton = wrapper.find('button[data-testid="save-button"]');
       assert.equal(saveButton.text(), 'Save');
+    });
+
+    it('skips the assignment-type workflow when editing', () => {
+      // The assignment mode (reading vs. "Hide & Reveal") is chosen only at
+      // creation, so editing goes straight to the assignment content/details
+      // even when several types are available.
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      assert.isFalse(wrapper.exists('AssignmentTypeSelector'));
+      assert.isFalse(wrapper.exists('CheckpointSelector'));
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('[data-testid="content-summary"]'));
     });
 
     [true, false].forEach(groupsEnabled => {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -2,6 +2,7 @@ import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 
 import type { AutoGradingConfig } from './api-types';
+import type { AssignmentType } from './components/AssignmentTypeSelector';
 import type { AppLaunchServerErrorCode, OAuthServerErrorCode } from './errors';
 
 /**
@@ -108,6 +109,15 @@ export type FilePickerConfig = {
   promptForTitle: boolean;
   promptForGradable: boolean;
   autoGradingEnabled: boolean;
+  /**
+   * The assignment types the instructor can choose from when configuring this
+   * assignment. The backend decides availability (e.g. via feature flags);
+   * `reading` is always present. When more than one type is offered, the file
+   * picker shows an initial "assignment type" selection step before the regular
+   * flow; with a single type that step is skipped. The backend that sets this
+   * is still pending, so it is optional for now.
+   */
+  assignmentTypes?: AssignmentType[];
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;
   blackboard: {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -87,6 +87,8 @@ export type FilePickerConfig = {
   promptForTitle: boolean;
   promptForGradable: boolean;
   autoGradingEnabled: boolean;
+  /** Whether the Hide & Reveal (checkpoint) option is available for new assignments. */
+  hideAndRevealEnabled?: boolean;
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;
   blackboard: {

--- a/lms/static/scripts/frontend_apps/config.ts
+++ b/lms/static/scripts/frontend_apps/config.ts
@@ -50,6 +50,26 @@ export type StudentInfo = {
 /**
  * Data needed to render the grading bar shown when an instructor views an assignment.
  */
+export type CheckpointConfig = {
+  /** Whether the assignment has a checkpoint (hide & reveal enabled). */
+  enabled: boolean;
+  /** Whether the checkpoint has already been revealed. */
+  revealed: boolean;
+  /** ISO date string of when the checkpoint was revealed, or null. */
+  revealDate: string | null;
+  /** ISO date string for the checkpoint due date, or null. */
+  dueDate: string | null;
+  /** API path to call to reveal the checkpoint. */
+  revealUrl: string;
+};
+
+export type StudentCheckpointConfig = {
+  /** Whether annotations are currently hidden. */
+  hidden: boolean;
+  /** ISO date string for the checkpoint due date, or null. */
+  dueDate: string | null;
+};
+
 export type InstructorConfig = {
   assignmentName: string;
   courseName: string;
@@ -58,6 +78,7 @@ export type InstructorConfig = {
   acceptGradingComments: boolean;
   students: StudentInfo[] | null;
   scoreMaximum: number | null;
+  checkpoint?: CheckpointConfig;
 };
 
 /**
@@ -87,8 +108,6 @@ export type FilePickerConfig = {
   promptForTitle: boolean;
   promptForGradable: boolean;
   autoGradingEnabled: boolean;
-  /** Whether the Hide & Reveal (checkpoint) option is available for new assignments. */
-  hideAndRevealEnabled?: boolean;
   deepLinkingAPI?: APICallInfo;
   ltiLaunchUrl: string;
   blackboard: {
@@ -340,6 +359,7 @@ export type ConfigObject = {
     getConfig: APICallInfo;
   };
   instructorToolbar?: InstructorConfig;
+  studentCheckpoint?: StudentCheckpointConfig;
   hypothesisClient?: ClientConfig;
   rpcServer?: {
     allowedOrigins: string[];

--- a/lms/templates/admin/application_instance/show.html.jinja2
+++ b/lms/templates/admin/application_instance/show.html.jinja2
@@ -130,6 +130,7 @@
                             {{ tri_state_settings_checkbox("Collect student emails", fields[Settings.HYPOTHESIS_COLLECT_STUDENT_EMAILS]) }}
                             {{ tri_state_settings_checkbox("Mentions", fields[Settings.HYPOTHESIS_MENTIONS]) }}
                             {{ tri_state_settings_checkbox("PDF image annotation", fields[Settings.HYPOTHESIS_PDF_IMAGE_ANNOTATION]) }}
+                            {{ tri_state_settings_checkbox("Hide & Reveal (Guided Social annotation)", fields[Settings.HYPOTHESIS_HIDE_AND_REVEAL]) }}
                         </fieldset>
                         <fieldset class="box">
                             <legend class="label has-text-centered">Grading settings</legend>

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -185,6 +185,9 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
     auto_grading_config = fields.Nested(
         AutoGradingConfigSchema, required=False, allow_none=True
     )
+    checkpoint_enabled = fields.Bool(
+        required=False, load_default=False, truthy={"true", "1"}, falsy={"false", "0", ""}
+    )
 
     @pre_load
     def _load_auto_grading_config(self, data, **_kwargs):

--- a/lms/validation/_lti_launch_params.py
+++ b/lms/validation/_lti_launch_params.py
@@ -186,7 +186,10 @@ class ConfigureAssignmentSchema(_CommonLTILaunchSchema):
         AutoGradingConfigSchema, required=False, allow_none=True
     )
     checkpoint_enabled = fields.Bool(
-        required=False, load_default=False, truthy={"true", "1"}, falsy={"false", "0", ""}
+        required=False,
+        load_default=False,
+        truthy={"true", "1"},
+        falsy={"false", "0", ""},
     )
 
     @pre_load

--- a/lms/views/api/checkpoint.py
+++ b/lms/views/api/checkpoint.py
@@ -26,7 +26,12 @@ def reveal_checkpoint(request):
         return {"error": "Assignment or checkpoint not found"}
 
     if assignment.checkpoint.reveal_date:
-        return {"revealed": True, "reveal_date": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()}
+        return {
+            "revealed": True,
+            "reveal_date": assignment.checkpoint.reveal_date.replace(
+                tzinfo=UTC
+            ).isoformat(),
+        }
 
     # Set the reveal date on the LMS side (source of truth)
     assignment.checkpoint.reveal_date = datetime.utcnow()  # noqa: DTZ003

--- a/lms/views/api/checkpoint.py
+++ b/lms/views/api/checkpoint.py
@@ -1,0 +1,53 @@
+from datetime import UTC, datetime
+
+from pyramid.view import view_config
+
+from lms.security import Permissions
+from lms.services import HAPI
+
+
+@view_config(
+    route_name="api.checkpoint.reveal",
+    request_method="POST",
+    renderer="json",
+    permission=Permissions.API,
+)
+def reveal_checkpoint(request):
+    if not request.lti_user.is_instructor:
+        request.response.status_code = 403
+        return {"error": "Only instructors can reveal annotations"}
+
+    assignment_id = int(request.matchdict["assignment_id"])
+    assignment_service = request.find_service(name="assignment")
+    assignment = assignment_service.get_by_id(assignment_id)
+
+    if not assignment or not assignment.checkpoint:
+        request.response.status_code = 404
+        return {"error": "Assignment or checkpoint not found"}
+
+    if assignment.checkpoint.reveal_date:
+        return {"revealed": True, "reveal_date": assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()}
+
+    # Set the reveal date on the LMS side (source of truth)
+    assignment.checkpoint.reveal_date = datetime.utcnow()  # noqa: DTZ003
+    reveal_date_iso = assignment.checkpoint.reveal_date.replace(tzinfo=UTC).isoformat()
+
+    # Sync the reveal to h via the existing sync_checkpoints endpoint
+    authority = request.registry.settings["h_authority"]
+    h_api = request.find_service(HAPI)
+    checkpoints = [
+        {
+            "group_authority_provided_id": grouping.authority_provided_id,
+            "document_uri": assignment.document_url,
+            "reveal_date": reveal_date_iso,
+        }
+        for grouping in assignment.groupings.all()
+    ]
+
+    if checkpoints:
+        h_api.sync_checkpoints(
+            authority=authority,
+            checkpoints=checkpoints,
+        )
+
+    return {"revealed": True, "reveal_date": reveal_date_iso}

--- a/lms/views/api/sync.py
+++ b/lms/views/api/sync.py
@@ -67,16 +67,32 @@ def sync(request):
             grading_student_id=grading_student_id,
         )
 
-    # Sync the groups over to H so they are ready to be annotated against
-    request.find_service(name="lti_h").sync(
-        groupings, request.parsed_params["group_info"]
-    )
-
     # Store the relationship between the assignment and the groupings
     assignment = assignment_service.get_assignment(
         course.application_instance.tool_consumer_instance_guid,
         request.parsed_params["resource_link_id"],
     )
+
+    # Look up the assignment to sync checkpoint data for the actual groupings
+    # (sections or canvas groups), not just the course group.
+    checkpoint_data = None
+    if assignment and assignment.checkpoint:
+        checkpoint_data = {
+            "document_uri": assignment.document_url,
+            "reveal_date": assignment.checkpoint.reveal_date.isoformat()
+            if assignment.checkpoint.reveal_date
+            else None,
+            "instructor_username": request.lti_user.h_user.username
+            if request.lti_user.is_instructor
+            else None,
+        }
+
+    # Sync the groups over to H so they are ready to be annotated against
+    request.find_service(name="lti_h").sync(
+        groupings, request.parsed_params["group_info"], checkpoint_data=checkpoint_data
+    )
+
+    # Store the relationship between the assignment and the groupings
     assignment_service.upsert_assignment_groupings(assignment, groupings=groupings)
 
     authority = request.registry.settings["h_authority"]

--- a/lms/views/api/sync.py
+++ b/lms/views/api/sync.py
@@ -3,6 +3,7 @@ from webargs import fields
 
 from lms.product.plugin.grouping import GroupError
 from lms.security import Permissions
+from lms.services.lti_h import checkpoint_sync_data
 from lms.validation._base import PyramidRequestSchema
 
 
@@ -67,29 +68,18 @@ def sync(request):
             grading_student_id=grading_student_id,
         )
 
-    # Store the relationship between the assignment and the groupings
+    # Look up the assignment so we can sync checkpoint data for the actual
+    # groupings (sections or canvas groups), not just the course group.
     assignment = assignment_service.get_assignment(
         course.application_instance.tool_consumer_instance_guid,
         request.parsed_params["resource_link_id"],
     )
 
-    # Look up the assignment to sync checkpoint data for the actual groupings
-    # (sections or canvas groups), not just the course group.
-    checkpoint_data = None
-    if assignment and assignment.checkpoint:
-        checkpoint_data = {
-            "document_uri": assignment.document_url,
-            "reveal_date": assignment.checkpoint.reveal_date.isoformat()
-            if assignment.checkpoint.reveal_date
-            else None,
-            "instructor_username": request.lti_user.h_user.username
-            if request.lti_user.is_instructor
-            else None,
-        }
-
     # Sync the groups over to H so they are ready to be annotated against
     request.find_service(name="lti_h").sync(
-        groupings, request.parsed_params["group_info"], checkpoint_data=checkpoint_data
+        groupings,
+        request.parsed_params["group_info"],
+        checkpoint_data=checkpoint_sync_data(assignment, request.lti_user),
     )
 
     # Store the relationship between the assignment and the groupings

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -22,6 +22,7 @@ from lms.product.plugin.misc import MiscPlugin  # noqa: TC001
 from lms.security import Permissions
 from lms.services import LTIGradingService, UserService, VitalSourceService
 from lms.services.assignment import AssignmentService  # noqa: TC001
+from lms.services.lti_h import checkpoint_sync_data
 from lms.validation import BasicLTILaunchSchema, ConfigureAssignmentSchema
 
 LOG = logging.getLogger(__name__)
@@ -177,22 +178,10 @@ class BasicLaunchViews:
 
         # Before any LTI assignments launch, create or update the Hypothesis
         # user and group corresponding to the LTI user and course.
-        checkpoint_data = None
-        if assignment.checkpoint:
-            checkpoint_data = {
-                "document_uri": assignment.document_url,
-                "reveal_date": assignment.checkpoint.reveal_date.isoformat()
-                if assignment.checkpoint.reveal_date
-                else None,
-                "instructor_username": self.request.lti_user.h_user.username
-                if self.request.lti_user.is_instructor
-                else None,
-            }
-
         self.request.find_service(name="lti_h").sync(
             [self.course],
             self.request.lti_params,
-            checkpoint_data=checkpoint_data,
+            checkpoint_data=checkpoint_sync_data(assignment, self.request.lti_user),
         )
 
         # Store the relationship between the assignment and the user

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -202,6 +202,12 @@ class BasicLaunchViews:
         ):
             self.context.js_config.enable_toolbar_editing()
 
+        if assignment.checkpoint:
+            if self.request.lti_user.is_instructor:
+                self.context.js_config.enable_toolbar_checkpoint(assignment)
+            else:
+                self.context.js_config.enable_student_checkpoint(assignment)
+
         if self.request.product.use_toolbar_grading and assignment.is_gradable:
             if self.request.lti_user.is_instructor:
                 # Get the list of students to display in the drop down

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -177,8 +177,22 @@ class BasicLaunchViews:
 
         # Before any LTI assignments launch, create or update the Hypothesis
         # user and group corresponding to the LTI user and course.
+        checkpoint_data = None
+        if assignment.checkpoint:
+            checkpoint_data = {
+                "document_uri": assignment.document_url,
+                "reveal_date": assignment.checkpoint.reveal_date.isoformat()
+                if assignment.checkpoint.reveal_date
+                else None,
+                "instructor_username": self.request.lti_user.h_user.username
+                if self.request.lti_user.is_instructor
+                else None,
+            }
+
         self.request.find_service(name="lti_h").sync(
-            [self.course], self.request.lti_params
+            [self.course],
+            self.request.lti_params,
+            checkpoint_data=checkpoint_data,
         )
 
         # Store the relationship between the assignment and the user
@@ -304,6 +318,9 @@ class BasicLaunchViews:
             group_set_id=self.request.parsed_params.get("group_set"),
             course=self.course,
             auto_grading_config=self.request.parsed_params.get("auto_grading_config"),
+            checkpoint_enabled=self.request.parsed_params.get(
+                "checkpoint_enabled", False
+            ),
         )
 
     def _configure_js_for_file_picker(

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -103,6 +103,7 @@ class DeepLinkingFieldsRequestSchema(JSONPyramidRequestSchema):
     auto_grading_config = fields.Nested(
         AutoGradingConfigSchema, required=False, allow_none=True
     )
+    checkpoint_enabled = fields.Bool(required=False, load_default=False)
 
 
 class LTI11DeepLinkingFieldsRequestSchema(DeepLinkingFieldsRequestSchema):
@@ -279,6 +280,9 @@ class DeepLinkingFieldsViews:
         if auto_grading_config := request.parsed_params.get("auto_grading_config"):
             # Custom params must be str, encode these settings as JSON
             params["auto_grading_config"] = json.dumps(auto_grading_config)
+
+        if request.parsed_params.get("checkpoint_enabled"):
+            params["checkpoint_enabled"] = "true"
 
         if content["type"] == "url":
             params["url"] = content["url"]

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -5,6 +5,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from tests.factories import requests_ as requests
 from tests.factories.application_instance import ApplicationInstance
 from tests.factories.assignment import Assignment, AutoGradingConfig
+from tests.factories.assignment_checkpoint import AssignmentCheckpoint
 from tests.factories.assignment_grouping import AssignmentGrouping
 from tests.factories.assignment_membership import (
     AssignmentMembership,

--- a/tests/factories/assignment_checkpoint.py
+++ b/tests/factories/assignment_checkpoint.py
@@ -1,0 +1,12 @@
+from factory import SubFactory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from lms import models
+from tests.factories.assignment import Assignment
+
+
+class AssignmentCheckpoint(SQLAlchemyModelFactory):
+    class Meta:
+        model = models.AssignmentCheckpoint
+
+    assignment = SubFactory(Assignment)

--- a/tests/functional/views/lti/deep_linking_test.py
+++ b/tests/functional/views/lti/deep_linking_test.py
@@ -28,6 +28,7 @@ class TestDeepLinkingLaunch:
         js_config = get_client_config(response)
         assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
         assert js_config["filePicker"] == {
+            "assignmentTypes": ["reading"],
             "autoGradingEnabled": True,
             "blackboard": {"enabled": None},
             "canvas": {

--- a/tests/unit/lms/models/application_instance_test.py
+++ b/tests/unit/lms/models/application_instance_test.py
@@ -194,6 +194,12 @@ class TestApplicationSettings:
                 "hypothesis.pdf_image_annotation",
                 SettingFormat.TRI_STATE,
             ),
+            (
+                "hypothesis",
+                "hide_and_reveal",
+                "hypothesis.hide_and_reveal",
+                SettingFormat.TRI_STATE,
+            ),
         ]
 
 

--- a/tests/unit/lms/models/assignment_checkpoint_test.py
+++ b/tests/unit/lms/models/assignment_checkpoint_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lms.models import AssignmentCheckpoint
+from tests import factories
+
+
+class TestAssignmentCheckpoint:
+    def test_it(self, db_session, assignment):
+        db_session.commit()  # Ensure our objects have ids
+
+        checkpoint = AssignmentCheckpoint(assignment=assignment)
+        db_session.add(checkpoint)
+
+        db_session.flush()
+        assert checkpoint.assignment == assignment
+        assert checkpoint.assignment_id == assignment.id
+        # reveal_date is NULL until the instructor reveals the assignment.
+        assert checkpoint.reveal_date is None
+
+    def test_factory(self, db_session):
+        checkpoint = factories.AssignmentCheckpoint()
+
+        db_session.flush()
+        assert checkpoint.assignment_id is not None
+
+    @pytest.fixture
+    def assignment(self):
+        return factories.Assignment.create()

--- a/tests/unit/lms/product/canvas/_plugin/misc_test.py
+++ b/tests/unit/lms/product/canvas/_plugin/misc_test.py
@@ -62,6 +62,17 @@ class TestCanvasMiscPlugin:
             "auto_grading_config": {"some": "value"},
         }
 
+    def test_get_assignment_configuration_with_checkpoint(
+        self, plugin, pyramid_request
+    ):
+        pyramid_request.params["checkpoint_enabled"] = "true"
+
+        config = plugin.get_assignment_configuration(
+            pyramid_request, sentinel.assignment, sentinel.historical_assignment
+        )
+
+        assert config["checkpoint_enabled"] is True
+
     def test_get_assignment_configuration(self, plugin, pyramid_request):
         config = plugin.get_assignment_configuration(
             pyramid_request, sentinel.assignment, sentinel.historical_assignment

--- a/tests/unit/lms/product/plugin/misc_test.py
+++ b/tests/unit/lms/product/plugin/misc_test.py
@@ -77,6 +77,30 @@ class TestMiscPlugin:
             == auto_grading_config.asdict()
         )
 
+    def test_get_assignment_configuration_with_checkpoint_in_existing_db_assignment(
+        self, plugin, pyramid_request
+    ):
+        assignment = factories.AssignmentCheckpoint().assignment
+        pyramid_request.lti_params["resource_link_id"] = sentinel.link_id
+
+        result = plugin.get_assignment_configuration(pyramid_request, assignment, None)
+
+        assert result["checkpoint_enabled"] is True
+
+    def test_get_assignment_configuration_with_checkpoint_in_deep_linked_configuration(
+        self, plugin, get_deep_linked_assignment_configuration
+    ):
+        get_deep_linked_assignment_configuration.return_value = {
+            "checkpoint_enabled": "true"
+        }
+
+        assert (
+            plugin.get_assignment_configuration(sentinel.request, None, None)[
+                "checkpoint_enabled"
+            ]
+            is True
+        )
+
     def test_get_assignment_configuration_with_assignment_in_db_copied_assignment(
         self, plugin, pyramid_request
     ):

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, create_autospec, patch, sentinel
 
 import pytest
@@ -619,8 +619,6 @@ class TestCheckpointToolbar:
         assert "revealUrl" in checkpoint
 
     def test_enable_toolbar_checkpoint_revealed(self, js_config):
-        from datetime import datetime
-
         assignment = MagicMock()
         assignment.checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
         assignment.id = 42
@@ -644,8 +642,6 @@ class TestCheckpointToolbar:
         assert config["studentCheckpoint"]["dueDate"] is None
 
     def test_enable_student_checkpoint_revealed(self, js_config):
-        from datetime import datetime
-
         assignment = MagicMock()
         assignment.checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
 

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import create_autospec, patch, sentinel
+from unittest.mock import MagicMock, create_autospec, patch, sentinel
 
 import pytest
 from h_matchers import Any
@@ -600,6 +600,60 @@ class TestInstructorToolbar:
             expected["scoreMaximum"] = sentinel.score_maximum
 
         assert js_config.asdict()["instructorToolbar"] == expected
+
+
+class TestCheckpointToolbar:
+    def test_enable_toolbar_checkpoint_unrevealed(self, js_config):
+        assignment = MagicMock()
+        assignment.checkpoint.reveal_date = None
+        assignment.id = 42
+
+        js_config.enable_toolbar_checkpoint(assignment)
+
+        config = js_config.asdict()
+        checkpoint = config["instructorToolbar"]["checkpoint"]
+        assert checkpoint["enabled"] is True
+        assert checkpoint["revealed"] is False
+        assert checkpoint["revealDate"] is None
+        assert checkpoint["dueDate"] is None
+        assert "revealUrl" in checkpoint
+
+    def test_enable_toolbar_checkpoint_revealed(self, js_config):
+        from datetime import datetime
+
+        assignment = MagicMock()
+        assignment.checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
+        assignment.id = 42
+
+        js_config.enable_toolbar_checkpoint(assignment)
+
+        config = js_config.asdict()
+        checkpoint = config["instructorToolbar"]["checkpoint"]
+        assert checkpoint["enabled"] is True
+        assert checkpoint["revealed"] is True
+        assert checkpoint["revealDate"] == "2026-07-01T12:00:00+00:00"
+
+    def test_enable_student_checkpoint_hidden(self, js_config):
+        assignment = MagicMock()
+        assignment.checkpoint.reveal_date = None
+
+        js_config.enable_student_checkpoint(assignment)
+
+        config = js_config.asdict()
+        assert config["studentCheckpoint"]["hidden"] is True
+        assert config["studentCheckpoint"]["dueDate"] is None
+
+    def test_enable_student_checkpoint_revealed(self, js_config):
+        from datetime import datetime
+
+        assignment = MagicMock()
+        assignment.checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
+
+        js_config.enable_student_checkpoint(assignment)
+
+        config = js_config.asdict()
+        assert config["studentCheckpoint"]["hidden"] is False
+        assert config["studentCheckpoint"]["dueDate"] == "2026-07-01T12:00:00+00:00"
 
 
 class TestSetFocusedUser:

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -67,6 +67,31 @@ class TestFilePickerMode:
         )
 
     @pytest.mark.parametrize(
+        "hide_and_reveal,expected_types",
+        [
+            # Flag explicitly on.
+            (True, ["reading", "hide_and_reveal"]),
+            # Flag explicitly off.
+            (False, ["reading"]),
+            # Flag unset: defaults to off.
+            (None, ["reading"]),
+        ],
+    )
+    def test_it_sets_assignment_types(
+        self, js_config, course, application_instance, hide_and_reveal, expected_types
+    ):
+        if hide_and_reveal is not None:
+            application_instance.settings.set(
+                "hypothesis", "hide_and_reveal", hide_and_reveal
+            )
+
+        js_config.enable_file_picker_mode(
+            sentinel.form_action, sentinel.form_fields, course
+        )
+
+        assert js_config.asdict()["filePicker"]["assignmentTypes"] == expected_types
+
+    @pytest.mark.parametrize(
         "config_function,key",
         (
             ("blackboard_config", "blackboard"),

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -6,6 +6,7 @@ from h_matchers import Any
 from sqlalchemy import select
 
 from lms.models import (
+    AssignmentCheckpoint,
     AssignmentGrouping,
     AssignmentMembership,
     AutoGradingConfig,
@@ -137,6 +138,52 @@ class TestAssignmentService:
 
         assert not assignment.auto_grading_config
         assert not db_session.get(AutoGradingConfig, auto_grading_config.id)
+
+    def test_update_assignment_with_checkpoint(self, svc, pyramid_request, course):
+        assignment = factories.Assignment()
+
+        assignment = svc.update_assignment(
+            pyramid_request,
+            assignment,
+            sentinel.document_url,
+            sentinel.group_set_id,
+            course,
+            checkpoint_enabled=True,
+        )
+
+        assert assignment.checkpoint
+
+    def test_update_assignment_without_checkpoint(self, svc, pyramid_request, course):
+        assignment = factories.Assignment()
+
+        assignment = svc.update_assignment(
+            pyramid_request,
+            assignment,
+            sentinel.document_url,
+            sentinel.group_set_id,
+            course,
+            checkpoint_enabled=False,
+        )
+
+        assert not assignment.checkpoint
+
+    def test_update_assignment_keeps_existing_checkpoint(
+        self, svc, pyramid_request, course
+    ):
+        existing_checkpoint = AssignmentCheckpoint()
+        assignment = factories.Assignment()
+        assignment.checkpoint = existing_checkpoint
+
+        assignment = svc.update_assignment(
+            pyramid_request,
+            assignment,
+            sentinel.document_url,
+            sentinel.group_set_id,
+            course,
+            checkpoint_enabled=True,
+        )
+
+        assert assignment.checkpoint is existing_checkpoint
 
     @pytest.mark.parametrize(
         "param",

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -266,6 +266,59 @@ class TestHAPI:
             for group in groups
         ]
 
+    def test_sync_checkpoints(self, h_api, _api_request):  # noqa: PT019
+        checkpoints = [
+            {
+                "group_authority_provided_id": "group1",
+                "document_uri": "https://example.com/doc",
+                "reveal_date": None,
+            }
+        ]
+
+        h_api.sync_checkpoints(authority="lms.hypothes.is", checkpoints=checkpoints)
+
+        _api_request.assert_called_once_with(
+            "POST",
+            path="bulk/checkpoint",
+            body=json.dumps(
+                {"authority": "lms.hypothes.is", "checkpoints": checkpoints}
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_sync_checkpoints_with_instructor(self, h_api, _api_request):  # noqa: PT019
+        checkpoints = [
+            {
+                "group_authority_provided_id": "group1",
+                "document_uri": "https://example.com/doc",
+                "reveal_date": None,
+            }
+        ]
+
+        h_api.sync_checkpoints(
+            authority="lms.hypothes.is",
+            checkpoints=checkpoints,
+            instructor_username="teacher",
+        )
+
+        _api_request.assert_called_once_with(
+            "POST",
+            path="bulk/checkpoint",
+            body=json.dumps(
+                {
+                    "authority": "lms.hypothes.is",
+                    "checkpoints": checkpoints,
+                    "instructor_username": "teacher",
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_sync_checkpoints_with_no_checkpoints(self, h_api, _api_request):  # noqa: PT019
+        h_api.sync_checkpoints(authority="lms.hypothes.is", checkpoints=[])
+
+        _api_request.assert_not_called()
+
     def test__api_request(self, h_api, http_service):
         h_api._api_request(sentinel.method, "dummy-path", body=sentinel.raw_body)  # noqa: SLF001
 

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -286,7 +286,7 @@ class TestHAPI:
             headers={"Content-Type": "application/json"},
         )
 
-    def test_sync_checkpoints_with_instructor(self, h_api, _api_request):  # noqa: PT019
+    def test_sync_checkpoints_with_user(self, h_api, _api_request):  # noqa: PT019
         checkpoints = [
             {
                 "group_authority_provided_id": "group1",
@@ -294,11 +294,12 @@ class TestHAPI:
                 "reveal_date": None,
             }
         ]
+        user = {"username": "teacher", "role": "instructor"}
 
         h_api.sync_checkpoints(
             authority="lms.hypothes.is",
             checkpoints=checkpoints,
-            instructor_username="teacher",
+            user=user,
         )
 
         _api_request.assert_called_once_with(
@@ -308,7 +309,7 @@ class TestHAPI:
                 {
                     "authority": "lms.hypothes.is",
                     "checkpoints": checkpoints,
-                    "instructor_username": "teacher",
+                    "user": user,
                 }
             ),
             headers={"Content-Type": "application/json"},
@@ -316,6 +317,30 @@ class TestHAPI:
 
     def test_sync_checkpoints_with_no_checkpoints(self, h_api, _api_request):  # noqa: PT019
         h_api.sync_checkpoints(authority="lms.hypothes.is", checkpoints=[])
+
+        _api_request.assert_not_called()
+
+    def test_reveal_checkpoints(self, h_api, _api_request):  # noqa: PT019
+        checkpoints = [
+            {
+                "group_authority_provided_id": "group1",
+                "document_uri": "https://example.com/doc",
+            }
+        ]
+
+        h_api.reveal_checkpoints(authority="lms.hypothes.is", checkpoints=checkpoints)
+
+        _api_request.assert_called_once_with(
+            "POST",
+            path="bulk/checkpoint/reveal",
+            body=json.dumps(
+                {"authority": "lms.hypothes.is", "checkpoints": checkpoints}
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_reveal_checkpoints_with_no_checkpoints(self, h_api, _api_request):  # noqa: PT019
+        h_api.reveal_checkpoints(authority="lms.hypothes.is", checkpoints=[])
 
         _api_request.assert_not_called()
 

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -69,6 +69,29 @@ class TestSync:
             grouping=grouping, params=sentinel.params
         )
 
+    def test_sync_syncs_checkpoints(self, h_api, lti_h_svc):
+        groupings = factories.Course.create_batch(2)
+        checkpoint_data = {
+            "document_uri": "https://example.com/doc",
+            "reveal_date": "2026-07-01T12:00:00",
+            "instructor_username": "teacher",
+        }
+
+        lti_h_svc.sync(groupings, sentinel.params, checkpoint_data=checkpoint_data)
+
+        h_api.sync_checkpoints.assert_called_once_with(
+            authority=lti_h_svc._authority,  # noqa: SLF001
+            checkpoints=[
+                {
+                    "group_authority_provided_id": grouping.authority_provided_id,
+                    "document_uri": "https://example.com/doc",
+                    "reveal_date": "2026-07-01T12:00:00",
+                }
+                for grouping in groupings
+            ],
+            instructor_username="teacher",
+        )
+
     @pytest.fixture
     def lti_h_svc(self, pyramid_request):
         return LTIHService(None, pyramid_request)

--- a/tests/unit/lms/services/lti_h_test.py
+++ b/tests/unit/lms/services/lti_h_test.py
@@ -74,7 +74,7 @@ class TestSync:
         checkpoint_data = {
             "document_uri": "https://example.com/doc",
             "reveal_date": "2026-07-01T12:00:00",
-            "instructor_username": "teacher",
+            "user": {"username": "teacher", "role": "instructor"},
         }
 
         lti_h_svc.sync(groupings, sentinel.params, checkpoint_data=checkpoint_data)
@@ -89,7 +89,7 @@ class TestSync:
                 }
                 for grouping in groupings
             ],
-            instructor_username="teacher",
+            user={"username": "teacher", "role": "instructor"},
         )
 
     @pytest.fixture

--- a/tests/unit/lms/views/api/checkpoint_test.py
+++ b/tests/unit/lms/views/api/checkpoint_test.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+from unittest.mock import MagicMock, create_autospec, sentinel
+
+import pytest
+
+from lms.models.assignment import Assignment
+from lms.models.assignment_checkpoint import AssignmentCheckpoint
+from lms.views.api.checkpoint import reveal_checkpoint
+
+
+@pytest.mark.usefixtures("assignment_service", "h_api", "user_is_instructor")
+class TestRevealCheckpoint:
+    def test_it_rejects_non_instructors(self, pyramid_request, user_is_learner):
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        result = reveal_checkpoint(pyramid_request)
+
+        assert pyramid_request.response.status_code == 403
+        assert "error" in result
+
+    def test_it_reveals_an_unrevealed_checkpoint(
+        self, pyramid_request, assignment_service, h_api
+    ):
+        assignment = self._assignment_with_checkpoint(reveal_date=None)
+        assignment_service.get_by_id.return_value = assignment
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        result = reveal_checkpoint(pyramid_request)
+
+        assignment_service.get_by_id.assert_called_once_with(1)
+        assert result["revealed"] is True
+        assert "reveal_date" in result
+        h_api.sync_checkpoints.assert_called_once()
+
+    def test_it_returns_already_revealed(
+        self, pyramid_request, assignment_service, h_api
+    ):
+        assignment = self._assignment_with_checkpoint(
+            reveal_date=datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
+        )
+        assignment_service.get_by_id.return_value = assignment
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        result = reveal_checkpoint(pyramid_request)
+
+        assert result["revealed"] is True
+        assert "reveal_date" in result
+        h_api.sync_checkpoints.assert_not_called()
+
+    def test_it_returns_404_when_assignment_not_found(
+        self, pyramid_request, assignment_service
+    ):
+        assignment_service.get_by_id.return_value = None
+        pyramid_request.matchdict = {"assignment_id": "999"}
+
+        result = reveal_checkpoint(pyramid_request)
+
+        assert pyramid_request.response.status_code == 404
+        assert "error" in result
+
+    def test_it_returns_404_when_no_checkpoint(
+        self, pyramid_request, assignment_service
+    ):
+        assignment = MagicMock()
+        assignment.checkpoint = None
+        assignment_service.get_by_id.return_value = assignment
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        result = reveal_checkpoint(pyramid_request)
+
+        assert pyramid_request.response.status_code == 404
+        assert "error" in result
+
+    def test_it_syncs_checkpoints_to_h(
+        self, pyramid_request, assignment_service, h_api
+    ):
+        assignment = self._assignment_with_checkpoint(reveal_date=None)
+        grouping = MagicMock()
+        grouping.authority_provided_id = "group1"
+        assignment.groupings.all.return_value = [grouping]
+        assignment.document_url = "https://example.com/doc"
+        assignment_service.get_by_id.return_value = assignment
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        reveal_checkpoint(pyramid_request)
+
+        h_api.sync_checkpoints.assert_called_once()
+        call_kwargs = h_api.sync_checkpoints.call_args[1]
+        assert call_kwargs["authority"] == "lms.hypothes.is"
+        assert len(call_kwargs["checkpoints"]) == 1
+        assert call_kwargs["checkpoints"][0]["group_authority_provided_id"] == "group1"
+        assert call_kwargs["checkpoints"][0]["document_uri"] == "https://example.com/doc"
+
+    def test_it_does_not_sync_when_no_groupings(
+        self, pyramid_request, assignment_service, h_api
+    ):
+        assignment = self._assignment_with_checkpoint(reveal_date=None)
+        assignment.groupings.all.return_value = []
+        assignment_service.get_by_id.return_value = assignment
+        pyramid_request.matchdict = {"assignment_id": "1"}
+
+        reveal_checkpoint(pyramid_request)
+
+        h_api.sync_checkpoints.assert_not_called()
+
+    def _assignment_with_checkpoint(self, reveal_date):
+        assignment = MagicMock()
+        checkpoint = MagicMock()
+        checkpoint.reveal_date = reveal_date
+        assignment.checkpoint = checkpoint
+        assignment.document_url = "https://example.com/doc"
+        grouping = MagicMock()
+        grouping.authority_provided_id = "group1"
+        assignment.groupings.all.return_value = [grouping]
+        return assignment
+
+    @pytest.fixture
+    def h_api(self, mock_service):
+        from lms.services import HAPI
+
+        return mock_service(HAPI)
+
+    @pytest.fixture
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.matchdict = {}
+        return pyramid_request

--- a/tests/unit/lms/views/api/checkpoint_test.py
+++ b/tests/unit/lms/views/api/checkpoint_test.py
@@ -1,16 +1,15 @@
 from datetime import datetime
-from unittest.mock import MagicMock, create_autospec, sentinel
+from unittest.mock import MagicMock
 
 import pytest
 
-from lms.models.assignment import Assignment
-from lms.models.assignment_checkpoint import AssignmentCheckpoint
+from lms.services import HAPI
 from lms.views.api.checkpoint import reveal_checkpoint
 
 
-@pytest.mark.usefixtures("assignment_service", "h_api", "user_is_instructor")
+@pytest.mark.usefixtures("assignment_service", "h_api")
 class TestRevealCheckpoint:
-    def test_it_rejects_non_instructors(self, pyramid_request, user_is_learner):
+    def test_it_rejects_non_instructors(self, pyramid_request):
         pyramid_request.matchdict = {"assignment_id": "1"}
 
         result = reveal_checkpoint(pyramid_request)
@@ -18,6 +17,7 @@ class TestRevealCheckpoint:
         assert pyramid_request.response.status_code == 403
         assert "error" in result
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_reveals_an_unrevealed_checkpoint(
         self, pyramid_request, assignment_service, h_api
     ):
@@ -32,6 +32,7 @@ class TestRevealCheckpoint:
         assert "reveal_date" in result
         h_api.sync_checkpoints.assert_called_once()
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_returns_already_revealed(
         self, pyramid_request, assignment_service, h_api
     ):
@@ -47,6 +48,7 @@ class TestRevealCheckpoint:
         assert "reveal_date" in result
         h_api.sync_checkpoints.assert_not_called()
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_returns_404_when_assignment_not_found(
         self, pyramid_request, assignment_service
     ):
@@ -58,6 +60,7 @@ class TestRevealCheckpoint:
         assert pyramid_request.response.status_code == 404
         assert "error" in result
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_returns_404_when_no_checkpoint(
         self, pyramid_request, assignment_service
     ):
@@ -71,6 +74,7 @@ class TestRevealCheckpoint:
         assert pyramid_request.response.status_code == 404
         assert "error" in result
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_syncs_checkpoints_to_h(
         self, pyramid_request, assignment_service, h_api
     ):
@@ -89,8 +93,11 @@ class TestRevealCheckpoint:
         assert call_kwargs["authority"] == "lms.hypothes.is"
         assert len(call_kwargs["checkpoints"]) == 1
         assert call_kwargs["checkpoints"][0]["group_authority_provided_id"] == "group1"
-        assert call_kwargs["checkpoints"][0]["document_uri"] == "https://example.com/doc"
+        assert (
+            call_kwargs["checkpoints"][0]["document_uri"] == "https://example.com/doc"
+        )
 
+    @pytest.mark.usefixtures("user_is_instructor")
     def test_it_does_not_sync_when_no_groupings(
         self, pyramid_request, assignment_service, h_api
     ):
@@ -116,8 +123,6 @@ class TestRevealCheckpoint:
 
     @pytest.fixture
     def h_api(self, mock_service):
-        from lms.services import HAPI
-
         return mock_service(HAPI)
 
     @pytest.fixture

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -1,7 +1,9 @@
-from unittest.mock import sentinel
+from datetime import datetime
+from unittest.mock import create_autospec, sentinel
 
 import pytest
 
+from lms.models.assignment_checkpoint import AssignmentCheckpoint
 from lms.product.plugin.grouping import GroupError
 from lms.views.api.sync import sync
 from tests import factories
@@ -31,7 +33,9 @@ class TestSync:
             grading_student_id=sentinel.grading_student_id,
         )
         lti_h_service.sync.assert_called_once_with(
-            grouping_service.get_sections.return_value, sentinel.group_info
+            grouping_service.get_sections.return_value,
+            sentinel.group_info,
+            checkpoint_data=None,
         )
         assignment_service.get_assignment.assert_called_once_with(
             course.application_instance.tool_consumer_instance_guid,
@@ -73,7 +77,9 @@ class TestSync:
             group_set_id=course.get_mapped_group_set_id.return_value,
         )
         lti_h_service.sync.assert_called_once_with(
-            grouping_service.get_groups.return_value, sentinel.group_info
+            grouping_service.get_groups.return_value,
+            sentinel.group_info,
+            checkpoint_data=None,
         )
         assignment_service.get_assignment.assert_called_once_with(
             course.application_instance.tool_consumer_instance_guid,
@@ -137,7 +143,9 @@ class TestSync:
         )
 
         lti_h_service.sync.assert_called_once_with(
-            grouping_service.get_groups.return_value, sentinel.group_info
+            grouping_service.get_groups.return_value,
+            sentinel.group_info,
+            checkpoint_data=None,
         )
         assignment_service.get_assignment.assert_called_once_with(
             course.application_instance.tool_consumer_instance_guid,
@@ -179,6 +187,116 @@ class TestSync:
             grading_student_id=sentinel.grading_student_id,
             group_set_id=course.get_mapped_group_set_id.return_value,
         )
+
+    @pytest.mark.usefixtures("course_service")
+    def test_it_syncs_checkpoint_data_with_sections(
+        self,
+        pyramid_request,
+        grouping_service,
+        assignment_service,
+        lti_h_service,
+    ):
+        checkpoint = create_autospec(AssignmentCheckpoint, instance=True)
+        checkpoint.reveal_date = None
+        assignment = assignment_service.get_assignment.return_value
+        assignment.checkpoint = checkpoint
+        assignment.document_url = "https://example.com/doc"
+
+        sync(pyramid_request)
+
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_sections.return_value,
+            sentinel.group_info,
+            checkpoint_data={
+                "document_uri": "https://example.com/doc",
+                "reveal_date": None,
+                "instructor_username": None,
+            },
+        )
+
+    @pytest.mark.usefixtures("course_service", "user_is_instructor")
+    def test_it_syncs_checkpoint_data_with_instructor(
+        self,
+        pyramid_request,
+        grouping_service,
+        assignment_service,
+        lti_h_service,
+    ):
+        checkpoint = create_autospec(AssignmentCheckpoint, instance=True)
+        checkpoint.reveal_date = None
+        assignment = assignment_service.get_assignment.return_value
+        assignment.checkpoint = checkpoint
+        assignment.document_url = "https://example.com/doc"
+
+        sync(pyramid_request)
+
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_sections.return_value,
+            sentinel.group_info,
+            checkpoint_data={
+                "document_uri": "https://example.com/doc",
+                "reveal_date": None,
+                "instructor_username": pyramid_request.lti_user.h_user.username,
+            },
+        )
+
+    @pytest.mark.usefixtures("course_service")
+    def test_it_syncs_checkpoint_data_with_reveal_date(
+        self,
+        pyramid_request,
+        grouping_service,
+        assignment_service,
+        lti_h_service,
+    ):
+        checkpoint = create_autospec(AssignmentCheckpoint, instance=True)
+        checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)
+        assignment = assignment_service.get_assignment.return_value
+        assignment.checkpoint = checkpoint
+        assignment.document_url = "https://example.com/doc"
+
+        sync(pyramid_request)
+
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_sections.return_value,
+            sentinel.group_info,
+            checkpoint_data={
+                "document_uri": "https://example.com/doc",
+                "reveal_date": "2026-07-01T12:00:00",
+                "instructor_username": None,
+            },
+        )
+
+    @pytest.mark.usefixtures("course_copy_plugin", "course_service")
+    def test_it_syncs_checkpoint_data_with_groups(
+        self,
+        pyramid_request,
+        grouping_service,
+        assignment_service,
+        lti_h_service,
+    ):
+        pyramid_request.parsed_params["group_set_id"] = sentinel.group_set_id
+        checkpoint = create_autospec(AssignmentCheckpoint, instance=True)
+        checkpoint.reveal_date = None
+        assignment = assignment_service.get_assignment.return_value
+        assignment.checkpoint = checkpoint
+        assignment.document_url = "https://example.com/doc"
+
+        sync(pyramid_request)
+
+        lti_h_service.sync.assert_called_once_with(
+            grouping_service.get_groups.return_value,
+            sentinel.group_info,
+            checkpoint_data={
+                "document_uri": "https://example.com/doc",
+                "reveal_date": None,
+                "instructor_username": None,
+            },
+        )
+
+    @pytest.fixture
+    def assignment_service(self, assignment_service):
+        assignment_service.get_assignment.return_value.checkpoint = None
+        return assignment_service
 
     @pytest.fixture
     def grouping_service(self, grouping_service):

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -249,7 +249,7 @@ class TestSync:
         lti_h_service,
     ):
         checkpoint = create_autospec(AssignmentCheckpoint, instance=True)
-        checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)
+        checkpoint.reveal_date = datetime(2026, 7, 1, 12, 0, 0)  # noqa: DTZ001
         assignment = assignment_service.get_assignment.return_value
         assignment.checkpoint = checkpoint
         assignment.document_url = "https://example.com/doc"

--- a/tests/unit/lms/views/api/sync_test.py
+++ b/tests/unit/lms/views/api/sync_test.py
@@ -210,7 +210,10 @@ class TestSync:
             checkpoint_data={
                 "document_uri": "https://example.com/doc",
                 "reveal_date": None,
-                "instructor_username": None,
+                "user": {
+                    "username": pyramid_request.lti_user.h_user.username,
+                    "role": "student",
+                },
             },
         )
 
@@ -236,7 +239,10 @@ class TestSync:
             checkpoint_data={
                 "document_uri": "https://example.com/doc",
                 "reveal_date": None,
-                "instructor_username": pyramid_request.lti_user.h_user.username,
+                "user": {
+                    "username": pyramid_request.lti_user.h_user.username,
+                    "role": "instructor",
+                },
             },
         )
 
@@ -262,7 +268,10 @@ class TestSync:
             checkpoint_data={
                 "document_uri": "https://example.com/doc",
                 "reveal_date": "2026-07-01T12:00:00",
-                "instructor_username": None,
+                "user": {
+                    "username": pyramid_request.lti_user.h_user.username,
+                    "role": "student",
+                },
             },
         )
 
@@ -289,7 +298,10 @@ class TestSync:
             checkpoint_data={
                 "document_uri": "https://example.com/doc",
                 "reveal_date": None,
-                "instructor_username": None,
+                "user": {
+                    "username": pyramid_request.lti_user.h_user.username,
+                    "role": "student",
+                },
             },
         )
 

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -80,6 +80,7 @@ class TestBasicLaunchViews:
             group_set_id=sentinel.group_set,
             course=course_service.get_from_launch.return_value,
             auto_grading_config=sentinel.auto_grading_config,
+            checkpoint_enabled=False,
         )
         _show_document.assert_called_once_with(
             assignment_service.create_assignment.return_value,
@@ -283,7 +284,9 @@ class TestBasicLaunchViews:
         result = svc._show_document(assignment)  # noqa: SLF001
 
         lti_h_service.sync.assert_called_once_with(
-            [course_service.get_from_launch.return_value], pyramid_request.lti_params
+            [course_service.get_from_launch.return_value],
+            pyramid_request.lti_params,
+            checkpoint_data=None,
         )
 
         assignment_service.upsert_assignment_membership.assert_called_once_with(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -399,8 +399,9 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    @pytest.mark.usefixtures("pyramid_request")
     def test__show_document_enables_checkpoint_toolbar_for_instructor(
-        self, svc, request, context, pyramid_request
+        self, svc, request, context
     ):
         request.getfixturevalue("user_is_instructor")
         assignment = factories.Assignment()
@@ -413,9 +414,8 @@ class TestBasicLaunchViews:
         context.js_config.enable_toolbar_checkpoint.assert_called_once_with(assignment)
         context.js_config.enable_student_checkpoint.assert_not_called()
 
-    def test__show_document_enables_student_checkpoint_for_student(
-        self, svc, context, pyramid_request
-    ):
+    @pytest.mark.usefixtures("pyramid_request")
+    def test__show_document_enables_student_checkpoint_for_student(self, svc, context):
         assignment = factories.Assignment()
         with mock.patch.object(
             type(assignment), "checkpoint", new_callable=mock.PropertyMock
@@ -426,9 +426,8 @@ class TestBasicLaunchViews:
         context.js_config.enable_student_checkpoint.assert_called_once_with(assignment)
         context.js_config.enable_toolbar_checkpoint.assert_not_called()
 
-    def test__show_document_no_checkpoint_config_without_checkpoint(
-        self, svc, context, pyramid_request
-    ):
+    @pytest.mark.usefixtures("pyramid_request")
+    def test__show_document_no_checkpoint_config_without_checkpoint(self, svc, context):
         assignment = factories.Assignment()
 
         svc._show_document(assignment)  # noqa: SLF001

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -399,6 +399,43 @@ class TestBasicLaunchViews:
 
         assert result == {}
 
+    def test__show_document_enables_checkpoint_toolbar_for_instructor(
+        self, svc, request, context, pyramid_request
+    ):
+        request.getfixturevalue("user_is_instructor")
+        assignment = factories.Assignment()
+        with mock.patch.object(
+            type(assignment), "checkpoint", new_callable=mock.PropertyMock
+        ) as checkpoint_prop:
+            checkpoint_prop.return_value = mock.MagicMock()
+            svc._show_document(assignment)  # noqa: SLF001
+
+        context.js_config.enable_toolbar_checkpoint.assert_called_once_with(assignment)
+        context.js_config.enable_student_checkpoint.assert_not_called()
+
+    def test__show_document_enables_student_checkpoint_for_student(
+        self, svc, context, pyramid_request
+    ):
+        assignment = factories.Assignment()
+        with mock.patch.object(
+            type(assignment), "checkpoint", new_callable=mock.PropertyMock
+        ) as checkpoint_prop:
+            checkpoint_prop.return_value = mock.MagicMock()
+            svc._show_document(assignment)  # noqa: SLF001
+
+        context.js_config.enable_student_checkpoint.assert_called_once_with(assignment)
+        context.js_config.enable_toolbar_checkpoint.assert_not_called()
+
+    def test__show_document_no_checkpoint_config_without_checkpoint(
+        self, svc, context, pyramid_request
+    ):
+        assignment = factories.Assignment()
+
+        svc._show_document(assignment)  # noqa: SLF001
+
+        context.js_config.enable_toolbar_checkpoint.assert_not_called()
+        context.js_config.enable_student_checkpoint.assert_not_called()
+
     @pytest.fixture
     def assignment(self):
         return factories.Assignment(is_gradable=False)

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -294,6 +294,7 @@ class TestDeepLinkingFieldsView:
                 {"auto_grading_config": {"key": "value"}},
                 {"auto_grading_config": '{"key": "value"}'},
             ),
+            ({"checkpoint_enabled": True}, {"checkpoint_enabled": "true"}),
         ],
     )
     def test__get_assignment_configuration(


### PR DESCRIPTION

  Hide & Reveal: backend feature flag + assignment types config

  Add a hypothesis.hide_and_reveal tri-state application setting (defaults to off), toggleable from the admin
  instance settings page.

  Expose an assignmentTypes array in the file picker JS config: reading is always available, hide_and_reveal
  is added only when the flag is enabled for the install.

  Includes unit tests for the new setting and the config output (flag on/off/unset).