### PR TITLE
Fix due date incompleteness error

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -128,6 +128,14 @@ function contentFromURL(url: string): Content {
   return { type: 'url', url };
 }
 
+function localDateTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
 /**
  * Fetch additional configuration needed by the file picker app.
  *
@@ -289,15 +297,9 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // local `datetime-local` string (`YYYY-MM-DDTHH:MM`); it's converted to UTC
   // on submit.
   const dueDateInputRef = useRef<HTMLInputElement | null>(null);
-  const minDueDate = useMemo(() => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
-    return `${year}-${month}-${day}T${hours}:${minutes}`;
-  }, []);
+  // Recomputed on each render rather than memoized on mount, so "now" cannot go
+  // stale while the picker sits open.
+  const minDueDate = localDateTime(new Date());
 
   // A checkpoint ("Hide & Reveal") assignment is being created when the
   // instructor picked that type in the workflow. This drives the
@@ -313,14 +315,27 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // further steps (checkpoint, due-date); other types go straight to the
   // regular flow.
   const goToNextWorkflowStep = () => {
-    // Block leaving the due-date step while a date has been entered but isn't in
-    // the future. An empty value is allowed since the due date is optional.
-    // `datetime-local` strings (`YYYY-MM-DDTHH:MM`) compare lexicographically,
-    // so a plain string comparison against the minimum (now) is correct.
-    if (workflowStep === 'due-date' && dueDate && dueDate < minDueDate) {
-      // Surface the input's native validation message (driven by its `min`).
-      dueDateInputRef.current?.reportValidity();
-      return;
+    if (workflowStep === 'due-date') {
+      const input = dueDateInputRef.current;
+
+      // A partly-filled `datetime-local` (say, one missing its AM/PM) reads
+      // back as the empty string, so `dueDate` is null here — indistinguishable
+      // from the legal "left blank". Only the input itself can tell them apart,
+      // via the `badInput` its validity carries.
+      if (input && !input.reportValidity()) {
+        return;
+      }
+
+      // Block leaving the step while a date has been entered but isn't in the
+      // future. An empty value is allowed since the due date is optional.
+      // `datetime-local` strings (`YYYY-MM-DDTHH:MM`) compare
+      // lexicographically, so a plain string comparison against the minimum
+      // (now) is correct.
+      if (dueDate && dueDate < minDueDate) {
+        // Surface the input's native validation message (driven by its `min`).
+        input?.reportValidity();
+        return;
+      }
     }
     // From 'checkpoint' the next step is 'due-date'; from 'due-date' (the last
     // step) the workflow is done. The 'assignment-type' step has no "Next" — it

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -147,6 +147,20 @@ describe('FilePickerApp', () => {
     }
 
     /**
+     * Stand in for the browser's constraint validation on the due-date input.
+     *
+     * `DueDateSelector` is mocked here, so the real `<input>` — and with it the
+     * `validity` the browser maintains — never exists. The mock still receives
+     * the ref, so populating it simulates an input the browser considers
+     * invalid (e.g. `badInput`, set when a `datetime-local` is only partly
+     * filled in).
+     */
+    function setInputValidity(wrapper, valid) {
+      const { inputRef } = wrapper.find('DueDateSelector').first().props();
+      inputRef.current = { reportValidity: () => valid };
+    }
+
+    /**
      * Local `datetime-local` string (`YYYY-MM-DDTHH:MM`) `days` from now
      * (negative for the past).
      */
@@ -240,6 +254,40 @@ describe('FilePickerApp', () => {
       clickNext(wrapper);
       assert.isTrue(wrapper.exists('DueDateSelector'));
       assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    it('blocks the due-date step when the date is incomplete', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+
+      // A partly-filled `datetime-local` (say, no AM/PM) reads back as the
+      // empty string, so the component is handed `null` — which is otherwise
+      // the legal "left blank". Only the input knows it is in a bad state.
+      setInputValidity(wrapper, false);
+      setDueDate(wrapper, null);
+
+      clickNext(wrapper);
+      assert.isTrue(wrapper.exists('DueDateSelector'));
+      assert.isFalse(wrapper.exists('ContentSelector'));
+    });
+
+    it('leaves the due-date step when no date is entered', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+
+      // The due date is optional, so an empty (and valid) input advances.
+      setInputValidity(wrapper, true);
+
+      clickNext(wrapper);
+      assert.isFalse(wrapper.exists('DueDateSelector'));
+      assert.isTrue(wrapper.exists('ContentSelector'));
     });
 
     it('leaves the due-date step when the date is in the future', () => {


### PR DESCRIPTION
This pull request improves the due date input validation in the `FilePickerApp` component to better handle incomplete or invalid date entries and updates the related tests to match the new logic. The main changes ensure that the app correctly blocks navigation when the due date field is partially filled or invalid, and allows progression only when the input is valid or empty.

**Due date validation improvements:**

* Refactored the computation of the minimum allowed due date (`minDueDate`) to use a new `localDateTime` helper function, ensuring the minimum date is always current and not stale. [[1]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883R131-R138) [[2]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883L292-R302)
* Enhanced the logic in the `goToNextWorkflowStep` function to use the input element's native validity checking (`reportValidity()`) for the due date field. This blocks progression if the input is incomplete or invalid, rather than relying solely on string comparison.

**Testing updates:**

* Added a utility function `setInputValidity` in the test suite to simulate browser constraint validation for the mocked due date input.
* Added new tests to verify that:
  - The due-date step is blocked when the input is incomplete or invalid.
  - The due-date step is correctly skipped when no date is entered and the input is valid.