### PR TITLE
Replace due-date time dropdown with theme-independent custom Select

### DIFF
--- a/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
@@ -1,6 +1,13 @@
-import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
+import {
+  IconButton,
+  InfoIcon,
+  Popover,
+  Select,
+} from '@hypothesis/frontend-shared';
 import type { Ref } from 'preact';
-import { useId, useRef, useState } from 'preact/hooks';
+import { useId, useImperativeHandle, useRef, useState } from 'preact/hooks';
+
+import UIMessage from './UIMessage';
 
 const TIME_STEP_MINUTES = 30;
 const MINUTES_PER_DAY = 24 * 60;
@@ -49,6 +56,15 @@ function timeOptions(include?: string): string[] {
   return times;
 }
 
+export type DueDateSelectorHandle = {
+  /**
+   * Check the entered due date, showing an error for any violation, and
+   * return whether it is valid. An empty value is valid — the due date is
+   * optional.
+   */
+  validate(): boolean;
+};
+
 export type DueDateSelectorProps = {
   /**
    * Currently selected due date as a local `datetime-local` string
@@ -61,14 +77,12 @@ export type DueDateSelectorProps = {
   /** Earliest selectable value, as a `YYYY-MM-DDTHH:MM` string. */
   min?: string;
 
-  /** Ref to the date input, used by the parent to validate it. */
-  inputRef?: Ref<HTMLInputElement>;
-
   /**
-   * Ref to the time dropdown. Each field carries its own constraints, so the
-   * parent checks both.
+   * Ref through which the parent validates the fields before leaving the
+   * due-date step. The time dropdown is not a native form control, so the
+   * check cannot be run from outside via `reportValidity`.
    */
-  timeInputRef?: Ref<HTMLSelectElement>;
+  selectorRef?: Ref<DueDateSelectorHandle>;
 };
 
 /**
@@ -83,8 +97,7 @@ export default function DueDateSelector({
   dueDate,
   onChange,
   min,
-  inputRef,
-  timeInputRef,
+  selectorRef,
 }: DueDateSelectorProps) {
   const headingId = useId();
   const dateLabelId = useId();
@@ -95,6 +108,14 @@ export default function DueDateSelector({
   // has to live here or a lone time would vanish on re-render.
   const [dateValue, setDateValue] = useState(() => splitDateTime(dueDate)[0]);
   const [timeValue, setTimeValue] = useState(() => splitDateTime(dueDate)[1]);
+
+  // Error shown under the fields when `validate` rejects the value. The time
+  // dropdown is a custom listbox rather than a native form control, so its
+  // constraint violations surface inline instead of through the browser's
+  // validation bubbles.
+  const [error, setError] = useState<string | null>(null);
+
+  const dateInputRef = useRef<HTMLInputElement | null>(null);
 
   const [minDate, minTime] = splitDateTime(min ?? null);
 
@@ -113,17 +134,56 @@ export default function DueDateSelector({
 
     setDateValue(date);
     setTimeValue(time);
+    setError(null);
     emit(date, time);
   };
 
   const onTimeChange = (time: string) => {
     setTimeValue(time);
+    setError(null);
     emit(dateValue, time);
   };
 
+  useImperativeHandle(
+    selectorRef ?? null,
+    () => ({
+      validate: () => {
+        // The date field is a native input, so the browser reports its own
+        // constraints: `required` once a time is set, `min`, malformed input.
+        const dateInput = dateInputRef.current;
+        if (dateInput && !dateInput.reportValidity()) {
+          return false;
+        }
+        // A date without a time is a half-entered due date. The parent cannot
+        // tell: the combined value it holds is null, the same as "left blank".
+        if (dateValue && !timeValue) {
+          setError('Select a time.');
+          return false;
+        }
+        // Reached only when the clock passes a time that was still in the
+        // future when it was picked, since the date's `min` and the dropdown's
+        // disabled options rule out the rest. `YYYY-MM-DDTHH:MM` strings
+        // compare lexicographically, so a plain string comparison against the
+        // minimum (now) is correct.
+        if (
+          dateValue &&
+          timeValue &&
+          min &&
+          `${dateValue}T${timeValue}` < min
+        ) {
+          setError('The due date must be in the future.');
+          return false;
+        }
+        setError(null);
+        return true;
+      },
+    }),
+    [dateValue, timeValue, min],
+  );
+
   // Mirrors the shared `Input` component's base classes (`inputStyles`), which
-  // does not support `type="date"` or `select`. `touch:text-at-least-16px`
-  // prevents iOS zoom-on-focus.
+  // does not support `type="date"`. `touch:text-at-least-16px` prevents iOS
+  // zoom-on-focus.
   const inputClasses =
     'focus-visible:ring focus-visible:outline-none ring-inset border rounded p-2 bg-grey-0 focus:bg-white disabled:bg-grey-1 placeholder:text-grey-6 disabled:placeholder:text-grey-7 touch:text-at-least-16px';
 
@@ -166,11 +226,10 @@ export default function DueDateSelector({
             type="date"
             id={`${dateLabelId}-input`}
             data-testid="due-date-input"
-            ref={inputRef}
+            ref={dateInputRef}
             min={minDate || undefined}
-            // Each field is required once the other is filled, so a
-            // half-entered due date fails validation instead of being read as
-            // the legal "left blank".
+            // Required once a time is set, so a lone time fails validation
+            // instead of being read as the legal "left blank".
             required={!!timeValue}
             className={inputClasses}
             value={dateValue}
@@ -181,30 +240,39 @@ export default function DueDateSelector({
           <label id={timeLabelId} htmlFor={`${timeLabelId}-input`}>
             Time
           </label>
-          <select
-            id={`${timeLabelId}-input`}
-            data-testid="due-date-time-input"
-            ref={timeInputRef}
-            required={!!dateValue}
-            className={inputClasses}
-            value={timeValue}
-            onChange={e => onTimeChange((e.target as HTMLSelectElement).value)}
-          >
-            <option value="">Select a time</option>
-            {timeOptions(timeValue || undefined).map(time => (
-              <option
-                key={time}
-                value={time}
-                // Only the earliest selectable date can hold past times; on any
-                // later date every time of day is still in the future.
-                disabled={dateValue === minDate && time < minTime}
-              >
-                {formatTime(time)}
-              </option>
-            ))}
-          </select>
+          {/* A custom listbox rather than a native `<select>`: it is rendered
+              as page DOM, so its appearance does not depend on the browser or
+              OS theme. */}
+          <div className="w-40">
+            <Select
+              value={timeValue}
+              onChange={onTimeChange}
+              buttonId={`${timeLabelId}-input`}
+              buttonContent={
+                timeValue ? formatTime(timeValue) : 'Select a time'
+              }
+            >
+              <Select.Option value="">Select a time</Select.Option>
+              {timeOptions(timeValue || undefined).map(time => (
+                <Select.Option
+                  key={time}
+                  value={time}
+                  // Only the earliest selectable date can hold past times; on
+                  // any later date every time of day is still in the future.
+                  disabled={dateValue === minDate && time < minTime}
+                >
+                  {formatTime(time)}
+                </Select.Option>
+              ))}
+            </Select>
+          </div>
         </div>
       </div>
