### PR TITLE
test: use a >=32-byte secret in JWTCookieHelper tests (unblocks pyjwt 2.13.0)

### DIFF
--- a/tests/unit/lms/extensions/feature_flags/_helpers_test.py
+++ b/tests/unit/lms/extensions/feature_flags/_helpers_test.py
@@ -107,12 +107,18 @@ class TestJWTCookieHelper:
         helper.set(response, original_payload)
 
         cookie = response.headers["Set-Cookie"].split(";")[0].split("=")[1]
-        decoded_payload = jwt.decode(cookie, "test_secret", algorithms=["HS256"])
+        decoded_payload = jwt.decode(
+            cookie, "test_secret_at_least_32_bytes_for_hs256", algorithms=["HS256"]
+        )
         assert decoded_payload == original_payload
 
     def test_get_returns_the_decoded_payload(self, pyramid_request):
         original_payload = {"test_key": "test_value"}
-        encoded_payload = jwt.encode(original_payload, "test_secret", algorithm="HS256")
+        encoded_payload = jwt.encode(
+            original_payload,
+            "test_secret_at_least_32_bytes_for_hs256",
+            algorithm="HS256",
+        )
         pyramid_request.cookies["test_cookie_name"] = encoded_payload
         helper = JWTCookieHelper("test_cookie_name", pyramid_request)
 
@@ -143,5 +149,7 @@ class TestJWTCookieHelper:
 
     @pytest.fixture(autouse=True)
     def pyramid_config(self, pyramid_config):
-        pyramid_config.registry.settings["feature_flags_cookie_secret"] = "test_secret"  # noqa: S105
+        pyramid_config.registry.settings["feature_flags_cookie_secret"] = (
+            "test_secret_at_least_32_bytes_for_hs256"  # noqa: S105
+        )
         return pyramid_config


### PR DESCRIPTION
**Unblocks the pyjwt 2.13.0 security bump ([#7376](https://github.com/hypothesis/lms/pull/7376)).**

pyjwt 2.13.0 adds `InsecureKeyLengthWarning` — `jwt.encode()` with an HMAC key < 32 bytes (HS256) now warns (RFC 7518 §3.2). Our `JWTCookieHelper` tests use `"test_secret"` (11 bytes) and pytest runs `filterwarnings=error`, so the warning **fails the suite** → #7376 (and the same across repos) shows red `Tests`/`Functests`.

This swaps the 3 matching `"test_secret"` literals for a ≥32-byte value. **Version-independent** — passes with the current pyjwt 2.10.1, and clears the warning under 2.13.0. Verified in isolation: 11-byte key raises the warning, 39-byte key roundtrips clean under `-W error`.

Production is unaffected — the warning is never an error there; and the real `feature_flags_cookie_secret` deployment setting should already be a proper-length secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)