### PR TITLE
Identify a checkpoint's file where a credential is known to work

### DIFF
--- a/lms/tasks/checkpoint.py
+++ b/lms/tasks/checkpoint.py
@@ -1,0 +1,48 @@
+import logging
+
+from lms.models import Assignment, Grouping
+from lms.services import HAPI
+from lms.services.document_uri import pdf_fingerprint
+from lms.tasks.celery import app
+
+LOG = logging.getLogger(__name__)
+
+
+@app.task(
+    max_retries=3,
+    retry_backoff=10,
+    autoretry_for=(Exception,),
+)
+def fingerprint_checkpoint_document(*, assignment_id: int, public_url: str):
+    """Identify a Hide & Reveal assignment's file, and create its checkpoint.
+
+    Queued from the viewer, where a working credential has just been proven by
+    the file resolving at all. The launch can't rely on one: it runs before the
+    browser has had a chance to refresh or obtain the token, and a launch that
+    can't read the file leaves the assignment with nothing hidden.
+    """
+    with app.request_context() as request:  # noqa: SIM117
+        with request.tm:
+            assignment = request.db.get(Assignment, assignment_id)
+            if not assignment or assignment.document_uri:
+                # Every viewer queues this until it lands, so most runs are a
+                # later one finding the work already done.
+                return
+
+            pdf = request.find_service(name="http").get(public_url).content
+            assignment.document_uri = f"urn:x-pdf:{pdf_fingerprint(pdf)}"
+
+            # A course's checkpoint is shared with every assignment on the same
+            # document, so it is only the fallback. Same rule as the reveal API.
+            groupings = assignment.groupings.all()
+            scoped = [g for g in groupings if g.type != Grouping.Type.COURSE]
+
+            request.find_service(HAPI).sync_checkpoints(
+                checkpoints=[
+                    {
+                        "group_authority_provided_id": grouping.authority_provided_id,
+                        "document_uri": assignment.document_uri,
+                    }
+                    for grouping in (scoped or groupings)
+                ]
+            )

--- a/lms/views/api/canvas/files.py
+++ b/lms/views/api/canvas/files.py
@@ -5,6 +5,7 @@ from pyramid.view import view_config, view_defaults
 from lms.document_url_regex import CANVAS_FILE as DOCUMENT_URL_REGEX
 from lms.security import Permissions
 from lms.services.canvas import CanvasService
+from lms.tasks.checkpoint import fingerprint_checkpoint_document
 from lms.views import helpers
 
 
@@ -46,6 +47,14 @@ class FilesAPIViews:
             assignment.course.extra["canvas"]["custom_canvas_course_id"],
             check_in_course=self.request.lti_user.is_instructor,
         )
+
+        if assignment.checkpoint_enabled and not assignment.document_uri:
+            # The launch could not read the file -- otherwise this would
+            # already be set -- but this request just did, so hand the URL to
+            # a task rather than making the reader wait for a download.
+            fingerprint_checkpoint_document.delay(
+                assignment_id=assignment.id, public_url=public_url
+            )
 
         # Currently we only let users pick PDF files, so we can save a little
         # time by specifying this, instead of Via having to work it out

--- a/tests/unit/lms/tasks/checkpoint_test.py
+++ b/tests/unit/lms/tasks/checkpoint_test.py
@@ -1,0 +1,117 @@
+from contextlib import contextmanager
+
+import pytest
+
+from lms.models import AssignmentGrouping
+from lms.tasks.checkpoint import fingerprint_checkpoint_document
+from tests import factories
+
+
+class TestFingerprintCheckpointDocument:
+    def test_it_identifies_the_document_and_creates_the_checkpoint(
+        self, assignment, http_service, h_api, pdf_fingerprint, section
+    ):
+        fingerprint_checkpoint_document(
+            assignment_id=assignment.id, public_url="https://example.com/file.pdf"
+        )
+
+        http_service.get.assert_called_once_with("https://example.com/file.pdf")
+        assert assignment.document_uri == f"urn:x-pdf:{pdf_fingerprint.return_value}"
+        h_api.sync_checkpoints.assert_called_once_with(
+            checkpoints=[
+                {
+                    "group_authority_provided_id": section.authority_provided_id,
+                    "document_uri": assignment.document_uri,
+                }
+            ]
+        )
+
+    def test_it_uses_the_course_when_there_are_no_other_groupings(
+        self,
+        assignment,
+        course,
+        h_api,
+        section,
+        db_session,
+        http_service,  # noqa: ARG002
+        pdf_fingerprint,  # noqa: ARG002
+    ):
+        # A course's checkpoint is shared with every assignment on the same
+        # document, so it is only the fallback.
+        db_session.query(AssignmentGrouping).filter_by(
+            assignment_id=assignment.id, grouping_id=section.id
+        ).delete()
+        db_session.flush()
+
+        fingerprint_checkpoint_document(
+            assignment_id=assignment.id, public_url="https://example.com/file.pdf"
+        )
+
+        h_api.sync_checkpoints.assert_called_once_with(
+            checkpoints=[
+                {
+                    "group_authority_provided_id": course.authority_provided_id,
+                    "document_uri": assignment.document_uri,
+                }
+            ]
+        )
+
+    def test_it_does_nothing_when_the_document_is_already_identified(
+        self, assignment, http_service, h_api, db_session
+    ):
+        # Every viewer queues this until it lands, so most runs find the work
+        # already done by an earlier one.
+        assignment.document_uri = "urn:x-pdf:already"
+        db_session.flush()
+
+        fingerprint_checkpoint_document(
+            assignment_id=assignment.id, public_url="https://example.com/file.pdf"
+        )
+
+        http_service.get.assert_not_called()
+        h_api.sync_checkpoints.assert_not_called()
+
+    def test_it_does_nothing_when_the_assignment_is_gone(self, http_service, h_api):
+        fingerprint_checkpoint_document(
+            assignment_id=1234567890, public_url="https://example.com/file.pdf"
+        )
+
+        http_service.get.assert_not_called()
+        h_api.sync_checkpoints.assert_not_called()
+
+    @pytest.fixture
+    def course(self, application_instance):
+        return factories.Course(application_instance=application_instance)
+
+    @pytest.fixture
+    def section(self, application_instance):
+        return factories.CanvasSection(application_instance=application_instance)
+
+    @pytest.fixture
+    def assignment(self, course, section, db_session):
+        assignment = factories.Assignment(
+            course=course,
+            checkpoint_enabled=True,
+            document_url="canvas://file/course/1/file_id/2",
+        )
+        factories.AssignmentGrouping(assignment=assignment, grouping=course)
+        factories.AssignmentGrouping(assignment=assignment, grouping=section)
+        db_session.flush()
+        return assignment
+
+    @pytest.fixture
+    def pdf_fingerprint(self, patch):
+        return patch("lms.tasks.checkpoint.pdf_fingerprint")
+
+
+@pytest.fixture(autouse=True)
+def app(patch, pyramid_request):
+    app = patch("lms.tasks.checkpoint.app")
+
+    @contextmanager
+    def request_context():
+        yield pyramid_request
+
+    app.request_context = request_context
+
+    return app

