### PR TITLE
Set default hide and reveal flag to true

### DIFF
--- a/lms/models/application_instance.py
+++ b/lms/models/application_instance.py
@@ -186,7 +186,7 @@ class ApplicationSettings(JSONSettings):
         Settings.HYPOTHESIS_HIDE_AND_REVEAL: JSONSetting(
             Settings.HYPOTHESIS_HIDE_AND_REVEAL,
             SettingFormat.TRI_STATE,
-            default=False,
+            default=True,
         ),
     }
 

--- a/tests/functional/views/lti/deep_linking_test.py
+++ b/tests/functional/views/lti/deep_linking_test.py
@@ -28,7 +28,7 @@ class TestDeepLinkingLaunch:
         js_config = get_client_config(response)
         assert js_config["mode"] == JSConfig.Mode.FILE_PICKER
         assert js_config["filePicker"] == {
-            "assignmentTypes": ["reading"],
+            "assignmentTypes": ["reading", "hide_and_reveal"],
             "autoGradingEnabled": True,
             "blackboard": {"enabled": None},
             "canvas": {

--- a/tests/unit/lms/resources/_js_config/__init___test.py
+++ b/tests/unit/lms/resources/_js_config/__init___test.py
@@ -74,8 +74,8 @@ class TestFilePickerMode:
             (True, ["reading", "hide_and_reveal"]),
             # Flag explicitly off.
             (False, ["reading"]),
-            # Flag unset: defaults to off.
-            (None, ["reading"]),
+            # Flag unset: defaults to on.
+            (None, ["reading", "hide_and_reveal"]),
         ],
     )
     def test_it_sets_assignment_types(


### PR DESCRIPTION
This pull request updates the default behavior for the "hide and reveal" feature and ensures that related tests and configuration reflect this change. The most important changes are grouped below:

**Feature Default Change:**

* The default value for the `HYPOTHESIS_HIDE_AND_REVEAL` setting in the `Settings` enum was changed from `False` to `True`, enabling the "hide and reveal" feature by default.

**Test and Configuration Updates:**

* Updated the expected assignment types in the Canvas deep linking test to include `"hide_and_reveal"` alongside `"reading"`, reflecting the new default.
* Adjusted unit tests to expect `"hide_and_reveal"` in assignment types when the flag is unset, since the default is now on.