### PR TITLE
Fix Hide & Reveal settings dropped on non-deep-linked assignments

### DIFF
--- a/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerApp.tsx
@@ -306,6 +306,8 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
   // instructor picked that type in the workflow. This drives the
   // `checkpoint_enabled` field the backend persists.
   const checkpointEnabled = assignmentType === 'hide_and_reveal';
+  // UTC ISO string for the backend. Both submit paths send this same value.
+  const dueDateISO = dueDate ? new Date(dueDate).toISOString() : null;
   // Current sub-step of the assignment-type workflow. When the workflow isn't
   // enabled we start as `done` so it is skipped entirely.
   const [workflowStep, setWorkflowStep] = useState<WorkflowStep>(
@@ -454,10 +456,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
           ...deepLinkingAPI.data,
           auto_grading_config: autoGradingConfigToSave,
           checkpoint_enabled: checkpointEnabled,
-          // Optional due date for "Hide & Reveal" assignments. The picker holds
-          // a local `datetime-local` value; convert it to a UTC ISO string for
-          // the backend. `null` when left blank or not a checkpoint assignment.
-          due_date: dueDate ? new Date(dueDate).toISOString() : null,
+          due_date: dueDateISO,
           content,
           group_set: groupConfig.useGroupSet ? groupConfig.groupSet : null,
           title,
@@ -486,7 +485,7 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
     [
       authToken,
       checkpointEnabled,
-      dueDate,
+      dueDateISO,
       deepLinkingFields,
       deepLinkingAPI,
       groupConfig.groupSet,
@@ -824,6 +823,8 @@ export default function FilePickerApp({ onSubmit }: FilePickerAppProps) {
                 formFields={formFields}
                 groupSet={groupConfig.useGroupSet ? groupConfig.groupSet : null}
                 autoGradingConfig={autoGradingConfigToSave}
+                checkpointEnabled={checkpointEnabled}
+                dueDate={dueDateISO}
               />
             )
           }

--- a/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
+++ b/lms/static/scripts/frontend_apps/components/FilePickerFormFields.tsx
@@ -24,6 +24,12 @@ export type FilePickerFormFieldsProps = {
 
   /** Auto-grading configuration for assignments where it is enabled */
   autoGradingConfig: AutoGradingConfig | null;
+
+  /** Whether this is a "Hide & Reveal" assignment. */
+  checkpointEnabled: boolean;
+
+  /** Due date as a UTC ISO string, or `null` when not set. */
+  dueDate: string | null;
 };
 
 /**
@@ -38,6 +44,8 @@ export default function FilePickerFormFields({
   formFields,
   groupSet,
   autoGradingConfig,
+  checkpointEnabled,
+  dueDate,
 }: FilePickerFormFieldsProps) {
   return (
     <>
@@ -57,6 +65,12 @@ export default function FilePickerFormFields({
           name="auto_grading_config"
           value={JSON.stringify(autoGradingConfig)}
         />
+      )}
+      {checkpointEnabled && (
+        <>
+          <input type="hidden" name="checkpoint_enabled" value="true" />
+          {dueDate && <input type="hidden" name="due_date" value={dueDate} />}
+        </>
       )}
     </>
   );

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerApp-test.js
@@ -75,6 +75,8 @@ describe('FilePickerApp', () => {
       formFields = {},
       title = null,
       autoGradingConfig = null,
+      checkpointEnabled = false,
+      dueDate = null,
     },
   ) {
     const fieldsComponent = wrapper.find('FilePickerFormFields');
@@ -85,6 +87,8 @@ describe('FilePickerApp', () => {
       groupSet,
       title,
       autoGradingConfig,
+      checkpointEnabled,
+      dueDate,
     });
   }
 

--- a/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
+++ b/lms/static/scripts/frontend_apps/components/test/FilePickerFormFields-test.js
@@ -16,6 +16,8 @@ describe('FilePickerFormFields', () => {
         formFields={staticFormFields}
         groupSet={null}
         title={null}
+        checkpointEnabled={false}
+        dueDate={null}
         {...props}
       />,
     );
@@ -90,5 +92,34 @@ describe('FilePickerFormFields', () => {
 
     assert.isTrue(configField.exists());
     assert.equal(configField.prop('value'), JSON.stringify(autoGradingConfig));
+  });
+
+  it('omits checkpoint fields when `checkpointEnabled` is false', () => {
+    const formFields = createComponent({ dueDate: '2026-09-01T12:00:00.000Z' });
+
+    assert.isFalse(
+      formFields.find('input[name="checkpoint_enabled"]').exists(),
+    );
+    assert.isFalse(formFields.find('input[name="due_date"]').exists());
+  });
+
+  it('renders `checkpoint_enabled` when `checkpointEnabled` is set', () => {
+    const formFields = createComponent({ checkpointEnabled: true });
+
+    const field = formFields.find('input[name="checkpoint_enabled"]');
+    assert.isTrue(field.exists());
+    assert.equal(field.prop('value'), 'true');
+    assert.isFalse(formFields.find('input[name="due_date"]').exists());
+  });
+
+  it('renders `due_date` when a due date is set', () => {
+    const formFields = createComponent({
+      checkpointEnabled: true,
+      dueDate: '2026-09-01T12:00:00.000Z',
+    });
+
+    const field = formFields.find('input[name="due_date"]');
+    assert.isTrue(field.exists());
+    assert.equal(field.prop('value'), '2026-09-01T12:00:00.000Z');
   });
 });


### PR DESCRIPTION
This pull request updates how "Hide & Reveal" (checkpoint) assignment fields are handled and submitted in the LMS frontend. The main improvements are the consistent calculation and passing of the due date as a UTC ISO string, the addition of explicit hidden fields for `checkpoint_enabled` and `due_date` in the form, and enhanced test coverage for these behaviors.

**Assignment workflow and form handling:**

* The due date is now calculated once as a UTC ISO string (`dueDateISO`) and consistently passed through all submit paths and components, ensuring the backend always receives the correct format. [[1]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883R309-R310) [[2]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883L457-R459) [[3]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883L489-R488) [[4]](diffhunk://#diff-e091c35773bd1791ba2d590e5316af91bda05575d38627e6e220aa803e2a1883R826-R827)
* The `FilePickerFormFields` component receives new props: `checkpointEnabled` (boolean) and `dueDate` (ISO string or null), making the assignment type and due date explicit in form handling. [[1]](diffhunk://#diff-a32552bf9686fe4027210b0f3489b0f99f81eff82bfc7b09d30c09c1615c9796R27-R32) [[2]](diffhunk://#diff-a32552bf9686fe4027210b0f3489b0f99f81eff82bfc7b09d30c09c1615c9796R47-R48)

**Form field rendering:**

* When `checkpointEnabled` is true, hidden fields for `checkpoint_enabled` and (if set) `due_date` are rendered in the form, ensuring these values are submitted only for the correct assignment type.

**Testing improvements:**

* New tests verify that the checkpoint fields are included or omitted as appropriate, and that the correct values are rendered for both `checkpoint_enabled` and `due_date`. [[1]](diffhunk://#diff-b278030aafbd6d87ad0ef4db34361354735cd3075ea4abb941f5f92144f965ecR19-R20) [[2]](diffhunk://#diff-b278030aafbd6d87ad0ef4db34361354735cd3075ea4abb941f5f92144f965ecR96-R124)