+      {error && (
+        <UIMessage status="error" role="alert" data-testid="due-date-error">
+          {error}
+        </UIMessage>
+      )}
     </div>
   );
 }

--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -39,6 +39,7 @@ import AutoGradingConfigurator from './AutoGradingConfigurator';
 import type { CheckpointType } from './CheckpointSelector';
 import CheckpointSelector from './CheckpointSelector';
 import ContentSelector from './ContentSelector';
+import type { DueDateSelectorHandle } from './DueDateSelector';
 import DueDateSelector from './DueDateSelector';
 import ErrorModal from './ErrorModal';
 import FilePickerFormFields from './FilePickerFormFields';
@@ -291,12 +292,12 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   const [checkpointType, setCheckpointType] =
     useState<CheckpointType>('manual');
   const [dueDate, setDueDate] = useState<string | null>(null);
-  // The due date is optional, but when set it must be in the future. The date
-  // and time are picked in separate fields, each carrying its own native
-  // constraints, so both are checked before leaving the due-date step. The
-  // value is a local `YYYY-MM-DDTHH:MM` string, converted to UTC on submit.
-  const dueDateInputRef = useRef<HTMLInputElement | null>(null);
-  const dueTimeInputRef = useRef<HTMLSelectElement | null>(null);
+  // The due date is optional, but when set it must be complete and in the
+  // future. The fields — and the checks over them — live in `DueDateSelector`;
+  // this handle triggers them before leaving the due-date step, and the
+  // selector presents any error itself. The value is a local
+  // `YYYY-MM-DDTHH:MM` string, converted to UTC on submit.
+  const dueDateSelectorRef = useRef<DueDateSelectorHandle | null>(null);
   // Recomputed on each render rather than memoized on mount, so "now" cannot go
   // stale while the picker sits open.
   const minDueDate = localDateTime(new Date());
