### PR TITLE
Make the due-date time picker typeable, Canvas-style

### DIFF
--- a/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
+++ b/lms/static/scripts/frontend_apps/components/DueDateSelector.tsx
@@ -1,12 +1,8 @@
-import {
-  IconButton,
-  InfoIcon,
-  Popover,
-  Select,
-} from '@hypothesis/frontend-shared';
+import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
 import type { Ref } from 'preact';
 import { useId, useImperativeHandle, useRef, useState } from 'preact/hooks';
 
+import TimeInput from './TimeInput';
 import UIMessage from './UIMessage';
 
 const TIME_STEP_MINUTES = 30;
@@ -29,6 +25,39 @@ function formatTime(time: string): string {
   // Midnight (0) and noon (12) both display as 12.
   const hour12 = hours % 12 || 12;
   return `${hour12}:${pad(minutes)} ${period}`;
+}
+
+/**
+ * Parse a typed time into canonical 24-hour `HH:MM`.
+ *
+ * Accepts 12-hour ("3:30 PM", "3pm") and 24-hour ("15:30") forms. Returns
+ * null when the text is not a time (e.g. "3:90 AM").
+ */
+function parseTime(text: string): string | null {
+  const match = text.trim().match(/^(\d{1,2})(?::(\d{1,2}))?\s*(am|pm)?$/i);
+  if (!match) {
+    return null;
+  }
+  let hours = Number(match[1]);
+  const minutes = match[2] ? Number(match[2]) : 0;
+  // Typed as `string`, but the group is undefined when no period was typed.
+  const period = (match[3] as string | undefined)?.toLowerCase();
+  if (minutes > 59) {
+    return null;
+  }
+  if (period) {
+    if (hours < 1 || hours > 12) {
+      return null;
+    }
+    // Midnight and noon are hour 12 on a 12-hour clock but 0 and 12 here.
+    hours = hours % 12;
+    if (period === 'pm') {
+      hours += 12;
+    }
+  } else if (hours > 23) {
+    return null;
+  }
+  return `${pad(hours)}:${pad(minutes)}`;
 }
 
 /**
@@ -107,7 +136,13 @@ export default function DueDateSelector({
   // combined value (null until both halves exist), so the half-entered state
   // has to live here or a lone time would vanish on re-render.
   const [dateValue, setDateValue] = useState(() => splitDateTime(dueDate)[0]);
-  const [timeValue, setTimeValue] = useState(() => splitDateTime(dueDate)[1]);
+  // The time field allows typing, so what it holds is free-form text; the
+  // canonical `HH:MM` half of the value is parsed back out of it on the fly.
+  const [timeText, setTimeText] = useState(() => {
+    const time = splitDateTime(dueDate)[1];
+    return time ? formatTime(time) : '';
+  });
+  const timeValue = parseTime(timeText) ?? '';
 
   // Error shown under the fields when `validate` rejects the value. The time
   // dropdown is a custom listbox rather than a native form control, so its
@@ -130,33 +165,51 @@ export default function DueDateSelector({
   const onDateChange = (date: string) => {
     // Clearing the date unsets the due date as a whole, so the time goes with
     // it rather than lingering on its own.
-    const time = date ? timeValue : '';
+    const text = date ? timeText : '';
 
     setDateValue(date);
-    setTimeValue(time);
+    setTimeText(text);
     setError(null);
-    emit(date, time);
+    emit(date, parseTime(text) ?? '');
   };
 
-  const onTimeChange = (time: string) => {
-    setTimeValue(time);
+  const onTimeTextChange = (text: string) => {
+    setTimeText(text);
     setError(null);
-    emit(dateValue, time);
+    emit(dateValue, parseTime(text) ?? '');
+  };
+
+  // Once editing ends, rewrite parseable text in the canonical display form,
+  // e.g. "15:30" -> "3:30 PM". The functional update matters: picking a
+  // suggestion reports the new text and commits in the same batch.
+  const onTimeCommit = () => {
+    setTimeText(text => {
+      const parsed = parseTime(text);
+      return parsed ? formatTime(parsed) : text;
+    });
   };
 
   useImperativeHandle(
     selectorRef ?? null,
     () => ({
       validate: () => {
+        // Typed text that isn't a time is neither "blank" nor a value. This
+        // is checked first: it is the most specific problem, and the date
+        // input's `required` (hit next when the date is also missing) would
+        // otherwise talk about the wrong field.
+        if (timeText && !timeValue) {
+          setError('Invalid time.');
+          return false;
+        }
         // The date field is a native input, so the browser reports its own
         // constraints: `required` once a time is set, `min`, malformed input.
         const dateInput = dateInputRef.current;
         if (dateInput && !dateInput.reportValidity()) {
           return false;
         }
-        // A date without a time is a half-entered due date. The parent cannot
-        // tell: the combined value it holds is null, the same as "left blank".
-        if (dateValue && !timeValue) {
+        // A date without a time is a half-entered due date, null to the
+        // parent as well — the same as the legal "left blank".
+        if (dateValue && !timeText) {
           setError('Select a time.');
           return false;
         }
@@ -178,7 +231,7 @@ export default function DueDateSelector({
         return true;
       },
     }),
-    [dateValue, timeValue, min],
+    [dateValue, timeText, timeValue, min],
   );
 
   // Mirrors the shared `Input` component's base classes (`inputStyles`), which
@@ -228,9 +281,9 @@ export default function DueDateSelector({
             data-testid="due-date-input"
             ref={dateInputRef}
             min={minDate || undefined}
-            // Required once a time is set, so a lone time fails validation
+            // Required once a time is entered, so a lone time fails validation
             // instead of being read as the legal "left blank".
-            required={!!timeValue}
+            required={!!timeText}
             className={inputClasses}
             value={dateValue}
             onChange={e => onDateChange((e.target as HTMLInputElement).value)}
@@ -240,31 +293,23 @@ export default function DueDateSelector({
           <label id={timeLabelId} htmlFor={`${timeLabelId}-input`}>
             Time
           </label>
-          {/* A custom listbox rather than a native `<select>`: it is rendered
-              as page DOM, so its appearance does not depend on the browser or
-              OS theme. */}
+          {/* A combobox (as in Canvas): the instructor can pick a suggestion
+              or type a time by hand. */}
           <div className="w-40">
