### PR TITLE
Retry h API requests on 429/503 with backoff

### DIFF
--- a/lms/services/assignment.py
+++ b/lms/services/assignment.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import Select, func, select, text
+from sqlalchemy import Select, func, or_, select, text
 from sqlalchemy.orm import Session
 
 from lms.models import (
@@ -44,22 +44,45 @@ class AssignmentService:
         )
 
     def get_by_canvas_assignment_id(
-        self, tool_consumer_instance_guid, canvas_assignment_id
+        self,
+        tool_consumer_instance_guid,
+        canvas_assignment_id=None,
+        ext_lti_assignment_id=None,
     ):
-        """Get an assignment by the Canvas assignment id recorded in `extra`.
+        """Get an assignment by a Canvas assignment identifier recorded in `extra`.
 
-        Canvas deep-linking "edit" launches don't carry a resource_link_id, but
-        they do send `custom_assignment_id`. We record that id in `extra` on
-        resource-link launches (see `_show_document`) so that a later edit can
-        find the existing assignment. Returns None when nothing matches (e.g. a
-        create, or an assignment not launched since this was introduced).
+        Canvas deep-linking "edit" launches don't carry a resource_link_id, so we
+        can't find the assignment the usual way. Instead we match on a Canvas
+        assignment identifier we recorded in `extra` on earlier resource-link
+        launches (see `_show_document`):
+
+        - LTI 1.3 sends ``custom_assignment_id`` (a numeric id).
+        - LTI 1.1 sends ``ext_lti_assignment_id`` (a UUID); Canvas does *not*
+          send ``custom_assignment_id`` there.
+
+        We match whichever identifier(s) the edit launch provides. Returns None
+        when nothing matches (e.g. a create, or an assignment not launched since
+        this was introduced).
         """
+        conditions = []
+        if canvas_assignment_id:
+            conditions.append(
+                Assignment.extra["canvas_assignment_id"].astext
+                == str(canvas_assignment_id)
+            )
+        if ext_lti_assignment_id:
+            conditions.append(
+                Assignment.extra["ext_lti_assignment_id"].astext
+                == str(ext_lti_assignment_id)
+            )
+        if not conditions:
+            return None
+
         return (
             self._db.query(Assignment)
             .filter(
                 Assignment.tool_consumer_instance_guid == tool_consumer_instance_guid,
-                Assignment.extra["canvas_assignment_id"].astext
-                == str(canvas_assignment_id),
+                or_(*conditions),
             )
             # Deterministic and crash-proof: never break the launch if, somehow,
             # more than one row shares the id.

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -2,7 +2,9 @@
 
 import itertools
 import json
+import random
 import re
+import time
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -13,6 +15,9 @@ from h_api.bulk_api import BulkAPI, CommandBuilder
 from lms.models import HUser
 from lms.services.exceptions import ExternalRequestError
 from lms.services.http import HTTPService
+
+RETRYABLE_STATUSES = {429, 503}
+MAX_ATTEMPTS = 3
 
 
 class AnnotationCounts(TypedDict):
@@ -287,6 +292,9 @@ class HAPI:
         :param body: the body to send as a string (without modification)
         :param headers: extra headers to pass with the request
 
+        Requests that fail with a retryable status (429 or 503) are retried
+        with a short backoff, up to MAX_ATTEMPTS attempts in total.
+
         :raise HAPIError: if the request fails for any other reason
         :return: the response from the h API
         :rtype: requests.Response
@@ -298,20 +306,37 @@ class HAPI:
         if body is not None:
             request_args["data"] = body
 
-        try:
-            response = self._http_service.request(
-                method=method,
-                url=self._base_url + path.lstrip("/"),
-                auth=self._http_auth,
-                headers=headers,
-                stream=stream,
-                timeout=(60, 60),
-                **request_args,
-            )
-        except ExternalRequestError as err:
-            raise HAPIError("Connecting to Hypothesis failed", err.response) from err  # noqa: EM101, TRY003
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                response = self._http_service.request(
+                    method=method,
+                    url=self._base_url + path.lstrip("/"),
+                    auth=self._http_auth,
+                    headers=headers,
+                    stream=stream,
+                    timeout=(60, 60),
+                    **request_args,
+                )
+            except ExternalRequestError as err:
+                status = err.response.status_code if err.response is not None else None
 
-        return response
+                if status not in RETRYABLE_STATUSES or attempt >= MAX_ATTEMPTS:
+                    raise HAPIError(  # noqa: TRY003
+                        "Connecting to Hypothesis failed",  # noqa: EM101
+                        err.response,
+                    ) from err
+
+                retry_after = (err.response.headers or {}).get("Retry-After")
+                delay = (
+                    float(retry_after)
+                    if retry_after
+                    else 0.5 * 2 ** (attempt - 1) + random.uniform(0, 0.2)  # noqa: S311
+                )
+                time.sleep(min(delay, 2.0))
+            else:
+                return response
 
     def get_userid(self, username):
         """Return the h userid for the given username and authority."""

--- a/lms/services/h_api.py
+++ b/lms/services/h_api.py
@@ -331,7 +331,8 @@ class HAPI:
                 retry_after = (err.response.headers or {}).get("Retry-After")
                 delay = (
                     float(retry_after)
-                    if retry_after
+                    # Retry-After can also be an HTTP-date, which we ignore.
+                    if retry_after and retry_after.replace(".", "", 1).isdigit()
                     else 0.5 * 2 ** (attempt - 1) + random.uniform(0, 0.2)  # noqa: S311
                 )
                 time.sleep(min(delay, 2.0))

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -110,14 +110,15 @@ export default function BasicLTILaunchApp() {
   // the app's access to the user's files in the LMS.
   const authWindow = useRef<AuthWindow | null>(null);
 
+  // Whether the client-side sync (sections/groups) has completed.
+  const [syncComplete, setSyncComplete] = useState(!syncAPICallInfo);
+
   // Checkpoint state from h, updated after the client-side sync resolves
   // the actual groupings (sections/canvas groups).
   const [syncCheckpoint, setSyncCheckpoint] = useState<
     SyncResponse['checkpoint'] | null
   >(null);
 
-  // Whether a client-side sync is pending (sections/groups assignments).
-  const waitingForSync = syncAPICallInfo && syncCheckpoint === null;
 
   const contentReady = !!contentURL;
 
@@ -183,9 +184,8 @@ export default function BasicLTILaunchApp() {
           data: syncAPICallInfo.data,
         });
         clientRPC.setGroups(groups);
-        if (checkpoint) {
-          setSyncCheckpoint(checkpoint);
-        }
+        setSyncCheckpoint(checkpoint ?? null);
+        setSyncComplete(true);
         success = true;
       } catch (e) {
         handleError(
@@ -368,11 +368,11 @@ export default function BasicLTILaunchApp() {
       >
         <InstructorToolbar
           syncCheckpoint={syncCheckpoint}
-          waitingForSync={waitingForSync}
+          syncComplete={syncComplete}
         />
         <StudentToolbar
           syncCheckpoint={syncCheckpoint}
-          waitingForSync={waitingForSync}
+          syncComplete={syncComplete}
         />
         <ContentFrame url={contentURL ?? ''} />
       </div>

--- a/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/BasicLTILaunchApp.tsx
@@ -119,7 +119,6 @@ export default function BasicLTILaunchApp() {
     SyncResponse['checkpoint'] | null
   >(null);
 
-
   const contentReady = !!contentURL;
 
   const incFetchCount = () => {

--- a/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/InstructorToolbar.tsx
@@ -17,10 +17,10 @@ type SyncCheckpoint = {
  */
 export default function InstructorToolbar({
   syncCheckpoint,
-  waitingForSync,
+  syncComplete,
 }: {
   syncCheckpoint?: SyncCheckpoint | null;
-  waitingForSync?: boolean;
+  syncComplete?: boolean;
 }) {
   const { instructorToolbar } = useConfig();
   if (!instructorToolbar) {
@@ -45,7 +45,7 @@ export default function InstructorToolbar({
   // `revealUrl` is required to reveal and only arrives with that config, so
   // without it we must not render a reveal button that would POST to an empty
   // URL.
-  const showCheckpoint = assignmentCheckpointEnabled && !waitingForSync;
+  const showCheckpoint = assignmentCheckpointEnabled && syncComplete;
 
   const withGradingControls = gradingEnabled && !!students;
 

--- a/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
@@ -63,7 +63,11 @@ export default function RevealAnnotationsButton({
       >
         Annotations revealed on
         <br className="md:hidden" />{' '}
-        {revealDate ? formatDateTime(revealDate.endsWith('Z') ? revealDate : revealDate + 'Z') : ''}
+        {revealDate
+          ? formatDateTime(
+              revealDate.endsWith('Z') ? revealDate : revealDate + 'Z',
+            )
+          : ''}
       </span>
     );
   }

--- a/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
@@ -63,7 +63,7 @@ export default function RevealAnnotationsButton({
       >
         Annotations revealed on
         <br className="md:hidden" />{' '}
-        {revealDate ? formatDateTime(revealDate) : ''}
+        {revealDate ? formatDateTime(revealDate.endsWith('Z') ? revealDate : revealDate + 'Z') : ''}
       </span>
     );
   }

--- a/lms/static/scripts/frontend_apps/components/StudentToolbar.tsx
+++ b/lms/static/scripts/frontend_apps/components/StudentToolbar.tsx
@@ -9,17 +9,17 @@ type SyncCheckpoint = {
 
 export default function StudentToolbar({
   syncCheckpoint,
-  waitingForSync,
+  syncComplete,
 }: {
   syncCheckpoint?: SyncCheckpoint | null;
-  waitingForSync?: boolean;
+  syncComplete?: boolean;
 }) {
   const { studentToolbar } = useConfig();
   if (!studentToolbar?.assignmentCheckpointEnabled) {
     return null;
   }
 
-  if (waitingForSync) {
+  if (!syncComplete) {
     return null;
   }
 

--- a/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
@@ -113,7 +113,7 @@ describe('InstructorToolbar', () => {
     fakeInstructorToolbar.assignmentCheckpointEnabled = true;
     fakeInstructorToolbar.courseCheckpointConfig = courseCheckpointConfig;
     assert.isFalse(
-      renderToolbar({ waitingForSync: true }).exists('CheckpointBar'),
+      renderToolbar({ syncComplete: false }).exists('CheckpointBar'),
     );
   });
 

--- a/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/InstructorToolbar-test.js
@@ -122,7 +122,7 @@ describe('InstructorToolbar', () => {
     fakeInstructorToolbar.courseCheckpointConfig = courseCheckpointConfig;
     fakeInstructorToolbar.assignmentDueDate = '2026-07-01T10:00:00';
 
-    const bar = renderToolbar().find('CheckpointBar');
+    const bar = renderToolbar({ syncComplete: true }).find('CheckpointBar');
     assert.isTrue(bar.exists());
     assert.deepEqual(bar.prop('checkpoint'), courseCheckpointConfig);
     assert.equal(bar.prop('dueDate'), '2026-07-01T10:00:00');
@@ -133,6 +133,7 @@ describe('InstructorToolbar', () => {
     fakeInstructorToolbar.courseCheckpointConfig = courseCheckpointConfig;
 
     const bar = renderToolbar({
+      syncComplete: true,
       syncCheckpoint: { revealed: true, revealDate: '2026-07-05T10:00:00' },
     }).find('CheckpointBar');
     assert.deepEqual(bar.prop('checkpoint'), {

--- a/lms/static/scripts/frontend_apps/components/test/StudentToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentToolbar-test.js
@@ -36,7 +36,7 @@ describe('StudentToolbar', () => {
   });
 
   it('renders nothing while waiting for sync', () => {
-    assert.isFalse(status(render({ waitingForSync: true })).exists());
+    assert.isFalse(status(render({ syncComplete: false })).exists());
   });
 
   it('shows annotations as hidden when not revealed', () => {

--- a/lms/static/scripts/frontend_apps/components/test/StudentToolbar-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/StudentToolbar-test.js
@@ -40,21 +40,31 @@ describe('StudentToolbar', () => {
   });
 
   it('shows annotations as hidden when not revealed', () => {
-    assert.include(status(render()).text(), 'Annotations are hidden');
+    assert.include(
+      status(render({ syncComplete: true })).text(),
+      'Annotations are hidden',
+    );
   });
 
   it('defaults to hidden when no checkpoint config is present', () => {
     delete fakeConfig.studentToolbar.courseCheckpointConfig;
-    assert.include(status(render()).text(), 'Annotations are hidden');
+    assert.include(
+      status(render({ syncComplete: true })).text(),
+      'Annotations are hidden',
+    );
   });
 
   it('shows annotations as visible when revealed via course config', () => {
     fakeConfig.studentToolbar.courseCheckpointConfig = { revealed: true };
-    assert.include(status(render()).text(), 'Annotations are visible');
+    assert.include(
+      status(render({ syncComplete: true })).text(),
+      'Annotations are visible',
+    );
   });
 
   it('prefers the sync checkpoint state over the course config', () => {
     const wrapper = render({
+      syncComplete: true,
       syncCheckpoint: { revealed: true, revealDate: null },
     });
     assert.include(status(wrapper).text(), 'Annotations are visible');
@@ -62,21 +72,25 @@ describe('StudentToolbar', () => {
 
   it('does not render a due date when none is provided', () => {
     assert.isFalse(
-      render().exists('[data-testid="student-checkpoint-due-date"]'),
+      render({ syncComplete: true }).exists(
+        '[data-testid="student-checkpoint-due-date"]',
+      ),
     );
   });
 
   it('renders the due date when provided', () => {
     fakeConfig.studentToolbar.assignmentDueDate = '2026-07-01T10:00:00';
     assert.isTrue(
-      render().exists('[data-testid="student-checkpoint-due-date"]'),
+      render({ syncComplete: true }).exists(
+        '[data-testid="student-checkpoint-due-date"]',
+      ),
     );
   });
 
   it(
     'should pass a11y checks',
     checkAccessibility({
-      content: () => render(),
+      content: () => render({ syncComplete: true }),
     }),
   );
 });

--- a/lms/views/lti/basic_launch.py
+++ b/lms/views/lti/basic_launch.py
@@ -176,10 +176,12 @@ class BasicLaunchViews:
     def _show_document(self, assignment):  # noqa: C901, PLR0912
         """Display a document to the user for annotation or grading."""
 
-        # Record the Canvas assignment id so that a later deep-linking "edit"
-        # launch (which carries no resource_link_id) can find this assignment and
-        # know it's an edit. No-op for other LMS (they don't send this param) and
-        # for unsubstituted values like "$Canvas.assignment.id".
+        # Record Canvas assignment identifiers so that a later deep-linking
+        # "edit" launch (which carries no resource_link_id) can find this
+        # assignment and know it's an edit. LTI 1.3 sends `custom_assignment_id`;
+        # LTI 1.1 sends `ext_lti_assignment_id` (Canvas does not send
+        # `custom_assignment_id` there). No-op for other LMS (they don't send
+        # these) and for unsubstituted values like "$Canvas.assignment.id".
         canvas_assignment_id = self.request.lti_params.get("custom_assignment_id")
         if (
             canvas_assignment_id
@@ -187,6 +189,13 @@ class BasicLaunchViews:
             and assignment.extra.get("canvas_assignment_id") != canvas_assignment_id
         ):
             assignment.extra["canvas_assignment_id"] = canvas_assignment_id
+
+        ext_lti_assignment_id = self.request.lti_params.get("ext_lti_assignment_id")
+        if (
+            ext_lti_assignment_id
+            and assignment.extra.get("ext_lti_assignment_id") != ext_lti_assignment_id
+        ):
+            assignment.extra["ext_lti_assignment_id"] = ext_lti_assignment_id
 
         # Determine the grouping type to decide whether to sync checkpoint
         # data for the course group. When the assignment uses sections/groups,

--- a/lms/views/lti/deep_linking.py
+++ b/lms/views/lti/deep_linking.py
@@ -77,13 +77,19 @@ def deep_linking_launch(context, request):
     request.find_service(name="lti_h").sync([course], request.params)
 
     # A Canvas deep-linking "edit" launch carries no resource_link_id, but Canvas
-    # sends `custom_assignment_id`. Look up the existing assignment by the Canvas
+    # sends an assignment identifier: `custom_assignment_id` on LTI 1.3 and
+    # `ext_lti_assignment_id` on LTI 1.1. Look up the existing assignment by the
     # id we recorded on previous resource-link launches so the frontend treats
     # this as an edit (skips the assignment-type workflow). None for a create or
-    # for any other LMS (they don't send this param).
-    assignment = None
+    # for any other LMS (they don't send these).
     canvas_assignment_id = request.lti_params.get("custom_assignment_id")
-    if canvas_assignment_id and not str(canvas_assignment_id).startswith("$"):
+    if canvas_assignment_id and str(canvas_assignment_id).startswith("$"):
+        # Unsubstituted placeholder like "$Canvas.assignment.id".
+        canvas_assignment_id = None
+    ext_lti_assignment_id = request.lti_params.get("ext_lti_assignment_id")
+
+    assignment = None
+    if canvas_assignment_id or ext_lti_assignment_id:
         assignment = request.find_service(
             name="assignment"
         ).get_by_canvas_assignment_id(
@@ -91,6 +97,7 @@ def deep_linking_launch(context, request):
                 "tool_consumer_instance_guid"
             ),
             canvas_assignment_id=canvas_assignment_id,
+            ext_lti_assignment_id=ext_lti_assignment_id,
         )
 
     context.js_config.enable_file_picker_mode(

--- a/tests/unit/lms/services/assignment_test.py
+++ b/tests/unit/lms/services/assignment_test.py
@@ -37,6 +37,48 @@ class TestAssignmentService:
             == assignment
         )
 
+    def test_get_by_canvas_assignment_id_via_ext_lti_assignment_id(self, svc):
+        # LTI 1.1 launches identify the assignment with `ext_lti_assignment_id`
+        # rather than `custom_assignment_id`.
+        assignment = factories.Assignment(
+            tool_consumer_instance_guid="GUID",
+            extra={"ext_lti_assignment_id": "a4c7af3a-uuid"},
+        )
+
+        assert (
+            svc.get_by_canvas_assignment_id(
+                tool_consumer_instance_guid="GUID",
+                ext_lti_assignment_id="a4c7af3a-uuid",
+            )
+            == assignment
+        )
+
+    def test_get_by_canvas_assignment_id_matches_either_id(self, svc):
+        # Passing both ids matches an assignment that has either one recorded.
+        assignment = factories.Assignment(
+            tool_consumer_instance_guid="GUID",
+            extra={"ext_lti_assignment_id": "a4c7af3a-uuid"},
+        )
+
+        assert (
+            svc.get_by_canvas_assignment_id(
+                tool_consumer_instance_guid="GUID",
+                canvas_assignment_id="9714",
+                ext_lti_assignment_id="a4c7af3a-uuid",
+            )
+            == assignment
+        )
+
+    def test_get_by_canvas_assignment_id_without_any_id(self, svc):
+        factories.Assignment(
+            tool_consumer_instance_guid="GUID",
+            extra={"canvas_assignment_id": "9714"},
+        )
+
+        assert (
+            svc.get_by_canvas_assignment_id(tool_consumer_instance_guid="GUID") is None
+        )
+
     @pytest.mark.parametrize(
         "guid,canvas_id",
         [

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -382,6 +382,81 @@ class TestHAPI:
         # It records the requests exception that caused the HAPIError.
         assert exc_info.value.__cause__ == exception
 
+    @pytest.mark.parametrize("status_code", [429, 503])
+    def test__api_request_retries_retryable_statuses_then_succeeds(
+        self, h_api, http_service, time, status_code
+    ):
+        response = factories.requests.Response(status_code=200)
+        http_service.request.side_effect = [
+            ExternalRequestError(
+                response=factories.requests.Response(status_code=status_code)
+            ),
+            response,
+        ]
+
+        result = h_api._api_request(sentinel.method, "dummy-path")  # noqa: SLF001
+
+        assert result == response
+        assert http_service.request.call_count == 2
+        # The first retry backs off 0.5s plus jitter (random.uniform => 0.1).
+        time.sleep.assert_called_once_with(0.6)
+
+    @pytest.mark.parametrize("status_code", [429, 503])
+    def test__api_request_raises_HAPIError_when_retries_are_exhausted(
+        self, h_api, http_service, time, status_code
+    ):
+        http_service.request.side_effect = [
+            ExternalRequestError(
+                response=factories.requests.Response(status_code=status_code)
+            )
+            for _ in range(3)
+        ]
+
+        with pytest.raises(HAPIError):
+            h_api._api_request(sentinel.method, "dummy-path")  # noqa: SLF001
+
+        assert http_service.request.call_count == 3
+        # Exponential backoff: 0.5s then 1s, plus jitter (random.uniform => 0.1).
+        assert time.sleep.call_args_list == [call(0.6), call(1.1)]
+
+    @pytest.mark.parametrize(
+        "retry_after,expected_delay",
+        [
+            # It sleeps for the number of seconds given by the Retry-After
+            # header, capped at 2s.
+            ("1.5", 1.5),
+            ("30", 2.0),
+        ],
+    )
+    def test__api_request_honors_the_Retry_After_header(
+        self, h_api, http_service, time, retry_after, expected_delay
+    ):
+        http_service.request.side_effect = [
+            ExternalRequestError(
+                response=factories.requests.Response(
+                    status_code=429, headers={"Retry-After": retry_after}
+                )
+            ),
+            factories.requests.Response(status_code=200),
+        ]
+
+        h_api._api_request(sentinel.method, "dummy-path")  # noqa: SLF001
+
+        time.sleep.assert_called_once_with(expected_delay)
+
+    def test__api_request_does_not_retry_non_retryable_statuses(
+        self, h_api, http_service, time
+    ):
+        http_service.request.side_effect = ExternalRequestError(
+            response=factories.requests.Response(status_code=400)
+        )
+
+        with pytest.raises(HAPIError):
+            h_api._api_request(sentinel.method, "dummy-path")  # noqa: SLF001
+
+        assert http_service.request.call_count == 1
+        time.sleep.assert_not_called()
+
     def test__api_request_raises_other_exceptions_normally(self, h_api, http_service):
         http_service.request.side_effect = OSError()
 
@@ -401,6 +476,16 @@ class TestHAPI:
     @pytest.fixture
     def BulkAPI(self, patch):
         return patch("lms.services.h_api.BulkAPI")
+
+    @pytest.fixture
+    def random(self, patch):
+        random = patch("lms.services.h_api.random")
+        random.uniform.return_value = 0.1
+        return random
+
+    @pytest.fixture
+    def time(self, patch, random):  # noqa: ARG002
+        return patch("lms.services.h_api.time")
 
     @pytest.fixture
     def h_api(self, http_service):

--- a/tests/unit/lms/services/h_api_test.py
+++ b/tests/unit/lms/services/h_api_test.py
@@ -426,6 +426,9 @@ class TestHAPI:
             # header, capped at 2s.
             ("1.5", 1.5),
             ("30", 2.0),
+            # Retry-After can also be an HTTP-date, which we ignore and fall
+            # back on the default backoff (0.5s plus jitter).
+            ("Wed, 08 Jul 2026 12:00:00 GMT", 0.6),
         ],
     )
     def test__api_request_honors_the_Retry_After_header(

--- a/tests/unit/lms/views/lti/basic_launch_test.py
+++ b/tests/unit/lms/views/lti/basic_launch_test.py
@@ -486,6 +486,27 @@ class TestBasicLaunchViews:
 
         assert "canvas_assignment_id" not in assignment.extra
 
+    def test__show_document_records_ext_lti_assignment_id(
+        self, svc, pyramid_request, assignment
+    ):
+        # LTI 1.1 Canvas launches identify the assignment with
+        # `ext_lti_assignment_id` instead of `custom_assignment_id`.
+        pyramid_request.lti_params["ext_lti_assignment_id"] = "a4c7af3a-uuid"
+
+        svc._show_document(assignment)  # noqa: SLF001
+
+        assert assignment.extra["ext_lti_assignment_id"] == "a4c7af3a-uuid"
+
+    @pytest.mark.usefixtures("lti_h_service", "assignment_service", "course_service")
+    def test__show_document_ignores_missing_ext_lti_assignment_id(
+        self, svc, pyramid_request, assignment
+    ):
+        assert "ext_lti_assignment_id" not in pyramid_request.lti_params
+
+        svc._show_document(assignment)  # noqa: SLF001
+
+        assert "ext_lti_assignment_id" not in assignment.extra
+
     @pytest.fixture
     def assignment(self):
         return factories.Assignment(is_gradable=False)

--- a/tests/unit/lms/views/lti/deep_linking_test.py
+++ b/tests/unit/lms/views/lti/deep_linking_test.py
@@ -122,17 +122,50 @@ class TestDeepLinkingLaunch:
         course_service,
         user_service,  # noqa: ARG002
     ):
-        # A Canvas deep-linking "edit" launch carries no resource_link_id but does
-        # send `custom_assignment_id`; we look the assignment up by the Canvas id
-        # recorded on previous resource-link launches so the frontend treats it as
-        # an edit.
+        # An LTI 1.3 Canvas deep-linking "edit" launch carries no resource_link_id
+        # but does send `custom_assignment_id`; we look the assignment up by the
+        # Canvas id recorded on previous resource-link launches so the frontend
+        # treats it as an edit.
         pyramid_request.lti_params["tool_consumer_instance_guid"] = "GUID"
         pyramid_request.lti_params["custom_assignment_id"] = "9714"
 
         deep_linking_launch(context, pyramid_request)
 
         assignment_service.get_by_canvas_assignment_id.assert_called_once_with(
-            tool_consumer_instance_guid="GUID", canvas_assignment_id="9714"
+            tool_consumer_instance_guid="GUID",
+            canvas_assignment_id="9714",
+            ext_lti_assignment_id=None,
+        )
+        context.js_config.enable_file_picker_mode.assert_called_once_with(
+            form_action="TEST_CONTENT_ITEM_RETURN_URL",
+            form_fields=Any(),
+            course=course_service.get_from_launch.return_value,
+            assignment=assignment_service.get_by_canvas_assignment_id.return_value,
+            prompt_for_title=misc_plugin.deep_linking_prompt_for_title,
+            prompt_for_gradable=misc_plugin.deep_linking_prompt_for_gradable.return_value,
+        )
+
+    def test_it_detects_a_canvas_edit_via_ext_lti_assignment_id(
+        self,
+        context,
+        pyramid_request,
+        assignment_service,
+        misc_plugin,
+        course_service,
+        user_service,  # noqa: ARG002
+    ):
+        # An LTI 1.1 Canvas deep-linking "edit" launch doesn't send
+        # `custom_assignment_id` but does send `ext_lti_assignment_id` (a UUID);
+        # we look the assignment up by that id instead.
+        pyramid_request.lti_params["tool_consumer_instance_guid"] = "GUID"
+        pyramid_request.lti_params["ext_lti_assignment_id"] = "a4c7af3a-uuid"
+
+        deep_linking_launch(context, pyramid_request)
+
+        assignment_service.get_by_canvas_assignment_id.assert_called_once_with(
+            tool_consumer_instance_guid="GUID",
+            canvas_assignment_id=None,
+            ext_lti_assignment_id="a4c7af3a-uuid",
         )
         context.js_config.enable_file_picker_mode.assert_called_once_with(
             form_action="TEST_CONTENT_ITEM_RETURN_URL",


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to assignment identification in Canvas LTI deep-linking launches, enhances the reliability of the Hypothesis API integration, and refines the frontend logic for assignment checkpoint synchronization. The most significant changes are grouped below.

### Backend: Canvas Assignment Identification Improvements

* The assignment service (`lms/services/assignment.py`) now supports looking up assignments by either `custom_assignment_id` (LTI 1.3) or `ext_lti_assignment_id` (LTI 1.1), allowing for more robust matching during Canvas deep-linking "edit" launches. The query matches assignments with either identifier, and both are now recorded on assignment launches if present. [[1]](diffhunk://#diff-26c58b6f938dfacf6ea122e6a784da3875b368b5889be39ab6ac2f1248da162eL47-R85) [[2]](diffhunk://#diff-138f3a71775a94d60bd0b0532c6b08e7ec836db1957ee2783d39feede66bf527L179-R184) [[3]](diffhunk://#diff-138f3a71775a94d60bd0b0532c6b08e7ec836db1957ee2783d39feede66bf527R193-R199) [[4]](diffhunk://#diff-0196b8e891fd66e48109dcc2e2dc688bad2e043ad6ebf88c93bd0c2739126519L80-R100)
* The deep-linking launch view (`lms/views/lti/deep_linking.py`) is updated to check for both types of assignment identifiers, ignoring unsubstituted placeholders, and passes both to the assignment lookup.
* Unit tests are added to cover assignment retrieval by either or both identifiers, and to ensure that missing identifiers are handled gracefully.

### Backend: Hypothesis API Reliability

* The Hypothesis API service (`lms/services/h_api.py`) now retries requests that fail with HTTP 429 or 503 status codes, using an exponential backoff with jitter and respecting the `Retry-After` header if present, up to a maximum of three attempts. This improves resilience against temporary rate limits and service outages. [[1]](diffhunk://#diff-dcf88913acd7b02802bfc19784c4117c2f9ccd191958d16b595429949de2c54aR19-R21) [[2]](diffhunk://#diff-dcf88913acd7b02802bfc19784c4117c2f9ccd191958d16b595429949de2c54aR295-R297) [[3]](diffhunk://#diff-dcf88913acd7b02802bfc19784c4117c2f9ccd191958d16b595429949de2c54aR309-R311) [[4]](diffhunk://#diff-dcf88913acd7b02802bfc19784c4117c2f9ccd191958d16b595429949de2c54aL312-R339)

### Frontend: Assignment Checkpoint Synchronization

* The frontend apps (`BasicLTILaunchApp.tsx`, `InstructorToolbar.tsx`, `StudentToolbar.tsx`) now use a `syncComplete` state to track when client-side group/section sync has finished, replacing the previous `waitingForSync` logic. This ensures that checkpoint bars and annotation visibility are only displayed after synchronization is complete. [[1]](diffhunk://#diff-92a7a0185a75537b4e918609638e94510d91d773db52d273c8dd849a2367d222R113-L121) [[2]](diffhunk://#diff-92a7a0185a75537b4e918609638e94510d91d773db52d273c8dd849a2367d222L186-R187) [[3]](diffhunk://#diff-92a7a0185a75537b4e918609638e94510d91d773db52d273c8dd849a2367d222L371-R374) [[4]](diffhunk://#diff-3f398d67fdd3d38eaa4cca2e6198ec87107b548340b3be63e12c65181ca39de1L20-R23) [[5]](diffhunk://#diff-3f398d67fdd3d38eaa4cca2e6198ec87107b548340b3be63e12c65181ca39de1L48-R48) [[6]](diffhunk://#diff-37d4387b635f3ae83382456cce703452fbbd138f37dd4124f52120597b91c898L12-R22)
* Corresponding frontend tests are updated to use the new `syncComplete` prop and verify correct behavior. [[1]](diffhunk://#diff-dbb3fb98cc82c125c76ff68ab12078f8347fe047cdb0bf1b6c9bfca679e2d281L116-R116) [[2]](diffhunk://#diff-dbb3fb98cc82c125c76ff68ab12078f8347fe047cdb0bf1b6c9bfca679e2d281L125-R125) [[3]](diffhunk://#diff-dbb3fb98cc82c125c76ff68ab12078f8347fe047cdb0bf1b6c9bfca679e2d281R136) [[4]](diffhunk://#diff-a470402d23b5af20c7fa0b627c45c2a0318918928ca77ecbc11bf7cbd3310e97L39-R93)

### Frontend: Annotation Reveal Date Handling

* The `RevealAnnotationsButton` component now ensures that reveal dates are always formatted as UTC by appending 'Z' if necessary, fixing potential display issues for non-UTC dates.

These changes collectively improve assignment edit detection, reliability under API rate limits, and the user experience around assignment checkpoint visibility.