@@ -315,38 +316,16 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // further steps (checkpoint, due-date); other types go straight to the
   // regular flow.
   const goToNextWorkflowStep = () => {
-    if (workflowStep === 'due-date') {
-      const dateInput = dueDateInputRef.current;
-      const timeInput = dueTimeInputRef.current;
-
-      // A half-entered due date leaves `dueDate` null here, indistinguishable
-      // from the legal "left blank". Only the fields themselves know, via the
-      // `required` each carries once the other is filled.
-      if (dateInput && !dateInput.reportValidity()) {
-        return;
-      }
-      if (timeInput && !timeInput.reportValidity()) {
-        return;
-      }
-
-      // Block leaving the step while a date has been entered but isn't in the
-      // future. An empty value is allowed since the due date is optional.
-      // `datetime-local` strings (`YYYY-MM-DDTHH:MM`) compare
-      // lexicographically, so a plain string comparison against the minimum
-      // (now) is correct.
-      if (dueDate && dueDate < minDueDate) {
-        // Reached only when the clock passes a time that was still in the
-        // future when it was picked, since the date's `min` and the dropdown's
-        // disabled options rule out the rest. Neither field is natively
-        // invalid then, so say why rather than blocking with no explanation.
-        // The message is cleared so it cannot outlive the value behind it.
-        if (timeInput) {
-          timeInput.setCustomValidity('The due date must be in the future.');
-          timeInput.reportValidity();
-          timeInput.setCustomValidity('');
-        }
-        return;
-      }
+    // A half-entered due date leaves `dueDate` null here, indistinguishable
+    // from the legal "left blank", and a complete one can have fallen into
+    // the past. Only the selector can tell; it shows the reason for any
+    // rejection itself.
+    if (
+      workflowStep === 'due-date' &&
+      dueDateSelectorRef.current &&
+      !dueDateSelectorRef.current.validate()
+    ) {
+      return;
     }
     // From 'checkpoint' the next step is 'due-date'; from 'due-date' (the last
     // step) the workflow is done. The 'assignment-type' step has no "Next" — it
@@ -630,8 +609,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                       dueDate={dueDate}
                       onChange={setDueDate}
                       min={minDueDate}
-                      inputRef={dueDateInputRef}
-                      timeInputRef={dueTimeInputRef}
+                      selectorRef={dueDateSelectorRef}
                     />
                   )}
                 </div>

--- a/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
@@ -1,4 +1,6 @@
+import { Select } from '@hypothesis/frontend-shared';
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { createRef } from 'preact';
 import { act } from 'preact/test-utils';
 
 import DueDateSelector from '../DueDateSelector';
@@ -10,23 +12,34 @@ describe('DueDateSelector', () => {
     fakeOnChange = sinon.stub();
   });
 
