### PR TITLE
Fix toolbar-h async

### DIFF
--- a/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
+++ b/lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx
@@ -41,12 +41,18 @@ export default function RevealAnnotationsButton({
     setBusy(true);
     setError(null);
     try {
-      const result = await apiCall<{ reveal_date: string }>({
+      // h is the source of truth for reveal state, so take it from the
+      // response rather than assuming the request succeeding means the
+      // annotations were revealed.
+      const result = await apiCall<{
+        revealed: boolean;
+        reveal_date: string | null;
+      }>({
         authToken,
         path: checkpoint.revealUrl,
         data: {},
       });
-      setRevealed(true);
+      setRevealed(result.revealed);
       setRevealDate(result.reveal_date);
       setShowModal(false);
     } catch (err) {

--- a/lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js
@@ -20,6 +20,7 @@ describe('RevealAnnotationsButton', () => {
 
   beforeEach(() => {
     fakeApiCall = sinon.stub().resolves({
+      revealed: true,
       // h returns timezone-aware datetimes with an explicit offset.
       reveal_date: '2026-07-02T10:00:00.622705+00:00',
     });
@@ -118,6 +119,23 @@ describe('RevealAnnotationsButton', () => {
       path: checkpoint.revealUrl,
       data: {},
     });
+  });
+
+  it('stays unrevealed when the backend reports nothing was revealed', async () => {
+    // h is the source of truth. A 200 response doesn't mean a checkpoint was
+    // revealed -- if h revealed nothing, the toolbar must not claim otherwise.
+    fakeApiCall.resolves({ revealed: false, reveal_date: null });
+    const wrapper = render();
+    clickButton(wrapper, 'reveal-annotations-button');
+    clickButton(wrapper, 'confirm-reveal-button');
+
+    await waitFor(() => {
+      wrapper.update();
+      return !wrapper.exists('[data-testid="confirm-reveal-button"]');
+    });
+
+    assert.isFalse(wrapper.exists('[data-testid="checkpoint-revealed"]'));
+    assert.isTrue(wrapper.exists('[data-testid="reveal-annotations-button"]'));
   });
 
   it('shows an error and keeps the modal open if revealing fails', async () => {

--- a/lms/views/api/checkpoint.py
+++ b/lms/views/api/checkpoint.py
@@ -69,12 +69,14 @@ def reveal_checkpoint(request):
         checkpoints=checkpoints,
     )
 
-    # Return the reveal date from h's response
+    # Report h's answer
     reveal_date = None
+    revealed = False
     if results:
         for result in results:
             if result.get("revealed"):
+                revealed = True
                 reveal_date = result.get("reveal_date")
                 break
 
-    return {"revealed": True, "reveal_date": reveal_date}
+    return {"revealed": revealed, "reveal_date": reveal_date}

--- a/tests/unit/lms/views/api/checkpoint_test.py
+++ b/tests/unit/lms/views/api/checkpoint_test.py
@@ -140,9 +140,11 @@ class TestRevealCheckpoint:
         )
 
     @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_returns_null_reveal_date_when_no_result_revealed(
+    def test_it_reports_not_revealed_when_h_revealed_nothing(
         self, pyramid_request, assignment_service, h_api
     ):
+        # h is the source of truth for reveal state: if it reveals nothing, we
+        # must not tell the toolbar the annotations were revealed.
         assignment = self._assignment_with_checkpoint(
             pyramid_request.lti_user.application_instance_id
         )
@@ -152,11 +154,11 @@ class TestRevealCheckpoint:
 
         result = reveal_checkpoint(pyramid_request)
 
-        assert result["revealed"] is True
+        assert result["revealed"] is False
         assert result["reveal_date"] is None
 
     @pytest.mark.usefixtures("user_is_instructor")
-    def test_it_returns_null_reveal_date_when_h_returns_no_results(
+    def test_it_reports_not_revealed_when_h_returns_no_results(
         self, pyramid_request, assignment_service, h_api
     ):
         # reveal_checkpoints is typed list | None; guard against the None case.
@@ -169,7 +171,7 @@ class TestRevealCheckpoint:
 
         result = reveal_checkpoint(pyramid_request)
 
-        assert result == {"revealed": True, "reveal_date": None}
+        assert result == {"revealed": False, "reveal_date": None}
 
     @pytest.mark.usefixtures("user_is_instructor")
     def test_it_returns_404_when_no_groupings(


### PR DESCRIPTION
This pull request updates the annotation reveal logic to ensure the frontend only considers annotations revealed if the backend explicitly confirms it. Previously, the UI assumed a successful request meant annotations were revealed, but now it relies on the backend's `revealed` field, which reflects the actual state reported by the source of truth (`h`). The tests and backend logic are updated to match this behavior.

**Backend logic improvements:**

* [`lms/views/api/checkpoint.py`](diffhunk://#diff-0eda9adc077a1788e63f6fd1e4cc961909d6d71ac2e7966abc61c84ece9ffd68L72-R82): The `reveal_checkpoint` API now returns `{"revealed": False, "reveal_date": None}` if no annotations were actually revealed, instead of always returning `revealed: True`. This ensures the frontend accurately reflects the real reveal state.

**Frontend logic updates:**

* [`lms/static/scripts/frontend_apps/components/RevealAnnotationsButton.tsx`](diffhunk://#diff-82500533e535b6af4a43f8c30e4bb1e882545038031c9ac503381e3657853190L44-R55): The component now sets its revealed state based on the backend response's `revealed` field, rather than assuming a successful request means reveal succeeded.

**Testing improvements:**

* [`lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js`](diffhunk://#diff-f7c5f73a88e854a3b3a081158969c7a2bee593f2877846842f50d6748a21f65cR124-R140): Added a test to verify the UI does not show annotations as revealed if the backend reports `revealed: false`.
* [`lms/static/scripts/frontend_apps/components/test/RevealAnnotationsButton-test.js`](diffhunk://#diff-f7c5f73a88e854a3b3a081158969c7a2bee593f2877846842f50d6748a21f65cR23): Updated test setup to expect the new backend response shape with a `revealed` field.
* [`tests/unit/lms/views/api/checkpoint_test.py`](diffhunk://#diff-9f139ad146096768b701d316cca7d6defaae37ade623c0e6e5309e597b1c714dL143-R147): Updated and renamed tests to check that the backend correctly reports `revealed: False` when nothing is revealed, and that the frontend handles this accurately. [[1]](diffhunk://#diff-9f139ad146096768b701d316cca7d6defaae37ade623c0e6e5309e597b1c714dL143-R147) [[2]](diffhunk://#diff-9f139ad146096768b701d316cca7d6defaae37ade623c0e6e5309e597b1c714dL155-R161) [[3]](diffhunk://#diff-9f139ad146096768b701d316cca7d6defaae37ade623c0e6e5309e597b1c714dL172-R174)