-            <Select
-              value={timeValue}
-              onChange={onTimeChange}
-              buttonId={`${timeLabelId}-input`}
-              buttonContent={
-                timeValue ? formatTime(timeValue) : 'Select a time'
-              }
-            >
-              <Select.Option value="">Select a time</Select.Option>
-              {timeOptions(timeValue || undefined).map(time => (
-                <Select.Option
-                  key={time}
-                  value={time}
-                  // Only the earliest selectable date can hold past times; on
-                  // any later date every time of day is still in the future.
-                  disabled={dateValue === minDate && time < minTime}
-                >
-                  {formatTime(time)}
-                </Select.Option>
-              ))}
-            </Select>
+            <TimeInput
+              value={timeText}
+              onChange={onTimeTextChange}
+              onCommit={onTimeCommit}
+              inputId={`${timeLabelId}-input`}
+              placeholder="Select a time"
+              classes={inputClasses}
+              options={timeOptions(timeValue || undefined).map(time => ({
+                label: formatTime(time),
+                // Only the earliest selectable date can hold past times; on
+                // any later date every time of day is still in the future.
+                disabled: dateValue === minDate && time < minTime,
+              }))}
+            />
           </div>
         </div>
       </div>

--- a/lms/static/scripts/frontend_apps/components/TimeInput.tsx
+++ b/lms/static/scripts/frontend_apps/components/TimeInput.tsx
@@ -1,0 +1,251 @@
+import { Popover } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { JSX } from 'preact';
+import { useId, useLayoutEffect, useRef, useState } from 'preact/hooks';
+
+export type TimeInputOption = {
+  /** Text shown for — and inserted by — this suggestion. */
+  label: string;
+  /** Shown greyed out and not selectable. */
+  disabled?: boolean;
+};
+
+/** Case- and whitespace-insensitive comparison key for labels and input. */
+const normalize = (text: string) => text.toLowerCase().replace(/\s+/g, '');
+
+export type TimeInputProps = {
+  /**
+   * Current text in the field. Free-form: it is not necessarily one of the
+   * suggestions or even a valid time. The parent validates it.
+   */
+  value: string;
+
+  /** Reports the text on every edit. Picking a suggestion reports its label. */
+  onChange: (text: string) => void;
+
+  /**
+   * Invoked when editing finishes (blur, Enter, picking a suggestion) — the
+   * parent's chance to normalize the text.
+   */
+  onCommit?: () => void;
+
+  /**
+   * Suggestions offered in the dropdown. They are filtered as the user types,
+   * by label prefix ("3:3" offers "3:30 AM" and "3:30 PM").
+   */
+  options: TimeInputOption[];
+
+  /** id for the input, letting an external `<label>` point at it. */
+  inputId?: string;
+
+  placeholder?: string;
+
+  /** Classes for the input element. */
+  classes?: string;
+};
+
+/**
+ * A text field with time suggestions, mirroring the pickers in Canvas: the
+ * user can either choose a suggestion or type a time by hand.
+ *
+ * The dropdown is rendered as page DOM (not a native `<select>` popup), so
+ * its appearance does not depend on the browser or OS theme.
+ */
+export default function TimeInput({
+  value,
+  onChange,
+  onCommit,
+  options,
+  inputId,
+  placeholder,
+  classes,
+}: TimeInputProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listboxRef = useRef<HTMLUListElement | null>(null);
+  const listboxId = useId();
+  const [open, setOpen] = useState(false);
+
+  // Index into `filtered` of the option the arrow keys point at. The visual
+  // highlight and `aria-activedescendant` follow it; focus stays on the input
+  // so the user can keep typing.
+  const [highlight, setHighlight] = useState(-1);
+
+  const filterOptions = (text: string) =>
+    options.filter(o => normalize(o.label).startsWith(normalize(text)));
+  const filtered = filterOptions(value);
+
+  // Keep the highlighted option in view while arrow keys move it beyond the
+  // visible part of the list.
+  useLayoutEffect(() => {
+    if (highlight >= 0) {
+      listboxRef.current
+        ?.querySelector(`[data-index="${highlight}"]`)
+        ?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlight]);
+
+  const close = () => {
+    setOpen(false);
+    setHighlight(-1);
+  };
+
+  const commit = () => {
+    close();
+    onCommit?.();
+  };
+
+  const openListbox = () => {
+    if (open) {
+      return;
+    }
+    setOpen(true);
+    // Point the highlight at the current value, or the first selectable
+    // suggestion when the text doesn't match one.
+    const match = filtered.findIndex(
+      o => !o.disabled && normalize(o.label) === normalize(value),
+    );
+    setHighlight(match >= 0 ? match : filtered.findIndex(o => !o.disabled));
+  };
+
+  const selectOption = (option: TimeInputOption) => {
+    if (option.disabled) {
+      return;
+    }
+    onChange(option.label);
+    commit();
+  };
+
+  const onInput = (e: JSX.TargetedEvent<HTMLInputElement>) => {
+    const text = e.currentTarget.value;
+    setOpen(true);
+    // Highlight the first selectable suggestion still matching the text.
+    setHighlight(filterOptions(text).findIndex(o => !o.disabled));
+    onChange(text);
+  };
+
+  const moveHighlight = (dir: 1 | -1) => {
+    setHighlight(current => {
+      let next = current;
+      do {
+        next += dir;
+      } while (filtered[next]?.disabled);
+      // Stop at either end of the list rather than wrapping around.
+      return next >= 0 && next < filtered.length ? next : current;
+    });
+  };
+
+  const onKeyDown = (e: JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!open) {
+          openListbox();
+        } else {
+          moveHighlight(e.key === 'ArrowDown' ? 1 : -1);
+        }
+        break;
+      case 'Enter': {
+        // Typed as always-present, but `highlight` is -1 with no selection.
+        const highlighted = filtered[highlight] as TimeInputOption | undefined;
+        if (open && highlighted && !highlighted.disabled) {
+          // Swallow the implicit form submission only while the key means
+          // "choose the highlighted suggestion".
+          e.preventDefault();
+          onChange(highlighted.label);
+        }
+        commit();
+        break;
+      }
+      case 'Escape':
+        close();
+        break;
+    }
+  };
+
+  const onBlur = (e: JSX.TargetedFocusEvent<HTMLInputElement>) => {
+    // Ignore focus moving into the dropdown itself (e.g. its scrollbar).
+    const next = e.relatedTarget as Node | null;
+    if (next && containerRef.current?.contains(next)) {
+      return;
+    }
+    commit();
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        type="text"
+        autocomplete="off"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        // Only reference the listbox while it exists: its contents are not
+        // rendered while the dropdown is closed.
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={
+          highlight >= 0 ? `${listboxId}-${highlight}` : undefined
+        }
+        id={inputId}
+        data-testid="time-input"
+        className={classnames('w-full', classes)}
+        placeholder={placeholder}
+        value={value}
+        onInput={onInput}
+        onClick={openListbox}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+      />
+      <Popover
+        open={open}
+        onClose={close}
+        anchorElementRef={containerRef}
+        classes="max-h-64 overflow-y-auto"
+      >
+        <ul
+          role="listbox"
+          id={listboxId}
+          ref={listboxRef}
+          // Keep focus (and the pending blur-commit) on the input while
+          // clicking options.
+          onMouseDown={e => e.preventDefault()}
+        >
+          {filtered.length === 0 && (
+            // Mirrors the Canvas pickers: an inert row marking "no matches".
+            <li
+              role="option"
+              aria-disabled="true"
+              aria-selected={false}
+              className="p-2 text-grey-6"
+            >
+              ---
+            </li>
+          )}
+          {filtered.map((option, index) => (
+            // Keyboard access goes through the combobox input (arrow keys +
+            // Enter), per the ARIA combobox pattern; the rows themselves are
+            // never focusable.
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+            <li
+              key={option.label}
+              id={`${listboxId}-${index}`}
+              data-index={index}
+              role="option"
+              aria-disabled={option.disabled}
+              aria-selected={normalize(option.label) === normalize(value)}
+              className={classnames('px-2 py-1', {
+                'bg-grey-2': index === highlight,
+                'text-grey-6': option.disabled,
+                'cursor-pointer': !option.disabled,
+              })}
+              onClick={() => selectOption(option)}
+              onMouseMove={() => !option.disabled && setHighlight(index)}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      </Popover>
+    </div>
+  );
+}

--- a/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
@@ -126,12 +126,19 @@ describe('DueDateSelector', () => {
     assert.equal(timeInput(wrapper).prop('value'), '3:90 AM');
   });
 
-  it('reports no due date while the typed time is not valid', () => {
-    const wrapper = createComponent('2026-06-11T14:30');
+  [
+    '3:90 AM', // Minutes beyond 59.
+    '0:30 PM', // Hour outside 1-12 while a period makes the clock 12-hour.
+    '13:00 PM',
+    '25:00', // Hour beyond 23 on the 24-hour clock.
+  ].forEach(time => {
+    it(`reports no due date while the typed time is not valid ("${time}")`, () => {
+      const wrapper = createComponent('2026-06-11T14:30');
 
-    changeTime(wrapper, '3:90 AM');
+      changeTime(wrapper, time);
 
-    assert.calledWith(fakeOnChange, null);
+      assert.calledWith(fakeOnChange, null);
+    });
   });
 
   it('reports no due date when the time is cleared', () => {

--- a/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/DueDateSelector-test.js
@@ -1,4 +1,3 @@
-import { Select } from '@hypothesis/frontend-shared';
 import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 import { createRef } from 'preact';
 import { act } from 'preact/test-utils';
@@ -28,18 +27,16 @@ describe('DueDateSelector', () => {
 
   const dateInput = wrapper =>
     wrapper.find('input[data-testid="due-date-input"]');
-  const timeSelect = wrapper => wrapper.find(Select);
+  const timeInput = wrapper => wrapper.find('input[data-testid="time-input"]');
   const errorMessage = wrapper =>
     wrapper.find('div[data-testid="due-date-error"]');
 
-  // Open the time dropdown. Its options are only rendered while it is open.
-  const openTimeSelect = wrapper => {
-    timeSelect(wrapper)
-      .find('button[data-testid="select-toggle-button"]')
-      .simulate('click');
+  // Open the time dropdown. Its suggestions are only rendered while open.
+  const openTimeOptions = wrapper => {
+    act(() => timeInput(wrapper).props().onClick());
     wrapper.update();
   };
-  const timeSelectOptions = wrapper => timeSelect(wrapper).find(Select.Option);
+  const timeOptions = wrapper => wrapper.find('li[role="option"]');
 
   // Each helper re-renders before returning. The change handlers close over
   // the current date and time, so acting twice against a stale wrapper would
@@ -49,7 +46,11 @@ describe('DueDateSelector', () => {
     wrapper.update();
   };
   const changeTime = (wrapper, value) => {
-    act(() => timeSelect(wrapper).props().onChange(value));
+    act(() => timeInput(wrapper).props().onInput({ currentTarget: { value } }));
+    wrapper.update();
+  };
+  const finishTimeEditing = wrapper => {
+    act(() => timeInput(wrapper).props().onBlur({ relatedTarget: null }));
     wrapper.update();
   };
 
@@ -57,16 +58,15 @@ describe('DueDateSelector', () => {
     const wrapper = createComponent('2026-06-11T14:30');
 
     assert.equal(dateInput(wrapper).prop('value'), '2026-06-11');
-    assert.equal(timeSelect(wrapper).prop('value'), '14:30');
-    assert.include(timeSelect(wrapper).text(), '2:30 PM');
+    assert.equal(timeInput(wrapper).prop('value'), '2:30 PM');
   });
 
   it('renders empty fields when no due date is set', () => {
     const wrapper = createComponent(null);
 
     assert.equal(dateInput(wrapper).prop('value'), '');
-    assert.equal(timeSelect(wrapper).prop('value'), '');
-    assert.include(timeSelect(wrapper).text(), 'Select a time');
+    assert.equal(timeInput(wrapper).prop('value'), '');
+    assert.equal(timeInput(wrapper).prop('placeholder'), 'Select a time');
   });
 
   it('reports no due date while only a date has been picked', () => {
@@ -78,13 +78,13 @@ describe('DueDateSelector', () => {
     // until they pick one.
     assert.calledWith(fakeOnChange, null);
     wrapper.update();
-    assert.equal(timeSelect(wrapper).prop('value'), '');
+    assert.equal(timeInput(wrapper).prop('value'), '');
   });
 
   it('keeps an already-entered time when a date is picked', () => {
     const wrapper = createComponent();
 
-    changeTime(wrapper, '09:00');
+    changeTime(wrapper, '9:00 AM');
     changeDate(wrapper, '2026-06-11');
 
     assert.calledWith(fakeOnChange, '2026-06-11T09:00');
@@ -93,9 +93,45 @@ describe('DueDateSelector', () => {
   it('invokes onChange with the combined value when the time changes', () => {
     const wrapper = createComponent('2026-06-11T23:59');
 
-    changeTime(wrapper, '08:15');
+    changeTime(wrapper, '8:15 AM');
 
     assert.calledWith(fakeOnChange, '2026-06-11T08:15');
+  });
+
+  it('accepts times typed in 24-hour form', () => {
+    const wrapper = createComponent('2026-06-11T23:59');
+
+    changeTime(wrapper, '20:15');
+
+    assert.calledWith(fakeOnChange, '2026-06-11T20:15');
+  });
+
+  it('normalizes the typed time when editing ends', () => {
+    const wrapper = createComponent('2026-06-11T23:59');
+
+    changeTime(wrapper, '15:30');
+    finishTimeEditing(wrapper);
+
+    assert.equal(timeInput(wrapper).prop('value'), '3:30 PM');
+  });
+
+  it('keeps unparseable text as typed when editing ends', () => {
+    const wrapper = createComponent();
+
+    changeTime(wrapper, '3:90 AM');
+    finishTimeEditing(wrapper);
+
+    // The instructor sees exactly what they typed next to the error, rather
+    // than a silent "correction".
+    assert.equal(timeInput(wrapper).prop('value'), '3:90 AM');
+  });
+
+  it('reports no due date while the typed time is not valid', () => {
+    const wrapper = createComponent('2026-06-11T14:30');
+
+    changeTime(wrapper, '3:90 AM');
+
+    assert.calledWith(fakeOnChange, null);
   });
 
   it('reports no due date when the time is cleared', () => {
@@ -109,7 +145,7 @@ describe('DueDateSelector', () => {
   it('reports no due date while only a time has been entered', () => {
     const wrapper = createComponent();
 
-    changeTime(wrapper, '09:00');
+    changeTime(wrapper, '9:00 AM');
 
     assert.calledWith(fakeOnChange, null);
   });
@@ -119,7 +155,7 @@ describe('DueDateSelector', () => {
 
     assert.isNotTrue(dateInput(wrapper).prop('required'));
 
-    changeTime(wrapper, '09:00');
+    changeTime(wrapper, '9:00 AM');
     wrapper.update();
 
     // Lets `validate` catch the half-entered value via the input's own
@@ -135,7 +171,7 @@ describe('DueDateSelector', () => {
     assert.calledWith(fakeOnChange, null);
     wrapper.update();
     assert.equal(dateInput(wrapper).prop('value'), '');
-    assert.equal(timeSelect(wrapper).prop('value'), '');
+    assert.equal(timeInput(wrapper).prop('value'), '');
   });
 
   it('constrains the date to the minimum', () => {
@@ -146,49 +182,47 @@ describe('DueDateSelector', () => {
 
   it('offers times at half-hour steps, labelled for a 12-hour clock', () => {
     const wrapper = createComponent();
-    openTimeSelect(wrapper);
-    const options = timeSelectOptions(wrapper);
+    openTimeOptions(wrapper);
+    const labels = timeOptions(wrapper).map(o => o.text());
 
-    // A placeholder plus one option per half hour.
-    assert.equal(options.length, 1 + 48);
-    assert.equal(options.at(0).prop('value'), '');
-
-    const labelFor = value =>
-      options.filterWhere(o => o.prop('value') === value).text();
-    assert.equal(labelFor('00:00'), '12:00 AM');
-    assert.equal(labelFor('00:30'), '12:30 AM');
-    assert.equal(labelFor('12:00'), '12:00 PM');
-    assert.equal(labelFor('13:30'), '1:30 PM');
-    assert.equal(labelFor('23:30'), '11:30 PM');
+    // One suggestion per half hour; typing replaces the old placeholder row.
+    assert.equal(labels.length, 48);
+    assert.include(labels, '12:00 AM');
+    assert.include(labels, '12:30 AM');
+    assert.include(labels, '12:00 PM');
+    assert.include(labels, '1:30 PM');
+    assert.include(labels, '11:30 PM');
   });
 
   it('keeps an existing time that is not on the half-hour grid', () => {
     // An assignment saved before this dropdown existed can hold any minute;
     // dropping it would silently change the due date.
     const wrapper = createComponent('2026-06-11T14:45');
-    openTimeSelect(wrapper);
+    openTimeOptions(wrapper);
 
-    const values = timeSelectOptions(wrapper).map(o => o.prop('value'));
-    assert.include(values, '14:45');
-    assert.equal(timeSelect(wrapper).prop('value'), '14:45');
+    assert.include(
+      timeOptions(wrapper).map(o => o.text()),
+      '2:45 PM',
+    );
+    assert.equal(timeInput(wrapper).prop('value'), '2:45 PM');
   });
 
   it('disables past times only on the earliest selectable date', () => {
     const wrapper = createComponent(null, '2026-06-11T14:30');
-    const disabled = value =>
-      timeSelectOptions(wrapper)
-        .filterWhere(o => o.prop('value') === value)
-        .prop('disabled');
+    const disabled = label =>
+      timeOptions(wrapper)
+        .filterWhere(o => o.text() === label)
+        .prop('aria-disabled');
 
     // On the earliest date, times before the minimum are in the past.
     changeDate(wrapper, '2026-06-11');
-    openTimeSelect(wrapper);
-    assert.isTrue(disabled('14:00'));
-    assert.isFalse(disabled('15:00'));
+    openTimeOptions(wrapper);
+    assert.isTrue(disabled('2:00 PM'));
+    assert.isFalse(disabled('3:00 PM'));
 
     // On any later date, every time of day is still in the future.
     changeDate(wrapper, '2026-06-12');
-    assert.isFalse(disabled('14:00'));
+    assert.isFalse(disabled('2:00 PM'));
   });
 
   describe('validate', () => {
@@ -222,6 +256,15 @@ describe('DueDateSelector', () => {
       assert.isFalse(errorMessage(wrapper).exists());
     });
 
+    it('rejects text that is not a time', () => {
+      const wrapper = createWithHandle();
+
+      changeTime(wrapper, '3:90 AM');
+
+      assert.isFalse(validate(wrapper));
+      assert.equal(errorMessage(wrapper).text(), 'Invalid time.');
+    });
+
     it('rejects a date without a time', () => {
       const wrapper = createWithHandle();
 
@@ -234,7 +277,7 @@ describe('DueDateSelector', () => {
     it('rejects a time without a date', () => {
       const wrapper = createWithHandle();
 
-      changeTime(wrapper, '09:00');
+      changeTime(wrapper, '9:00 AM');
 
       // The date field is a native input carrying `required`, so the browser
       // reports this one rather than the inline message.
@@ -261,7 +304,7 @@ describe('DueDateSelector', () => {
       assert.isFalse(validate(wrapper));
       assert.isTrue(errorMessage(wrapper).exists());
 
-      changeTime(wrapper, '09:00');
+      changeTime(wrapper, '9:00 AM');
       assert.isFalse(errorMessage(wrapper).exists());
     });
   });

--- a/lms/static/scripts/frontend_apps/components/test/TimeInput-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/TimeInput-test.js
@@ -228,6 +228,18 @@ describe('TimeInput', () => {
     assert.isFalse(input(wrapper).prop('aria-expanded'));
   });
 
+  it('keeps focus on the input while pressing on the dropdown', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    const event = new MouseEvent('mousedown', { cancelable: true });
+    act(() => wrapper.find('ul').props().onMouseDown(event));
+
+    // A default-allowed mousedown would move focus off the input and fire
+    // its blur-commit before the option's click could land.
+    assert.isTrue(event.defaultPrevented);
+  });
+
   it('does not commit when focus moves into the dropdown', () => {
     const wrapper = createComponent();
     clickInput(wrapper);

--- a/lms/static/scripts/frontend_apps/components/test/TimeInput-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/TimeInput-test.js
@@ -1,0 +1,261 @@
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
+import { act } from 'preact/test-utils';
+
+import TimeInput from '../TimeInput';
+
+describe('TimeInput', () => {
+  let fakeOnChange;
+  let fakeOnCommit;
+
+  // A short list exercising both plain and disabled suggestions.
+  const defaultOptions = [
+    { label: '3:00 AM' },
+    { label: '3:30 AM', disabled: true },
+    { label: '3:00 PM' },
+  ];
+
+  beforeEach(() => {
+    fakeOnChange = sinon.stub();
+    fakeOnCommit = sinon.stub();
+  });
+
+  function createComponent(value = '', options = defaultOptions) {
+    return mount(
+      <TimeInput
+        value={value}
+        onChange={fakeOnChange}
+        onCommit={fakeOnCommit}
+        options={options}
+      />,
+      // Connect to the DOM so the dropdown (native popover API) can toggle.
+      { connected: true },
+    );
+  }
+
+  const input = wrapper => wrapper.find('input[data-testid="time-input"]');
+  const listOptions = wrapper => wrapper.find('li[role="option"]');
+  const optionLabels = wrapper => listOptions(wrapper).map(o => o.text());
+  const highlightedId = wrapper => input(wrapper).prop('aria-activedescendant');
+  const highlightedText = wrapper => {
+    const id = highlightedId(wrapper);
+    return id ? wrapper.find(`li[id="${id}"]`).text() : null;
+  };
+
+  // Mirror the controlled-component contract: the parent echoes reported
+  // text back through the `value` prop.
+  const typeText = (wrapper, text) => {
+    act(() =>
+      input(wrapper)
+        .props()
+        .onInput({ currentTarget: { value: text } }),
+    );
+    wrapper.setProps({ value: text });
+    wrapper.update();
+  };
+
+  const clickInput = wrapper => {
+    act(() => input(wrapper).props().onClick());
+    wrapper.update();
+  };
+
+  const pressKey = (wrapper, key) => {
+    const event = new KeyboardEvent('keydown', { key, cancelable: true });
+    act(() => input(wrapper).props().onKeyDown(event));
+    wrapper.update();
+    return event;
+  };
+
+  const blurInput = (wrapper, relatedTarget = null) => {
+    act(() => input(wrapper).props().onBlur({ relatedTarget }));
+    wrapper.update();
+  };
+
+  it('renders the current text', () => {
+    const wrapper = createComponent('3:00 PM');
+    assert.equal(input(wrapper).prop('value'), '3:00 PM');
+  });
+
+  it('shows the suggestions when the input is clicked', () => {
+    const wrapper = createComponent();
+
+    // The dropdown contents are not rendered while it is closed.
+    assert.equal(listOptions(wrapper).length, 0);
+    assert.isFalse(input(wrapper).prop('aria-expanded'));
+
+    clickInput(wrapper);
+
+    assert.deepEqual(optionLabels(wrapper), ['3:00 AM', '3:30 AM', '3:00 PM']);
+    assert.isTrue(input(wrapper).prop('aria-expanded'));
+
+    // Clicking the input again keeps the dropdown open, with the highlight
+    // where it was.
+    clickInput(wrapper);
+    assert.isTrue(input(wrapper).prop('aria-expanded'));
+  });
+
+  it('reports and filters as the user types', () => {
+    const wrapper = createComponent();
+
+    // Prefix-matching ignores case and spaces, and offers every period.
+    typeText(wrapper, '3:0');
+
+    assert.calledWith(fakeOnChange, '3:0');
+    assert.deepEqual(optionLabels(wrapper), ['3:00 AM', '3:00 PM']);
+  });
+
+  it('shows an inert row when nothing matches', () => {
+    const wrapper = createComponent();
+
+    typeText(wrapper, '9:99');
+
+    assert.deepEqual(optionLabels(wrapper), ['---']);
+    assert.equal(listOptions(wrapper).prop('aria-disabled'), 'true');
+    assert.isNull(highlightedText(wrapper));
+  });
+
+  it('chooses a suggestion on click', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    act(() => listOptions(wrapper).at(2).props().onClick());
+    wrapper.update();
+
+    assert.calledWith(fakeOnChange, '3:00 PM');
+    assert.called(fakeOnCommit);
+    assert.isFalse(input(wrapper).prop('aria-expanded'));
+  });
+
+  it('ignores clicks on disabled suggestions', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    act(() => listOptions(wrapper).at(1).props().onClick());
+    wrapper.update();
+
+    assert.notCalled(fakeOnChange);
+    assert.notCalled(fakeOnCommit);
+    assert.isTrue(input(wrapper).prop('aria-expanded'));
+  });
+
+  it('opens the dropdown with the arrow keys', () => {
+    const wrapper = createComponent();
+
+    pressKey(wrapper, 'ArrowDown');
+
+    assert.isTrue(input(wrapper).prop('aria-expanded'));
+    assert.equal(highlightedText(wrapper), '3:00 AM');
+  });
+
+  it('highlights the suggestion matching the current text when opening', () => {
+    const wrapper = createComponent('3:00 pm');
+
+    clickInput(wrapper);
+
+    assert.equal(highlightedText(wrapper), '3:00 PM');
+  });
+
+  it('moves the highlight with the arrow keys, skipping disabled options', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+    assert.equal(highlightedText(wrapper), '3:00 AM');
+
+    // Down skips the disabled "3:30 AM" and stops at the end of the list.
+    pressKey(wrapper, 'ArrowDown');
+    assert.equal(highlightedText(wrapper), '3:00 PM');
+    pressKey(wrapper, 'ArrowDown');
+    assert.equal(highlightedText(wrapper), '3:00 PM');
+
+    // Up skips it likewise and stops at the start.
+    pressKey(wrapper, 'ArrowUp');
+    assert.equal(highlightedText(wrapper), '3:00 AM');
+    pressKey(wrapper, 'ArrowUp');
+    assert.equal(highlightedText(wrapper), '3:00 AM');
+  });
+
+  it('follows the mouse with the highlight, except over disabled options', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    act(() => listOptions(wrapper).at(2).props().onMouseMove());
+    wrapper.update();
+    assert.equal(highlightedText(wrapper), '3:00 PM');
+
+    act(() => listOptions(wrapper).at(1).props().onMouseMove());
+    wrapper.update();
+    assert.equal(highlightedText(wrapper), '3:00 PM');
+  });
+
+  it('chooses the highlighted suggestion with Enter', () => {
+    const wrapper = createComponent();
+    pressKey(wrapper, 'ArrowDown');
+
+    const event = pressKey(wrapper, 'Enter');
+
+    assert.calledWith(fakeOnChange, '3:00 AM');
+    assert.called(fakeOnCommit);
+    assert.isFalse(input(wrapper).prop('aria-expanded'));
+    // The keypress meant "choose", not "submit the surrounding form".
+    assert.isTrue(event.defaultPrevented);
+  });
+
+  it('commits the typed text with Enter when nothing is highlighted', () => {
+    const wrapper = createComponent();
+    typeText(wrapper, '9:99');
+
+    const event = pressKey(wrapper, 'Enter');
+
+    assert.called(fakeOnCommit);
+    assert.isFalse(event.defaultPrevented);
+  });
+
+  it('closes without committing on Escape', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    pressKey(wrapper, 'Escape');
+
+    assert.isFalse(input(wrapper).prop('aria-expanded'));
+    assert.notCalled(fakeOnCommit);
+  });
+
+  it('commits when focus leaves the field', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    blurInput(wrapper);
+
+    assert.called(fakeOnCommit);
+    assert.isFalse(input(wrapper).prop('aria-expanded'));
+  });
+
+  it('does not commit when focus moves into the dropdown', () => {
+    const wrapper = createComponent();
+    clickInput(wrapper);
+
+    blurInput(wrapper, wrapper.find('ul').getDOMNode());
+
+    assert.notCalled(fakeOnCommit);
+    assert.isTrue(input(wrapper).prop('aria-expanded'));
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      // The field expects its label from the surrounding form, tied via
+      // `inputId` — as `DueDateSelector` does.
+      content: () =>
+        mount(
+          <div>
+            <label htmlFor="a11y-time">Time</label>
+            <TimeInput
+              value=""
+              onChange={fakeOnChange}
+              options={defaultOptions}
+              inputId="a11y-time"
+            />
+          </div>,
+          { connected: true },
+        ),
+    }),
+  );
+});


### PR DESCRIPTION
Follow-up to #7413. That PR made the time dropdown theme-independent but kept it pick-only; the target design (the Canvas assignment pickers) is an editable combobox where the instructor can also **type** a time.

## Changes

- **New `TimeInput` component** — a text field with a suggestions dropdown, following the ARIA combobox pattern:
  - Suggestions filter by label prefix as the user types (`"3:3"` → *3:30 AM*, *3:30 PM*), ignoring case and spaces; an inert `---` row shows when nothing matches (as in Canvas).
  - Arrow keys open the list and move the highlight (skipping disabled rows), Enter chooses the highlighted suggestion, Escape closes, blur commits.
  - The dropdown is page DOM (shared `Popover`), so it stays theme-independent like #7413.
- **`DueDateSelector`** now treats the time as free-form text:
  - Accepts 12-hour (`3:30 PM`, `3pm`) and 24-hour (`15:30`) input, parsing the canonical `HH:MM` on the fly and normalizing the display once editing ends (`15:30` → `3:30 PM`).
  - `validate()` gains an **"Invalid time."** rejection for unparseable text (e.g. `3:90 AM`), checked before the date's native constraints so the message points at the right field. Unparseable text is kept as typed next to the error rather than silently corrected.
  - All existing rules unchanged: optional due date, half-entered values block the step, past values rejected (`min` date + disabled past suggestions + the combined-value check — a *typed* past time is caught by the latter).
- **No `FilePickerApp` changes** — the `validate()` handle contract from #7413 absorbs the new rejection.

## Tests

- New `TimeInput` suite (16 tests): filtering, no-match row, click/keyboard/mouse selection, disabled suggestions, commit-on-blur vs focus-into-dropdown, a11y.
- `DueDateSelector` suite reworked for typing (26 tests): 24-hour input, normalization on blur, invalid text kept as typed, "Invalid time." validation, plus all previous coverage.
- `yarn typecheck`, eslint, prettier clean; suites pass in headless Chromium (16 + 26 + 65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)