--- a/tests/unit/lms/views/api/canvas/files_test.py
+++ b/tests/unit/lms/views/api/canvas/files_test.py
@@ -49,6 +49,60 @@ class TestFilesAPIViews:
         )
         assert result == {"via_url": helpers.via_url.return_value}
 
+    @pytest.mark.usefixtures("with_teacher_or_student")
+    def test_via_url_identifies_an_unidentified_checkpoint_document(
+        self,
+        pyramid_request,
+        assignment_service,
+        canvas_service,
+        fingerprint_checkpoint_document,
+    ):
+        # The launch could not read the file, or this would already be set.
+        # This request just did, so the identity can be worked out from here.
+        assignment = assignment_service.get_assignment.return_value
+        assignment.document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
+        assignment.checkpoint_enabled = True
+        assignment.document_uri = None
+        pyramid_request.matchdict = {"resource_link_id": "test_resource_link_id"}
+
+        FilesAPIViews(pyramid_request).via_url()
+
+        fingerprint_checkpoint_document.delay.assert_called_once_with(
+            assignment_id=assignment.id,
+            public_url=canvas_service.public_url_for_file.return_value,
+        )
+
+    @pytest.mark.usefixtures("with_teacher_or_student")
+    @pytest.mark.parametrize(
+        ("checkpoint_enabled", "document_uri"),
+        [
+            (False, None),
+            (True, "urn:x-pdf:already"),
+            (False, "urn:x-pdf:already"),
+        ],
+    )
+    def test_via_url_doesnt_identify_it_otherwise(
+        self,
+        pyramid_request,
+        assignment_service,
+        fingerprint_checkpoint_document,
+        checkpoint_enabled,
+        document_uri,
+    ):
+        assignment = assignment_service.get_assignment.return_value
+        assignment.document_url = "canvas://file/course/COURSE_ID/file_id/FILE_ID"
+        assignment.checkpoint_enabled = checkpoint_enabled
+        assignment.document_uri = document_uri
+        pyramid_request.matchdict = {"resource_link_id": "test_resource_link_id"}
+
+        FilesAPIViews(pyramid_request).via_url()
+
+        fingerprint_checkpoint_document.delay.assert_not_called()
+
+    @pytest.fixture
+    def fingerprint_checkpoint_document(self, patch):
+        return patch("lms.views.api.canvas.files.fingerprint_checkpoint_document")
+
     @pytest.fixture(params=("instructor", "learner"))
     def with_teacher_or_student(self, request, pyramid_request):
         pyramid_request.lti_user.roles = request.param


### PR DESCRIPTION
This pull request introduces a background task to improve how checkpoint documents are created for Hide & Reveal assignments. Instead of blocking the user while the system fingerprints a PDF and creates a checkpoint, this work is now done asynchronously, improving user experience and system reliability. The main changes are the addition of the `fingerprint_checkpoint_document` Celery task and its integration into the Canvas file launch flow.

**Background task for document fingerprinting and checkpoint creation:**

* Added a new Celery task `fingerprint_checkpoint_document` in `lms/tasks/checkpoint.py` to asynchronously fingerprint a PDF file and create a checkpoint for Hide & Reveal assignments. The task ensures that the operation is retried on failure and only runs if the assignment does not already have a `document_uri`.

**Integration with Canvas file launches:**

* Updated `lms/views/api/canvas/files.py` to import and call the new `fingerprint_checkpoint_document` task. When launching a Canvas file for an assignment with checkpointing enabled and no existing `document_uri`, the task is queued rather than blocking the request. [[1]](diffhunk://#diff-56651ed282a9d219a1be16428b853e47e052042969d353dadd24b80f555a2646R8) [[2]](diffhunk://#diff-56651ed282a9d219a1be16428b853e47e052042969d353dadd24b80f555a2646R51-R58)