### PR TITLE
Don't let LTIA token request timeouts kill workers or trigger retries

### DIFF
--- a/lms/services/__init__.py
+++ b/lms/services/__init__.py
@@ -15,6 +15,7 @@ from lms.services.exceptions import (
     CanvasAPIServerError,
     ExternalAsyncRequestError,
     ExternalRequestError,
+    LTIATokenRequestError,
     OAuth2TokenError,
     SerializableError,
 )

--- a/lms/services/exceptions.py
+++ b/lms/services/exceptions.py
@@ -172,6 +172,19 @@ class OAuth2TokenError(ExternalRequestError):
     """
 
 
+class LTIATokenRequestError(ExternalRequestError):
+    """
+    A request for an LTI Advantage access token failed.
+
+    Raised instead of a plain `ExternalRequestError` when the failing request
+    is the `client_credentials` call to the LMS's own token endpoint, rather
+    than the LTI Advantage call the caller actually asked for. Callers need to
+    tell the two apart because retrying a failed token request means issuing
+    another token request, which is counter-productive when the endpoint is
+    rate-limiting us.
+    """
+
+
 class ConcurrentTokenRefreshError(Exception):
     """Another process is attempting to refresh the same OAuth token."""
 

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -88,7 +88,10 @@ class LTIAHTTPService:
                 "client_assertion": signed_jwt,
                 "scope": " ".join(scopes),
             },
-            timeout=(30, 30),
+            # Keep this comfortably below the gunicorn worker timeout. A
+            # read timeout at or above it means the worker is killed
+            # mid-request instead of raising an error we can handle.
+            timeout=(10, 20),
         )
 
         try:

--- a/lms/services/ltia_http.py
+++ b/lms/services/ltia_http.py
@@ -6,7 +6,11 @@ from requests.exceptions import JSONDecodeError
 
 from lms.models import JWTOAuth2Token, LTIRegistration
 from lms.product.plugin.misc import MiscPlugin
-from lms.services.exceptions import SerializableError
+from lms.services.exceptions import (
+    ExternalRequestError,
+    LTIATokenRequestError,
+    SerializableError,
+)
 from lms.services.jwt import JWTService
 from lms.services.jwt_oauth2_token import JWTOAuth2TokenService
 
@@ -80,19 +84,29 @@ class LTIAHTTPService:
             }
         )
 
-        response = self._http.post(
-            lti_registration.token_url,
-            data={
-                "grant_type": "client_credentials",
-                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                "client_assertion": signed_jwt,
-                "scope": " ".join(scopes),
-            },
-            # Keep this comfortably below the gunicorn worker timeout. A
-            # read timeout at or above it means the worker is killed
-            # mid-request instead of raising an error we can handle.
-            timeout=(10, 20),
-        )
+        try:
+            response = self._http.post(
+                lti_registration.token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    "client_assertion": signed_jwt,
+                    "scope": " ".join(scopes),
+                },
+                # Keep this comfortably below the gunicorn worker timeout. A
+                # read timeout at or above it means the worker is killed
+                # mid-request instead of raising an error we can handle.
+                timeout=(10, 20),
+            )
+        except ExternalRequestError as err:
+            # Re-raise as LTIATokenRequestError so callers can tell a failure
+            # to authenticate apart from a failure of the LTI Advantage call
+            # they asked for. Chain from `err.__cause__` (the underlying
+            # requests exception) rather than from `err`, to keep
+            # `ExternalRequestError.is_timeout` working.
+            raise LTIATokenRequestError(
+                request=err.request, response=err.response
+            ) from err.__cause__
 
         try:
             token_data = response.json()

--- a/lms/views/api/grading.py
+++ b/lms/views/api/grading.py
@@ -8,7 +8,11 @@ from lms.error_code import ErrorCode
 from lms.events import LTIEvent
 from lms.security import Permissions
 from lms.services import LTIGradingService
-from lms.services.exceptions import ExternalRequestError, SerializableError
+from lms.services.exceptions import (
+    ExternalRequestError,
+    LTIATokenRequestError,
+    SerializableError,
+)
 from lms.validation import (
     APIReadResultSchema,
     APIRecordResultSchema,
@@ -119,8 +123,13 @@ class GradingViews:
 
         except ExternalRequestError as err:
             if err.is_timeout:
-                # We'll inform the frontend that this is a retryable error for timeouts.
-                err.retryable = True
+                # We'll inform the frontend that this is a retryable error for
+                # timeouts -- but not when the request that timed out was the
+                # LTI Advantage token request itself. Retrying that issues
+                # another token request, and a timeout there means the token
+                # endpoint is already rate-limiting us, so a retry makes the
+                # problem worse rather than better.
+                err.retryable = not isinstance(err, LTIATokenRequestError)
                 raise
 
             if (

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -44,7 +44,7 @@ class TestLTIAHTTPService:
                 "client_assertion": jwt_service.encode_with_private_key.return_value,
                 "scope": " ".join(scopes),
             },
-            timeout=(30, 30),
+            timeout=(10, 20),
         )
         http_service.request.assert_called_once_with(
             "POST",

--- a/tests/unit/lms/services/ltia_http_test.py
+++ b/tests/unit/lms/services/ltia_http_test.py
@@ -3,7 +3,9 @@ from unittest.mock import sentinel
 
 import pytest
 from freezegun import freeze_time
+from requests.exceptions import Timeout
 
+from lms.services.exceptions import ExternalRequestError, LTIATokenRequestError
 from lms.services.ltia_http import LTIAHTTPService, factory
 from tests import factories
 
@@ -60,6 +62,23 @@ class TestLTIAHTTPService:
             http_service.post.return_value.json.return_value["access_token"],
             http_service.post.return_value.json.return_value["expires_in"],
         )
+
+    def test_request_raises_LTIATokenRequestError_when_the_token_request_fails(
+        self, svc, http_service, jwt_oauth2_token_service, scopes, lti_registration
+    ):
+        jwt_oauth2_token_service.get_token.return_value = None
+        cause = Timeout()
+        original = ExternalRequestError(request=sentinel.request)
+        original.__cause__ = cause
+        http_service.post.side_effect = original
+
+        with pytest.raises(LTIATokenRequestError) as exc_info:
+            svc.request(lti_registration, "POST", "https://example.com", scopes)
+
+        # The caller must still be able to tell this was a timeout, so the
+        # underlying requests exception has to stay as __cause__.
+        assert exc_info.value.is_timeout
+        assert exc_info.value.request == sentinel.request
 
     @freeze_time("2022-04-04")
     def test_request_with_existing_token(

--- a/tests/unit/lms/views/api/grading_test.py
+++ b/tests/unit/lms/views/api/grading_test.py
@@ -5,7 +5,11 @@ import pytest
 from h_matchers import Any
 from requests.exceptions import Timeout
 
-from lms.services.exceptions import ExternalRequestError, SerializableError
+from lms.services.exceptions import (
+    ExternalRequestError,
+    LTIATokenRequestError,
+    SerializableError,
+)
 from lms.services.lti_grading.interface import GradingResult
 from lms.views.api.grading import CanvasPreRecordHook, GradingViews
 
@@ -51,6 +55,20 @@ class TestRecordCanvasSpeedgraderSubmission:
             GradingViews(pyramid_request).record_canvas_speedgrader_submission()
 
         assert exc_info.value.retryable
+
+    def test_it_does_not_retry_a_token_request_timeout(
+        self, lti_grading_service, pyramid_request
+    ):
+        # Retrying a token-request timeout just issues another token request,
+        # which is what tips the endpoint into rate-limiting us.
+        exception = LTIATokenRequestError()
+        exception.__cause__ = Timeout()
+        lti_grading_service.read_result.side_effect = exception
+
+        with pytest.raises(LTIATokenRequestError) as exc_info:
+            GradingViews(pyramid_request).record_canvas_speedgrader_submission()
+
+        assert not exc_info.value.retryable
 
     def test_it_max_attempts(self, pyramid_request, lti_grading_service):
         lti_grading_service.read_result.side_effect = ExternalRequestError(


### PR DESCRIPTION
Two related fixes for the LTI Advantage token request path, which currently
turns a slow token endpoint into a killed gunicorn worker and then amplifies
it with retries.

### 1. Lower the token request timeout below the worker timeout

`ltia_http.py` used `timeout=(30, 30)`. Gunicorn's worker timeout is its 30s
default (`conf/gunicorn.conf.py` sets only `bind` and `worker_tmp_dir`), so a
hanging token request races the worker reaper — whichever 30s clock fires
first decides whether we raise a handled `ExternalRequestError` or the worker
is killed mid-request. The killed-worker case surfaces as an unhandled
`SystemExit` on `lti_api.submissions.record`, with no useful error for the
student.

dd7ea10f raised this from `(20, 20)` to `(30, 30)` in May 2024 to "clean up
the logs" while timeouts were being investigated. Raising the ceiling to meet
the worker timeout is what created the reaped-worker mode; at 20s it failed
cleanly.

Now `(10, 20)` — 10s of headroom below the worker timeout, still well above
the codebase default of `(10, 10)` so we don't reintroduce the slow-response
failures dd7ea10f was reacting to.

### 2. Don't mark token request timeouts retryable

4a2ef607 made submission timeouts retryable so the frontend could recover from
transient blips: `grading.py` sets `err.retryable = True` for any timeout, and
`BasicLTILaunchApp` calls `/api/lti/submissions` with `maxRetries: 2`.

That's right for a timeout against the AGS endpoints and wrong for a timeout
against the LMS's own OAuth2 token endpoint. A timeout there means the token
endpoint is already refusing to answer, and each retry issues another
`client_credentials` request — three token requests per launch where one
already failed. The retry can't repopulate the token cache either, since
nothing succeeds. So it adds load exactly when there's none to spare, and the
student still lands on a dialog with no retry button.

New `LTIATokenRequestError` lets callers tell a failure to *authenticate*
apart from a failure of the LTI Advantage call they actually asked for; only
the latter stays retryable.

### Note on the exception chaining

The re-raise chains from `err.__cause__`, not from `err`. This is deliberate:
`ExternalRequestError.is_timeout` inspects `__cause__`, so chaining from the
`ExternalRequestError` would make every token timeout look like a non-timeout
and break the very branch fix #2 depends on. There's a test pinning this.

### Testing

Unit tests added for both behaviours. **Not yet verified against a live LMS.**

### Sentry side effect — read before/after deploying

This changes the exception type captured on the token-timeout path. `_get_new_access_token`
now raises `LTIATokenRequestError` instead of letting `ExternalRequestError` propagate, and the
stack gains the new raise site. Sentry groups on stack trace + exception type, so **this path
will regroup.**

Expect, shortly after deploy:

- **LMS-1CY goes flat** — 805 of its ~840 events are this path.
- **A new issue appears** with the same signature under `LTIATokenRequestError`.

That is the rename working. It is **not** the failures stopping, and the new issue is **not** a
regression. Both are the expected shape of this change.

Alerts on this path are deliberately filtered on transaction + error type rather than issue ID,
so the series stays continuous across the rename:

| Alert | Filter |
|---|---|
| Token timeout rate | `transaction:lti_api.submissions.record error.type:[ExternalRequestError, LTIATokenRequestError]` |
| Reaped workers | `transaction:lti_api.submissions.record error.type:SystemExit` |

**Please don't re-pin those alerts to the new issue ID.** `SystemExit` on this transaction has
already fragmented across LMS-1N5, LMS-2DW and LMS-2EB in 30 days, because it's raised wherever
the worker happened to be when it was terminated — its grouping key is inherently unstable. The
transaction filter is what keeps the verification alert from reading a false all-clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
