### PR TITLE
 resolve the UI playground's frontend-shared deep imports

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import virtual from '@rollup/plugin-virtual';
+
+const FRONTEND_SHARED = 'node_modules/@hypothesis/frontend-shared';
+const FRONTEND_SHARED_DEEP_IMPORT = '@hypothesis/frontend-shared/lib/';
+
+/**
+ * Resolve `@hypothesis/frontend-shared/lib/...` imports to the files on disk.
+ *
+ * The UI playground reaches into the package for `pattern-library` and its
+ * `Library` component, but the package's `exports` map only publishes
+ * `.` and `./pattern-library`. Node (and so `@rollup/plugin-node-resolve`)
+ * refuses the deeper paths, and Rollup then leaves them as bare imports the
+ * browser cannot load, breaking the playground bundle at runtime.
+ *
+ * Only the playground uses these paths, so the app bundles are unaffected.
+ */
+function resolveFrontendSharedDeepImports() {
+  return {
+    name: 'resolve-frontend-shared-deep-imports',
+    resolveId(source) {
+      if (!source.startsWith(FRONTEND_SHARED_DEEP_IMPORT)) {
+        return null;
+      }
+
+      const subPath = source.slice('@hypothesis/frontend-shared/'.length);
+      const base = path.resolve(FRONTEND_SHARED, subPath);
+
+      const candidate = [base, `${base}.js`, path.join(base, 'index.js')].find(
+        file => fs.existsSync(file) && fs.statSync(file).isFile(),
+      );
+
+      return candidate ?? null;
+    },
+  };
+}
 
 const isProd = process.env.NODE_ENV === 'production';
 const prodPlugins = [];
@@ -46,6 +83,7 @@ function bundleConfig(name, entryFile) {
         exclude: 'node_modules/**',
         extensions: ['.js', '.ts', '.tsx'],
       }),
+      resolveFrontendSharedDeepImports(),
       nodeResolve({
         extensions: ['.js', '.ts', '.tsx'],
       }),


### PR DESCRIPTION
**Fix the UI playground bundle**

Every page of the UI playground currently fails to load. Opening any of them (e.g. /ui-playground/grade-status-chip) throws:

_Uncaught TypeError: The specifier "@hypothesis/frontend-shared/lib/pattern-library"
was a bare specifier, but was not remapped to anything._

**Cause**

@hypothesis/frontend-shared@10.3.0 publishes an exports map:

```
"exports": {
  ".": "./lib/index.js",
  "./pattern-library": "./lib/pattern-library/index.js",
  ...
}
```

exports is an allowlist (any subpath not listed is unreachable, even if the file exists on disk). The playground imports two paths that aren't listed:

`@hypothesis/frontend-shared/lib/pattern-library`
`@hypothesis/frontend-shared/lib/pattern-library/components/Library`

So @rollup/plugin-node-resolve can't resolve them. Rollup then treats an unresolvable import as external rather than failing, and emits it as a bare specifier into an ES bundle, which browsers reject. The build exits 0, so this broke silently.

Why not just change the import paths

startApp is reachable via the supported ./pattern-library path, but Library has no public export path at all: lib/pattern-library/index.js exports only startApp. Rewriting the specifiers can't fix it while Library stays unreachable.

**The fix**

A resolveId hook that maps `@hypothesis/frontend-shared/lib/...` to the corresponding file on disk, so nodeResolve sees a real path and bundles it. Prefix-scoped, so only the playground's imports are affected, frontend_apps and browser_check produce byte-identical output.

This is a workaround. It deliberately reaches past a boundary the package set on purpose. The real fix belongs upstream in frontend-shared: export ./pattern-library/components/Library, or re-export Library from the pattern-library index. Worth filing there; this unblocks local UI work in the meantime.

**Verifying**

```
yarn build
head -c 100 build/scripts/ui-playground.bundle.js   # no bare `import ... from '@hypothesis/...'`

```