### PR TITLE
chore: change label

### DIFF
--- a/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/AssignmentTypeSelector.tsx
@@ -12,8 +12,8 @@ export type AssignmentType = 'reading' | 'hide_and_reveal';
 
 /** Human-readable label shown in the selector for each assignment type. */
 const ASSIGNMENT_TYPE_LABELS: Record<AssignmentType, string> = {
-  reading: 'Social annotation',
-  hide_and_reveal: 'Guided Social annotation',
+  reading: 'Social Annotation',
+  hide_and_reveal: 'Paced Social Annotation',
 };
 
 /** Short description shown under each option's label. */


### PR DESCRIPTION
This pull request makes minor improvements to the assignment type labels in the `AssignmentTypeSelector` component, updating them for consistency and clarity.

* Changed the label for the `reading` assignment type to "Social Annotation" and the label for the `hide_and_reveal` assignment type to "Paced Social Annotation" in `AssignmentTypeSelector.tsx` for improved clarity and consistency.