### PR TITLE
Fix: reveal-annotations UI freezes when h returns timezone-aware reveal dates

### DIFF
--- a/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
@@ -8,6 +8,7 @@ import { useCallback, useRef, useState } from 'preact/hooks';
 import type { CheckpointConfig } from '../config';
 import { useConfig } from '../config';
 import { apiCall } from '../utils/api';
+import { assumeUTC } from '../utils/date';
 import ErrorDisplay from './ErrorDisplay';
 
 export type RevealAnnotationsButtonProps = {
@@ -63,11 +64,7 @@ export default function RevealAnnotationsButton({
       >
         Annotations revealed on
         <br className="md:hidden" />{' '}
-        {revealDate
-          ? formatDateTime(
-              revealDate.endsWith('Z') ? revealDate : revealDate + 'Z',
-            )
-          : ''}
+        {revealDate ? formatDateTime(assumeUTC(revealDate)) : ''}
       </span>
     );
   }

--- a/lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js
@@ -19,7 +19,10 @@ describe('RevealAnnotationsButton', () => {
   };
 
   beforeEach(() => {
-    fakeApiCall = sinon.stub().resolves({ reveal_date: '2026-07-02T10:00:00' });
+    fakeApiCall = sinon.stub().resolves({
+      // h returns timezone-aware datetimes with an explicit offset.
+      reveal_date: '2026-07-02T10:00:00.622705+00:00',
+    });
     fakeConfig = { api: { authToken: 'dummyAuthToken' } };
 
     // Keep `Button`/`ModalDialog` real so the click-through works; only mock
@@ -57,6 +60,23 @@ describe('RevealAnnotationsButton', () => {
     });
     assert.isTrue(wrapper.exists('[data-testid="checkpoint-revealed"]'));
     assert.isFalse(wrapper.exists('[data-testid="reveal-annotations-button"]'));
+  });
+
+  it('formats reveal dates that have an explicit timezone offset', () => {
+    // Regression test: h returns timezone-aware datetimes
+    // ("2026-07-01T10:00:00+00:00"). Blindly appending "Z" produced an
+    // invalid date and `formatDateTime` threw, freezing the whole app.
+    const wrapper = render({
+      ...checkpoint,
+      revealed: true,
+      revealDate: '2026-07-01T10:00:00.622705+00:00',
+    });
+
+    const banner = wrapper.find('[data-testid="checkpoint-revealed"]');
+    assert.isTrue(banner.exists());
+    assert.notInclude(banner.text(), 'Invalid');
+    // The formatted date should include the year.
+    assert.include(banner.text(), '2026');
   });
 
   it('shows the revealed state without a reveal date', () => {

--- a/lms/static/scripts/frontend_apps/utils/date.ts
+++ b/lms/static/scripts/frontend_apps/utils/date.ts
@@ -1,0 +1,13 @@
+/**
+ * Return a datetime string that `Date` reliably parses as UTC.
+ *
+ * Backend datetimes come in two shapes: naive strings with no timezone
+ * ("2026-07-08T23:59:29.622705") which are implicitly UTC, and strings with
+ * an explicit offset ("2026-07-08T23:59:29.622705+00:00") produced by
+ * timezone-aware columns. Appending "Z" to a string that already has an
+ * offset (or a "Z") produces an invalid date, so only append it to naive
+ * strings.
+ */
+export function assumeUTC(date: string): string {
+  return /Z$|[+-]\d{2}:\d{2}$/.test(date) ? date : date + 'Z';
+}

--- a/lms/static/scripts/frontend_apps/utils/test/date-test.js
+++ b/lms/static/scripts/frontend_apps/utils/test/date-test.js
@@ -1,0 +1,21 @@
+import { assumeUTC } from '../date';
+
+describe('assumeUTC', () => {
+  [
+    // Naive datetimes are assumed to be UTC.
+    ['2026-07-08T23:59:29', '2026-07-08T23:59:29Z'],
+    ['2026-07-08T23:59:29.622705', '2026-07-08T23:59:29.622705Z'],
+    // Datetimes with an explicit offset or "Z" are returned unchanged.
+    ['2026-07-08T23:59:29.622705+00:00', '2026-07-08T23:59:29.622705+00:00'],
+    ['2026-07-08T20:59:29-03:00', '2026-07-08T20:59:29-03:00'],
+    ['2026-07-08T23:59:29Z', '2026-07-08T23:59:29Z'],
+  ].forEach(([input, expected]) => {
+    it(`normalizes ${input}`, () => {
+      assert.equal(assumeUTC(input), expected);
+    });
+
+    it(`produces a string that Date can parse (${input})`, () => {
+      assert.isFalse(isNaN(new Date(assumeUTC(input)).valueOf()));
+    });
+  });
+});


### PR DESCRIPTION

## Problem

Clicking **Reveal** on a checkpoint assignment leaves the confirmation modal
stuck open with the button disabled, and the "Annotations revealed on ..."
banner never appears — even though the reveal succeeds on the backend
(response: `{revealed: true, reveal_date: "2026-07-08T23:59:29.622705+00:00"}`).

The same crash also prevents the revealed banner from rendering on any
subsequent launch of an already-revealed assignment.

## Root cause

`RevealAnnotationsButton` renders the reveal date with:

```tsx
formatDateTime(revealDate.endsWith('Z') ? revealDate : revealDate + 'Z')
```

This assumes h returns *naive* datetimes. h's checkpoint `reveal_date` is
timezone-aware, so `isoformat()` produces `"...+00:00"`. Appending `Z` yields
`"...+00:00Z"` → `Invalid Date` → `Intl.DateTimeFormat.format()` throws
`RangeError: Invalid time value` **during render**. Preact aborts the render,
freezing the DOM at the previous frame (modal open, button disabled from the
`busy` state), while component state already says "revealed".

All three sources of this string flow into this one component: the initial
`js_config` checkpoint config, the `/api/sync` response, and the reveal API
response — so one fix site covers them all.

## Fix

- New `utils/date.ts` helper `assumeUTC()`: appends `Z` **only** to naive
  datetime strings; strings with an explicit offset (or `Z`) pass through
  unchanged.
- `RevealAnnotationsButton` uses it instead of the inline `endsWith('Z')`
  ternary.

## Tests

- `utils/test/date-test.js`: naive, `+00:00`, negative-offset, and `Z`-suffixed
  inputs all normalize to strings `Date` can parse.
- `RevealAnnotationsButton-test.js`:
  - regression test — rendering with `revealDate: "2026-07-01T10:00:00.622705+00:00"`
    shows the banner with a formatted date (previously threw).
  - the mocked reveal API now resolves with a timezone-aware datetime, matching
    what h actually returns, so the existing "reveals annotations when
    confirmed" flow exercises the real format.

## How to verify on staging

1. Launch a checkpoint assignment as instructor
   (e.g. hypothesis.instructure.com course 252, "TEST CHECKPOINT").
2. Click **Reveal annotations** → confirm. Modal closes and the banner
   "Annotations revealed on {date}" appears immediately.
3. Relaunch the assignment: banner still renders; no
   `RangeError: Invalid time value` in the console.

Related: HnR rollout (lms#7396, h#10155); staging launch 429s addressed in
h#10156 and lms#7403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
