### PR TITLE
[HnR-Autograder:1] DB migration

### DIFF
--- a/lms/migrations/versions/1103b3072f9e_add_auto_grading_config_previous_config_.py
+++ b/lms/migrations/versions/1103b3072f9e_add_auto_grading_config_previous_config_.py
@@ -1,0 +1,43 @@
+"""Add assignment_auto_grading_config.previous_config_id.
+
+Revision ID: 1103b3072f9e
+Revises: fa62e42cb531
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "1103b3072f9e"
+down_revision = "fa62e42cb531"
+
+# The generated name (fk__<table>__<column>__<table>) is too long, over
+# Postgres's limit, so we name it explicitly instead.
+FK_NAME = "fk__aagc__previous_config_id__aagc"
+UQ_NAME = "uq__assignment_auto_grading_config__previous_config_id"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assignment_auto_grading_config",
+        sa.Column("previous_config_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        FK_NAME,
+        "assignment_auto_grading_config",
+        "assignment_auto_grading_config",
+        ["previous_config_id"],
+        ["id"],
+        ondelete="cascade",
+    )
+    # Each config can be the predecessor of at most one other, which rules out
+    # forks. NULLS DISTINCT (the default) is required, not incidental: every
+    # assignment's first config has previous_config_id NULL.
+    op.create_unique_constraint(
+        UQ_NAME, "assignment_auto_grading_config", ["previous_config_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(UQ_NAME, "assignment_auto_grading_config", type_="unique")
+    op.drop_constraint(FK_NAME, "assignment_auto_grading_config", type_="foreignkey")
+    op.drop_column("assignment_auto_grading_config", "previous_config_id")


### PR DESCRIPTION
This pull request introduces a database schema migration to support tracking the predecessor of each auto grading configuration for assignments. The main change is the addition of a self-referential foreign key to the `assignment_auto_grading_config` table, allowing each configuration to reference its previous version. This enables a linear history of configuration changes without allowing forks.

Schema changes to `assignment_auto_grading_config`:

* Added a nullable `previous_config_id` column to `assignment_auto_grading_config`, allowing each configuration to reference a predecessor.
* Created a foreign key constraint on `previous_config_id` referencing the `id` of the same table, with cascading deletes.
* Added a unique constraint on `previous_config_id` to ensure that each configuration can only be the predecessor of at most one other configuration, preventing forks in the configuration history.