-  function createComponent(dueDate = null, min = undefined) {
+  function createComponent(dueDate = null, min = undefined, selectorRef) {
     return mount(
-      <DueDateSelector dueDate={dueDate} onChange={fakeOnChange} min={min} />,
-      // Connect to the DOM so the info `Popover` (which uses the native popover
-      // API) can toggle.
+      <DueDateSelector
+        dueDate={dueDate}
+        onChange={fakeOnChange}
+        min={min}
+        selectorRef={selectorRef}
+      />,
+      // Connect to the DOM so the popovers (which use the native popover API)
+      // can toggle.
       { connected: true },
     );
   }
 
   const dateInput = wrapper =>
     wrapper.find('input[data-testid="due-date-input"]');
-  const timeInput = wrapper =>
-    wrapper.find('select[data-testid="due-date-time-input"]');
-  const timeOptionValues = wrapper =>
-    timeInput(wrapper)
-      .find('option')
-      .map(option => option.prop('value'));
+  const timeSelect = wrapper => wrapper.find(Select);
+  const errorMessage = wrapper =>
+    wrapper.find('div[data-testid="due-date-error"]');
+
+  // Open the time dropdown. Its options are only rendered while it is open.
+  const openTimeSelect = wrapper => {
+    timeSelect(wrapper)
+      .find('button[data-testid="select-toggle-button"]')
+      .simulate('click');
+    wrapper.update();
+  };
+  const timeSelectOptions = wrapper => timeSelect(wrapper).find(Select.Option);
 
   // Each helper re-renders before returning. The change handlers close over
   // the current date and time, so acting twice against a stale wrapper would
@@ -36,7 +49,7 @@ describe('DueDateSelector', () => {
     wrapper.update();
   };
   const changeTime = (wrapper, value) => {
-    act(() => timeInput(wrapper).props().onChange({ target: { value } }));
+    act(() => timeSelect(wrapper).props().onChange(value));
     wrapper.update();
   };
 
@@ -44,14 +57,16 @@ describe('DueDateSelector', () => {
     const wrapper = createComponent('2026-06-11T14:30');
 
     assert.equal(dateInput(wrapper).prop('value'), '2026-06-11');
-    assert.equal(timeInput(wrapper).prop('value'), '14:30');
+    assert.equal(timeSelect(wrapper).prop('value'), '14:30');
+    assert.include(timeSelect(wrapper).text(), '2:30 PM');
   });
 
   it('renders empty fields when no due date is set', () => {
     const wrapper = createComponent(null);
 
     assert.equal(dateInput(wrapper).prop('value'), '');
-    assert.equal(timeInput(wrapper).prop('value'), '');
+    assert.equal(timeSelect(wrapper).prop('value'), '');
+    assert.include(timeSelect(wrapper).text(), 'Select a time');
   });
 
   it('reports no due date while only a date has been picked', () => {
@@ -63,18 +78,7 @@ describe('DueDateSelector', () => {
     // until they pick one.
     assert.calledWith(fakeOnChange, null);
     wrapper.update();
-    assert.equal(timeInput(wrapper).prop('value'), '');
-  });
-
-  it('requires the time once a date has been picked', () => {
-    const wrapper = createComponent();
-
-    assert.isNotTrue(timeInput(wrapper).prop('required'));
-
-    changeDate(wrapper, '2026-06-11');
-    wrapper.update();
-
-    assert.isTrue(timeInput(wrapper).prop('required'));
+    assert.equal(timeSelect(wrapper).prop('value'), '');
   });
 
   it('keeps an already-entered time when a date is picked', () => {
@@ -118,8 +122,8 @@ describe('DueDateSelector', () => {
     changeTime(wrapper, '09:00');
     wrapper.update();
 
-    // Lets the parent's `reportValidity()` catch the half-entered value rather
-    // than silently dropping the time.
+    // Lets `validate` catch the half-entered value via the input's own
+    // constraints rather than silently dropping the time.
     assert.isTrue(dateInput(wrapper).prop('required'));
   });
 
@@ -131,7 +135,7 @@ describe('DueDateSelector', () => {
     assert.calledWith(fakeOnChange, null);
     wrapper.update();
     assert.equal(dateInput(wrapper).prop('value'), '');
-    assert.equal(timeInput(wrapper).prop('value'), '');
+    assert.equal(timeSelect(wrapper).prop('value'), '');
   });
 
   it('constrains the date to the minimum', () => {
@@ -142,7 +146,8 @@ describe('DueDateSelector', () => {
 
   it('offers times at half-hour steps, labelled for a 12-hour clock', () => {
     const wrapper = createComponent();
-    const options = timeInput(wrapper).find('option');
+    openTimeSelect(wrapper);
+    const options = timeSelectOptions(wrapper);
 
     // A placeholder plus one option per half hour.
     assert.equal(options.length, 1 + 48);
@@ -161,34 +166,111 @@ describe('DueDateSelector', () => {
     // An assignment saved before this dropdown existed can hold any minute;
     // dropping it would silently change the due date.
     const wrapper = createComponent('2026-06-11T14:45');
+    openTimeSelect(wrapper);
 
-    assert.include(timeOptionValues(wrapper), '14:45');
-    assert.equal(timeInput(wrapper).prop('value'), '14:45');
+    const values = timeSelectOptions(wrapper).map(o => o.prop('value'));
+    assert.include(values, '14:45');
+    assert.equal(timeSelect(wrapper).prop('value'), '14:45');
   });
 
   it('disables past times only on the earliest selectable date', () => {
     const wrapper = createComponent(null, '2026-06-11T14:30');
     const disabled = value =>
-      timeInput(wrapper)
-        .find('option')
+      timeSelectOptions(wrapper)
         .filterWhere(o => o.prop('value') === value)
         .prop('disabled');
 
     // On the earliest date, times before the minimum are in the past.
     changeDate(wrapper, '2026-06-11');
-    wrapper.update();
+    openTimeSelect(wrapper);
     assert.isTrue(disabled('14:00'));
     assert.isFalse(disabled('15:00'));
 
     // On any later date, every time of day is still in the future.
     changeDate(wrapper, '2026-06-12');
-    wrapper.update();
     assert.isFalse(disabled('14:00'));
+  });
+
+  describe('validate', () => {
+    let selectorRef;
+
+    const createWithHandle = (dueDate = null, min = undefined) => {
+      selectorRef = createRef();
+      return createComponent(dueDate, min, selectorRef);
+    };
+
+    const validate = wrapper => {
+      let valid;
+      act(() => {
+        valid = selectorRef.current.validate();
+      });
+      wrapper.update();
+      return valid;
+    };
+
+    it('accepts an empty due date', () => {
+      const wrapper = createWithHandle();
+
+      assert.isTrue(validate(wrapper));
+      assert.isFalse(errorMessage(wrapper).exists());
+    });
+
+    it('accepts a complete future due date', () => {
+      const wrapper = createWithHandle('2026-06-11T14:30', '2026-06-11T10:00');
+
+      assert.isTrue(validate(wrapper));
+      assert.isFalse(errorMessage(wrapper).exists());
+    });
+
+    it('rejects a date without a time', () => {
+      const wrapper = createWithHandle();
+
+      changeDate(wrapper, '2026-06-11');
+
+      assert.isFalse(validate(wrapper));
+      assert.equal(errorMessage(wrapper).text(), 'Select a time.');
+    });
+
+    it('rejects a time without a date', () => {
+      const wrapper = createWithHandle();
+
+      changeTime(wrapper, '09:00');
+
+      // The date field is a native input carrying `required`, so the browser
+      // reports this one rather than the inline message.
+      assert.isFalse(validate(wrapper));
+      assert.isFalse(errorMessage(wrapper).exists());
+    });
+
+    it('rejects a due date that is no longer in the future', () => {
+      // Each field holds a value that was valid when picked; only the combined
+      // comparison can see that the clock has since passed it.
+      const wrapper = createWithHandle('2026-06-11T10:00', '2026-06-11T14:30');
+
+      assert.isFalse(validate(wrapper));
+      assert.equal(
+        errorMessage(wrapper).text(),
+        'The due date must be in the future.',
+      );
+    });
+
+    it('clears the error as soon as the value changes', () => {
+      const wrapper = createWithHandle();
+
+      changeDate(wrapper, '2026-06-11');
+      assert.isFalse(validate(wrapper));
+      assert.isTrue(errorMessage(wrapper).exists());
+
+      changeTime(wrapper, '09:00');
+      assert.isFalse(errorMessage(wrapper).exists());
+    });
   });
 
   it('shows the due date explanation in a popover instead of inline', () => {
     const wrapper = createComponent();
-    const popover = () => wrapper.find('Popover');
+    // The time dropdown renders its own (second) popover; the explanation
+    // lives in the first one, anchored to the info icon.
+    const popover = () => wrapper.find('Popover').first();
     const explanation =
       'The point where annotations are no longer tallied in auto grading.';
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -147,31 +147,17 @@ describe('FilePickerApp', () => {
     }
 
     /**
-     * Stand in for the browser's constraint validation on the due-date inputs.
+     * Stand in for `DueDateSelector`'s `validate`.
      *
-     * `DueDateSelector` is mocked here, so the real `<input>`s — and with them
-     * the `validity` the browser maintains — never exist. The mock still
-     * receives the refs, so populating them simulates inputs the browser
-     * considers invalid (e.g. `valueMissing`, set on either field when only
-     * the other one has been filled in).
-     *
-     * `time` defaults to `date` so the common "both fields agree" case reads
-     * as a single argument.
+     * `DueDateSelector` is mocked here, so the real fields — and the checks
+     * the real component runs over them — never exist. The mock still
+     * receives `selectorRef`, so populating the handle decides what the
+     * parent hears when it validates the step.
      */
-    function setInputValidity(wrapper, date, time = date) {
-      const { inputRef, timeInputRef } = wrapper
-        .find('DueDateSelector')
-        .first()
-        .props();
-      inputRef.current = {
-        reportValidity: () => date,
-        setCustomValidity: sinon.stub(),
-      };
-      timeInputRef.current = {
-        reportValidity: () => time,
-        setCustomValidity: sinon.stub(),
-      };
-      return { dateInput: inputRef.current, timeInput: timeInputRef.current };
+    function setDueDateValidity(wrapper, valid) {
+      const { selectorRef } = wrapper.find('DueDateSelector').first().props();
+      selectorRef.current = { validate: sinon.stub().returns(valid) };
+      return selectorRef.current;
     }
 
     /**
@@ -255,7 +241,7 @@ describe('FilePickerApp', () => {
       assert.isTrue(wrapper.exists('ContentSelector'));
     });
 
-    it('blocks the due-date step when the date is not in the future', () => {
+    it('blocks the due-date step while the selector reports an invalid value', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();
 
@@ -263,97 +249,27 @@ describe('FilePickerApp', () => {
       clickNext(wrapper); // -> due-date
       assert.isTrue(wrapper.exists('DueDateSelector'));
 
-      // A past date is rejected: navigation is blocked.
-      setDueDate(wrapper, dueDateFromNow(-1));
-      clickNext(wrapper);
-      assert.isTrue(wrapper.exists('DueDateSelector'));
-      assert.isFalse(wrapper.exists('ContentSelector'));
-    });
-
-    it('explains a due date that is no longer in the future', () => {
-      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
-      const wrapper = renderFilePicker();
-
-      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
-      clickNext(wrapper); // -> due-date
-
-      // Both fields are natively valid — the date is a real date and the time
-      // dropdown has a selection — but the value they add up to has fallen
-      // into the past, which only the combined comparison can see. Blocking
-      // without a message would leave the instructor stuck.
-      const { timeInput } = setInputValidity(wrapper, true);
-      setDueDate(wrapper, dueDateFromNow(-1));
-
-      clickNext(wrapper);
-      assert.isTrue(wrapper.exists('DueDateSelector'));
-      assert.calledWith(
-        timeInput.setCustomValidity,
-        'The due date must be in the future.',
-      );
-      // The message is cleared so it cannot outlive the value that caused it.
-      assert.calledWith(timeInput.setCustomValidity, '');
-    });
-
-    it('blocks the due-date step when the date is incomplete', () => {
-      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
-      const wrapper = renderFilePicker();
-
-      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
-      clickNext(wrapper); // -> due-date
-      assert.isTrue(wrapper.exists('DueDateSelector'));
-
-      // A partly-typed date reads back as the empty string, so the component
-      // is handed `null` — which is otherwise the legal "left blank". Only the
-      // input knows it is in a bad state.
-      setInputValidity(wrapper, false);
-      setDueDate(wrapper, null);
+      // Whatever the reason — a half-entered value, or a complete one that is
+      // no longer in the future — the selector shows it inline; the parent
+      // only acts on the verdict.
+      const handle = setDueDateValidity(wrapper, false);
 
       clickNext(wrapper);
       assert.isTrue(wrapper.exists('DueDateSelector'));
       assert.isFalse(wrapper.exists('ContentSelector'));
+      assert.called(handle.validate);
     });
 
-    it('blocks the due-date step when a date is picked but no time', () => {
+    it('leaves the due-date step when the selector reports a valid value', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();
 
       selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
       clickNext(wrapper); // -> due-date
 
-      // The date is valid on its own, but the time it requires is missing, so
-      // the combined value is `null` and only the time input is invalid.
-      setInputValidity(wrapper, true, false);
-      setDueDate(wrapper, null);
-
-      clickNext(wrapper);
-      assert.isTrue(wrapper.exists('DueDateSelector'));
-      assert.isFalse(wrapper.exists('ContentSelector'));
-    });
-
-    it('leaves the due-date step when no date is entered', () => {
-      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
-      const wrapper = renderFilePicker();
-
-      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
-      clickNext(wrapper); // -> due-date
-
-      // The due date is optional, so an empty (and valid) input advances.
-      setInputValidity(wrapper, true);
-
-      clickNext(wrapper);
-      assert.isFalse(wrapper.exists('DueDateSelector'));
-      assert.isTrue(wrapper.exists('ContentSelector'));
-    });
-
-    it('leaves the due-date step when the date is in the future', () => {
-      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
-      const wrapper = renderFilePicker();
-
-      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
-      clickNext(wrapper); // -> due-date
-
-      // A future date is accepted: the regular flow takes over.
+      setDueDateValidity(wrapper, true);
       setDueDate(wrapper, dueDateFromNow(7));
+
       clickNext(wrapper);
       assert.isFalse(wrapper.exists('DueDateSelector'));
       assert.isTrue(wrapper.exists('ContentSelector'));

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -260,6 +260,21 @@ describe('FilePickerApp', () => {
       assert.called(handle.validate);
     });
 
+    it('anchors the earliest selectable due date to the present', () => {
+      fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
+      const wrapper = renderFilePicker();
+
+      selectAssignmentType(wrapper, 'hide_and_reveal'); // -> checkpoint
+      clickNext(wrapper); // -> due-date
+
+      // The selector rejects anything below `min` (past dates, past times on
+      // the current day); pinning `min` to "now" is the parent's half of the
+      // "no due dates in the past" rule.
+      const { min } = wrapper.find('DueDateSelector').first().props();
+      assert.isTrue(min <= dueDateFromNow(0));
+      assert.isTrue(min > dueDateFromNow(-1));
+    });
+
     it('leaves the due-date step when the selector reports a valid value', () => {
       fakeConfig.filePicker.assignmentTypes = ['reading', 'hide_and_reveal'];
       const wrapper = renderFilePicker();


### PR DESCRIPTION
## Problem

The time picker in the Hide & Reveal due-date step was a native `<select>`. Its options popup is drawn by the browser, not by page CSS, so users with their OS/browser in dark mode saw a dark dropdown inside the otherwise-light dialog:

| Light-mode user | Dark-mode user |
|---|---|
| light dropdown | dark dropdown (browser-drawn) |

## Changes

- **`DueDateSelector`**: the time field is now the shared `Select` component from `@hypothesis/frontend-shared` (already used by the dashboard filters). Its listbox is regular page DOM styled by our CSS, so it renders identically regardless of browser/OS theme. Options (half-hour steps, 12-hour labels, off-grid legacy times, past times disabled on the minimum date) are unchanged.
- **Validation**: a custom listbox doesn't participate in native form validation, so the due-date checks moved from `FilePickerApp`'s `reportValidity`/`setCustomValidity` calls into a `validate()` handle exposed by `DueDateSelector` via `selectorRef`. Errors now show inline under the fields ("Select a time.", "The due date must be in the future.") instead of browser validation bubbles. The date field remains a native input and keeps its browser-reported constraints (`required`, `min`).
- **Rules unchanged**: the due date is still optional, a half-entered value (date without time, or time without date) still blocks the step, and a value that falls into the past while the dialog sits open is still rejected with an explanation.

## Tests

- `DueDateSelector` tests drive the custom Select (opening the listbox to assert the options, which only render while open) and cover every `validate()` verdict, including error clearing on change.
- `FilePickerApp` tests stub the `validate` handle instead of fake native inputs; the per-cause blocking tests collapsed into invalid/valid verdict tests since the causes are now unit-tested in the component.
- `yarn typecheck`, eslint, prettier, and both suites pass (21 + 64 tests, headless Chromium).

## Note

The date field's native calendar popup is still browser-drawn and will still render dark for dark-mode users. If we want the whole dialog theme-proof, a `color-scheme: light` declaration in `frontend_apps.css` covers it — left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)